### PR TITLE
Change integration test target from master to ruby_3_2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         baseruby: ['3.0']
-        ruby_branch: ['master']
+        ruby_branch: ['ruby_3_2']
     defaults:
       run:
         working-directory: ../ruby/build


### PR DESCRIPTION
lrama_0_4 is kept for Bison compatible branch. However lrama master branch is actively developed for ruby master branch. This commit changes test target to ruby_3_2.