### PR TITLE
Add warning.rbs

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -4,4 +4,5 @@ target :lib do
   signature "sig"
 
   check "lib/lrama/bitmap.rb"
+  check "lib/lrama/warning.rb"
 end

--- a/sig/lrama/warning.rbs
+++ b/sig/lrama/warning.rbs
@@ -1,0 +1,16 @@
+module Lrama
+  class Warning
+    interface _Appendable
+      def <<: (String message) -> self
+    end
+
+    @out: _Appendable
+
+    attr_reader errors: Array[String]
+    attr_reader warns: Array[String]
+    def initialize: (?_Appendable out) -> void
+    def error: (String message) -> void
+    def warn: (String message) -> void
+    def has_error?: -> bool
+  end
+end


### PR DESCRIPTION
Added warning.rbs ~~based on #19~~.

- The auto-generated type of `@out` was `IO`, but `@out` can be a String in [tests](https://github.com/ruby/lrama/blob/4b424415b49827758c99c8f4e74eb1dd71c80ef2/spec/lrama/context_spec.rb#L3).
- I could write the type of `message` to be `string & _ToS`, but I think it would be too complex.
