### PR TITLE
Stop passing YACC arg for make

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,5 +84,5 @@ jobs:
       - run: sudo apt-get --purge remove bison
       - run: ../autogen.sh
       - run: ../configure -C --disable-install-doc
-      - run: make YACC=$(readlink -f $(pwd)/../tool/lrama/exe/lrama)
+      - run: make
       - run: make test-all


### PR DESCRIPTION
After https://github.com/ruby/ruby/pull/7798, ruby uses lrama as default then no need to pass YACC anymore.