### PR TITLE
Implement named references

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -155,16 +155,16 @@ module Lrama
         last_column = ref.last_column
 
         case
-        when ref.number == "$" && ref.type == :dollar # $$
+        when ref.value == "$" && ref.type == :dollar # $$
           # Omit "<>"
           member = tag.s_value[1..-2]
           str = "((*yyvaluep).#{member})"
-        when ref.number == "$" && ref.type == :at # @$
+        when ref.value == "$" && ref.type == :at # @$
           str = "(*yylocationp)"
         when ref.type == :dollar # $n
-          raise "$#{ref.number} can not be used in %printer."
+          raise "$#{ref.value} can not be used in %printer."
         when ref.type == :at # @n
-          raise "@#{ref.number} can not be used in %printer."
+          raise "@#{ref.value} can not be used in %printer."
         else
           raise "Unexpected. #{self}, #{ref}"
         end
@@ -190,19 +190,19 @@ module Lrama
         last_column = ref.last_column
 
         case
-        when ref.number == "$" && ref.type == :dollar # $$
+        when ref.value == "$" && ref.type == :dollar # $$
           # Omit "<>"
           member = ref.tag.s_value[1..-2]
           str = "(yyval.#{member})"
-        when ref.number == "$" && ref.type == :at # @$
+        when ref.value == "$" && ref.type == :at # @$
           str = "(yyloc)"
         when ref.type == :dollar # $n
-          i = -ref.position_in_rhs + ref.number
+          i = -ref.position_in_rhs + ref.value
           # Omit "<>"
           member = ref.tag.s_value[1..-2]
           str = "(yyvsp[#{i}].#{member})"
         when ref.type == :at # @n
-          i = -ref.position_in_rhs + ref.number
+          i = -ref.position_in_rhs + ref.value
           str = "(yylsp[#{i}])"
         else
           raise "Unexpected. #{self}, #{ref}"
@@ -226,14 +226,14 @@ module Lrama
         last_column = ref.last_column
 
         case
-        when ref.number == "$" && ref.type == :dollar # $$
+        when ref.value == "$" && ref.type == :dollar # $$
           str = "yylval"
-        when ref.number == "$" && ref.type == :at # @$
+        when ref.value == "$" && ref.type == :at # @$
           str = "yylloc"
         when ref.type == :dollar # $n
-          raise "$#{ref.number} can not be used in initial_action."
+          raise "$#{ref.value} can not be used in initial_action."
         when ref.type == :at # @n
-          raise "@#{ref.number} can not be used in initial_action."
+          raise "@#{ref.value} can not be used in initial_action."
         else
           raise "Unexpected. #{self}, #{ref}"
         end
@@ -247,7 +247,7 @@ module Lrama
 
   # type: :dollar or :at
   # ex_tag: "$<tag>1" (Optional)
-  Reference = Struct.new(:type, :number, :ex_tag, :first_column, :last_column, :referring_symbol, :position_in_rhs, keyword_init: true) do
+  Reference = Struct.new(:type, :value, :ex_tag, :first_column, :last_column, :referring_symbol, :position_in_rhs, keyword_init: true) do
     def tag
       if ex_tag
         ex_tag
@@ -382,8 +382,8 @@ module Lrama
     end
 
     def build_references(token_code)
-      token_code.references.map! do |type, number, tag, first_column, last_column|
-        Reference.new(type: type, number: number, ex_tag: tag, first_column: first_column, last_column: last_column)
+      token_code.references.map! do |type, value, tag, first_column, last_column|
+        Reference.new(type: type, value: value, ex_tag: tag, first_column: first_column, last_column: last_column)
       end
 
       token_code
@@ -627,15 +627,14 @@ module Lrama
               ref.position_in_rhs = i - 1
               next if ref.type == :at
               # $$, $n, @$, @n can be used in any actions
-              number = ref.number
 
-              if number == "$"
+              if ref.value == "$"
                 # TODO: Should be postponed after middle actions are extracted?
                 ref.referring_symbol = lhs
               else
-                raise "Can not refer following component. #{number} >= #{i}. #{token}" if number >= i
-                rhs1[number - 1].referred = true
-                ref.referring_symbol = rhs1[number - 1]
+                raise "Can not refer following component. #{ref.value} >= #{i}. #{token}" if ref.value >= i
+                rhs1[ref.value - 1].referred = true
+                ref.referring_symbol = rhs1[ref.value - 1]
               end
             end
           end

--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -631,10 +631,19 @@ module Lrama
               if ref.value == "$"
                 # TODO: Should be postponed after middle actions are extracted?
                 ref.referring_symbol = lhs
-              else
+              elsif ref.value.is_a?(Integer)
                 raise "Can not refer following component. #{ref.value} >= #{i}. #{token}" if ref.value >= i
                 rhs1[ref.value - 1].referred = true
                 ref.referring_symbol = rhs1[ref.value - 1]
+              elsif ref.value.is_a?(String)
+                target_tokens = ([lhs] + rhs1 + [code]).compact.first(i)
+                referring_symbol_candidate = target_tokens.filter {|token| token.referred_by?(ref.value) }
+                raise "Referring symbol `#{ref.value}` is duplicated. #{token}" if referring_symbol_candidate.size >= 2
+                raise "Referring symbol `#{ref.value}` is not found. #{token}" if referring_symbol_candidate.count == 0
+
+                referring_symbol = referring_symbol_candidate.first
+                referring_symbol.referred = true
+                ref.referring_symbol = referring_symbol
               end
             end
           end

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -7,7 +7,7 @@ module Lrama
     include Lrama::Report::Duration
 
     # s_value is semantic value
-    Token = Struct.new(:type, :s_value, keyword_init: true) do
+    Token = Struct.new(:type, :s_value, :alias, keyword_init: true) do
       Type = Struct.new(:id, :name, keyword_init: true)
 
       attr_accessor :line, :column, :referred
@@ -20,6 +20,10 @@ module Lrama
 
       def referred_by?(string)
         [self.s_value, self.alias].include?(string)
+      end
+
+      def ==(other)
+        self.class == other.class && self.type == other.type && self.s_value == other.s_value
       end
 
       @i = 0

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -18,6 +18,10 @@ module Lrama
         "#{super} line: #{line}, column: #{column}"
       end
 
+      def referred_by?(string)
+        [self.s_value, self.alias].include?(string)
+      end
+
       @i = 0
       @types = []
 

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -26,6 +26,23 @@ module Lrama
         self.class == other.class && self.type == other.type && self.s_value == other.s_value
       end
 
+      def numberize_references(lhs, rhs)
+        self.references.map! {|ref|
+          ref_name = ref[1]
+          if ref_name.is_a?(String) && ref_name != '$'
+            value =
+              if lhs.referred_by?(ref_name)
+                '$'
+              else
+                rhs.find_index {|token| token.referred_by?(ref_name) } + 1
+              end
+            [ref[0], value, ref[2], ref[3], ref[4]]
+          else
+            ref
+          end
+        }
+      end
+
       @i = 0
       @types = []
 

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -179,7 +179,7 @@ module Lrama
         lhs.alias = named_ref.s_value
       end
 
-      rhs = parse_grammar_rule_rhs(ts, grammar)
+      rhs = parse_grammar_rule_rhs(ts, grammar, lhs)
 
       grammar.add_rule(lhs: lhs, rhs: rhs, lineno: rhs.first ? rhs.first.line : lhs.line)
 
@@ -189,7 +189,7 @@ module Lrama
           # |
           bar_lineno = ts.current_token.line
           ts.next
-          rhs = parse_grammar_rule_rhs(ts, grammar)
+          rhs = parse_grammar_rule_rhs(ts, grammar, lhs)
           grammar.add_rule(lhs: lhs, rhs: rhs, lineno: rhs.first ? rhs.first.line : bar_lineno)
         when T::Semicolon
           # ;
@@ -208,7 +208,7 @@ module Lrama
       end
     end
 
-    def parse_grammar_rule_rhs(ts, grammar)
+    def parse_grammar_rule_rhs(ts, grammar, lhs)
       a = []
       prec_seen = false
       code_after_prec = false
@@ -247,6 +247,7 @@ module Lrama
           end
 
           code = ts.current_token
+          code.numberize_references(lhs, a)
           grammar.build_references(code)
           a << code
           ts.next

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -175,6 +175,9 @@ module Lrama
       # LHS
       lhs = ts.consume!(T::Ident_Colon) # class:
       lhs.type = T::Ident
+      if named_ref = ts.consume(T::Named_Ref)
+        lhs.alias = named_ref.s_value
+      end
 
       rhs = parse_grammar_rule_rhs(ts, grammar)
 
@@ -246,6 +249,9 @@ module Lrama
           code = ts.current_token
           grammar.build_references(code)
           a << code
+          ts.next
+        when T::Named_Ref
+          ts.previous_token.alias = ts.current_token.s_value
           ts.next
         when T::Bar
           # |

--- a/lib/lrama/parser/token_scanner.rb
+++ b/lib/lrama/parser/token_scanner.rb
@@ -14,6 +14,10 @@ module Lrama
         current_token && current_token.type
       end
 
+      def previous_token
+        @tokens[@index - 1]
+      end
+
       def next
         token = current_token
         @index += 1

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1143,6 +1143,139 @@ emp: /* none */
             ),
           ])
         end
+
+        context "includes named references" do
+          it "can parse" do
+            y = <<~INPUT
+%{
+// Prologue
+%}
+
+%union {
+  int i;
+}
+
+%token NUM
+%type <val> expr
+
+%%
+
+input       : /* empty */
+            | input line
+;
+
+line        : '\\n'
+            | expr '\\n'
+                { printf("\\t%.10g\\n", $expr); }
+;
+
+expr[result]: NUM
+            | expr[left] expr[right] '+'
+                { $result = $left + $right; }
+            | expr expr '-'
+                { $$ = $1 - $2; }
+;
+            INPUT
+            grammar = Lrama::Parser.new(y).parse
+
+            expect(grammar.rules).to eq([
+              Rule.new(
+                id: 0,
+                lhs: grammar.find_symbol_by_s_value!("$accept"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("input"),
+                  grammar.find_symbol_by_s_value!("YYEOF"),
+                ],
+                code: nil,
+                nullable: false,
+                precedence_sym: grammar.find_symbol_by_s_value!("YYEOF"),
+                lineno: 14,
+              ),
+              Rule.new(
+                id: 1,
+                lhs: grammar.find_symbol_by_s_value!("input"),
+                rhs: [
+                ],
+                code: nil,
+                nullable: true,
+                precedence_sym: nil,
+                lineno: 14,
+              ),
+              Rule.new(
+                id: 2,
+                lhs: grammar.find_symbol_by_s_value!("input"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("input"),
+                  grammar.find_symbol_by_s_value!("line"),
+                ],
+                code: nil,
+                nullable: false,
+                precedence_sym: nil,
+                lineno: 15,
+              ),
+              Rule.new(
+                id: 3,
+                lhs: grammar.find_symbol_by_s_value!("line"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("'\\n'"),
+                ],
+                code: nil,
+                nullable: false,
+                precedence_sym: grammar.find_symbol_by_s_value!("'\\n'"),
+                lineno: 18,
+              ),
+              Rule.new(
+                id: 4,
+                lhs: grammar.find_symbol_by_s_value!("line"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("expr"),
+                  grammar.find_symbol_by_s_value!("'\\n'"),
+                ],
+                code: Code.new(type: :user_code, token_code: T.new(type: T::User_code, s_value: "{ printf(\"\\t%.10g\\n\", $expr); }")),
+                nullable: false,
+                precedence_sym: grammar.find_symbol_by_s_value!("'\\n'"),
+                lineno: 19,
+              ),
+              Rule.new(
+                id: 5,
+                lhs: grammar.find_symbol_by_s_value!("expr"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("NUM"),
+                ],
+                code: nil,
+                nullable: false,
+                precedence_sym: grammar.find_symbol_by_s_value!("NUM"),
+                lineno: 23,
+              ),
+              Rule.new(
+                id: 6,
+                lhs: grammar.find_symbol_by_s_value!("expr"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("expr"),
+                  grammar.find_symbol_by_s_value!("expr"),
+                  grammar.find_symbol_by_s_value!("'+'"),
+                ],
+                code: Code.new(type: :user_code, token_code: T.new(type: T::User_code, s_value: "{ $result = $left + $right; }")),
+                nullable: false,
+                precedence_sym: grammar.find_symbol_by_s_value!("'+'"),
+                lineno: 24,
+              ),
+              Rule.new(
+                id: 7,
+                lhs: grammar.find_symbol_by_s_value!("expr"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("expr"),
+                  grammar.find_symbol_by_s_value!("expr"),
+                  grammar.find_symbol_by_s_value!("'-'"),
+                ],
+                code: Code.new(type: :user_code, token_code: T.new(type: T::User_code, s_value: "{ $$ = $1 - $2; }")),
+                nullable: false,
+                precedence_sym: grammar.find_symbol_by_s_value!("'-'"),
+                lineno: 26,
+              ),
+            ])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

In this pull request, I have implemented the [Named References](https://www.gnu.org/software/bison/manual/html_node/Named-References.html) concept from bison.
By merging this pull request, it will be possible to refer to the value by its symbol in the rule or its alias from within the action.

## Changes made

- Detect and tokenize the named references declaration
- Make references from named references in actions
- Change some grammar parameters
    - Add alias to Token class
    - Rename number in the Reference class to value because there is now a case where a string is assigned in addition to a number.
- Add a test case