### PR TITLE
Add tests for stdin mode

### DIFF
--- a/spec/fixtures/command/basic.y
+++ b/spec/fixtures/command/basic.y
@@ -1,0 +1,90 @@
+/*
+ * This is a valid　sample grammar file.
+ * It works as simple calculator.
+ */
+
+%{
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#include "calc.h"
+
+static int yylex(YYSTYPE *val, YYLTYPE *loc);
+static int yyerror(YYLTYPE *loc, const char *str);
+%}
+
+%union {
+    int val;
+}
+%token LF
+%token <val> NUM
+%type <val> expr
+%left '+' '-'
+%left '*' '/'
+
+%%
+
+list : /* empty */
+     | list LF
+     | list expr LF { printf("=> %d\n", $2); }
+     ;
+expr : NUM
+     | expr '+' expr { $$ = $1 + $3; }
+     | expr '-' expr { $$ = $1 - $3; }
+     | expr '*' expr { $$ = $1 * $3; }
+     | expr '/' expr { $$ = $1 / $3; }
+     | '(' expr ')'  { $$ = $2; }
+     ;
+
+%%
+
+static int yylex(YYSTYPE *yylval, YYLTYPE *loc) {
+    int c = getchar();
+    int val;
+
+    switch (c) {
+    case ' ': case '\t':
+        return yylex(yylval, loc);
+
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+        val = c - '0';
+        while (1) {
+            c = getchar();
+            if (isdigit(c)) {
+                val = val * 10 + (c - '0');
+            }
+            else {
+                ungetc(c, stdin);
+                break;
+            }
+        }
+        yylval->val = val;
+        return NUM;
+
+    case '\n':
+        return LF;
+
+    case '+': case '-': case '*': case '/': case '(': case ')':
+        return c;
+
+    case EOF:
+        exit(0);
+
+    default:
+        fprintf(stderr, "unknown character: %c\n", c);
+        exit(1);
+    }
+}
+
+static int yyerror(YYLTYPE *loc, const char *str) {
+    fprintf(stderr, "parse error: %s\n", str);
+    return 0;
+}
+
+int main() {
+    printf("Enter the formula:\n");
+    yyparse();
+    return 0;
+}

--- a/spec/lrama/command_spec.rb
+++ b/spec/lrama/command_spec.rb
@@ -1,4 +1,41 @@
 RSpec.describe Lrama::Command do
+  describe "#run" do
+    let(:command) { Lrama::Command.new }
+
+    describe "a grammar file is specified " do
+      it "ends successfully" do
+        expect(command.run([fixture_path("command/basic.y")])).to be_nil
+      end
+    end
+
+    describe "STDIN mode and a grammar file is specified" do
+      it "ends successfully" do
+        File.open(fixture_path("command/basic.y")) do |f|
+          allow(STDIN).to receive(:read).and_return(f)
+          expect(command.run(["-", "test.y"])).to be_nil
+        end
+      end
+    end
+
+    describe "invalid argv" do
+      describe "a grammar file isn't specified" do
+        it "returns stderr" do
+          expect{ command.run([]) }.to raise_error(SystemExit) do |e|
+            expect(e.message).to eq("File should be specified\n")
+          end
+        end
+      end
+
+      describe "STDIN mode, but a grammar file isn't specified" do
+        it "returns stderr" do
+          expect{ command.run(["-"]) }.to raise_error(SystemExit) do |e|
+            expect(e.message).to eq("File name for STDIN should be specified\n")
+          end
+        end
+      end
+    end
+  end
+
   describe "#validate_report" do
     let(:command) { Lrama::Command.new }
 


### PR DESCRIPTION
# Summary
- In todo list, https://docs.google.com/document/d/1EAZzYMXBOdzK-6mMIj2YNJxZZRVcpJxE7-4zXbHn8JA/edit#heading=h.ncudzyf4x3b
- This PR add tests corresponding to the following implementation https://github.com/ruby/lrama/pull/8

# Changes Made
- Add tests in command_spec.rb
  - normal mode case(`e.g., lrama -d parse.y -o parse.c`)
  - stdin mode case(`e.g., ruby tool/id2token.rb parse.y | lrama -d - parse.y -o parse.c`)
  - invalid cases

# Issues I want to consult on
- I added spec/fixtures/command/basic.y to use normal input test.
- I copied a grammar file from sample/calc.y to spec/fixtures/command. The contents of the file do not have significant meaning.
- If the above approach is inappropriate, could you please give me some advice?