### PR TITLE
Added dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
How about use dependabot like these?
- https://github.com/ruby/csv/pull/265
- https://github.com/ruby/fiddle/pull/116
- https://github.com/ruby/rexml/pull/89
- https://github.com/ruby/rss/pull/40
- https://github.com/ruby/xmlrpc/pull/31