### PR TITLE
Support `//` style comment

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -206,6 +206,8 @@ module Lrama
         when ss.scan(/\/\*/)
           # TODO: Need to keep comment?
           line = lex_comment(ss, line, lines, "")
+        when ss.scan(/\/\//)
+          line = lex_line_comment(ss, line, "")
         when ss.scan(/'(.)'/)
           tokens << create_token(Token::Char, ss[0], line, ss.pos - column)
         when ss.scan(/'\\(.)'/) # '\\', '\t'
@@ -276,6 +278,9 @@ module Lrama
         when ss.scan(/\/\*/)
           str << ss[0]
           line = lex_comment(ss, line, lines, str)
+        when ss.scan(/\/\//)
+          str << ss[0]
+          line = lex_line_comment(ss, line, str)
         else
           # noop, just consume char
           str << ss.getch
@@ -314,8 +319,6 @@ module Lrama
       raise "Parse error (quote mismatch): #{ss.string.split("\n")[l]} \"#{ss.string[ss.pos]}\" (#{line}: #{ss.pos})"
     end
 
-    # TODO: Need to handle // style comment
-    #
     # /*  */ style comment
     def lex_comment(ss, line, lines, str)
       while !ss.eos? do
@@ -335,6 +338,23 @@ module Lrama
       # Reach to end of input but quote does not match
       l = line - lines.first[1]
       raise "Parse error (comment mismatch): #{ss.string.split("\n")[l]} \"#{ss.string[ss.pos]}\" (#{line}: #{ss.pos})"
+    end
+
+    # // style comment
+    def lex_line_comment(ss, line, str)
+      while !ss.eos? do
+        case
+        when ss.scan(/\n/)
+          return line + 1
+        else
+          str << ss.getch
+          next
+        end
+
+        str << ss[0]
+      end
+
+      line # Reach to end of input
     end
 
     def lex_grammar_rules_tokens

--- a/spec/fixtures/common/basic.y
+++ b/spec/fixtures/common/basic.y
@@ -46,7 +46,7 @@
 %token tEQ    "="
 %token tEQEQ  "=="
 
-%type <i> class /* comment for class */
+%type <i> class /* comment for class */ // line-comment for class
 
 %nonassoc tEQEQ
 %left  tPLUS tMINUS '>'

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Lrama::Lexer do
         %token tEQ    "="
         %token tEQEQ  "=="
 
-        %type <i> class /* comment for class */
+        %type <i> class /* comment for class */ // line-comment for class
 
         %nonassoc tEQEQ
         %left  tPLUS tMINUS '>'

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -387,11 +387,11 @@ program: stmt ;
 
 stmt: tBODY
         {
-          int i = 1; /* @ */
-          int j = 1; /* $ */
-          int k = 1; /* @1 */
-          int l = 1; /* $$ */
-          int m = 1; /* $2 */
+          int i = 1; /* @ */ // @
+          int j = 1; /* $ */ // $
+          int k = 1; /* @1 */ // @1
+          int l = 1; /* $$ */ // $$
+          int m = 1; /* $2 */ // $2
         }
     ;
 %%
@@ -403,11 +403,11 @@ stmt: tBODY
 
         expected = <<-CODE.chomp
 {
-          int i = 1; /* @ */
-          int j = 1; /* $ */
-          int k = 1; /* @1 */
-          int l = 1; /* $$ */
-          int m = 1; /* $2 */
+          int i = 1; /* @ */ // @
+          int j = 1; /* $ */ // $
+          int k = 1; /* @1 */ // @1
+          int l = 1; /* $$ */ // $$
+          int m = 1; /* $2 */ // $2
         }
         CODE
 


### PR DESCRIPTION
I'm not familiar with YACC/Bison, so I'm not sure if this fix is the correct and expected one. I welcome any comments.