### PR TITLE
Temporarily stop copying template to fix CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,9 @@ jobs:
       - run: mkdir tool/lrama
         working-directory: ../ruby
       - name: Copy Lrama to ruby/tool
-        run: cp -r exe lib template ../ruby/tool/lrama
+        run: cp -r exe lib ../ruby/tool/lrama
+        # TODO: Consider how to manage changes on ruby/ruby master and ruby/lrama
+        # run: cp -r exe lib template ../ruby/tool/lrama
         working-directory:
       - run: tree tool/lrama
         working-directory: ../ruby


### PR DESCRIPTION
Template file on ruby/ruby was changed by https://github.com/ruby/ruby/pull/7807. Then copying template in CI breaks build.