### PR TITLE
Suppress unused-but-set-variable warnings

### DIFF
--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -93,7 +93,7 @@ int main() {
 
   %%
 
-  program : /* empty */
+  program : { (void)yynerrs; }
        | expr { printf("=> %d", $1); }
        ;
   expr : NUM
@@ -128,7 +128,7 @@ int main() {
   %%
 
   line: expr
-          { printf("=> %d", $expr); }
+          { (void)yynerrs; printf("=> %d", $expr); }
       ;
 
   expr[result]: NUM


### PR DESCRIPTION
Some compilers warn `yynerrs` in the tests.

```
/tmp/test.c:1268:9: warning: variable 'yynerrs' set but not used
      [-Wunused-but-set-variable]
    int yynerrs = 0;
        ^
1 warning generated.
/tmp/test.c:1258:9: warning: variable 'yynerrs' set but not used
      [-Wunused-but-set-variable]
    int yynerrs = 0;
        ^
1 warning generated.
```