### PR TITLE
Raise proper error at reference with no declared type

### DIFF
--- a/lib/lrama/grammar/reference.rb
+++ b/lib/lrama/grammar/reference.rb
@@ -11,6 +11,13 @@ module Lrama
           referring_symbol.tag
         end
       end
+
+      def member
+        if tag = self.tag
+          # Omit "<>"
+          tag.s_value[1..-2]
+        end
+      end
     end
   end
 end

--- a/lib/lrama/grammar/rule.rb
+++ b/lib/lrama/grammar/rule.rb
@@ -27,7 +27,7 @@ module Lrama
 
       def translated_code
         if code
-          code.translated_code
+          code.translated_code(lhs.id)
         else
           nil
         end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1368,6 +1368,34 @@ class : keyword_class tSTRING keyword_end
         expect(codes[2].references.count).to eq(1)
         expect(codes[2].references[0].tag.s_value).to eq("<l>")
       end
+
+      it "reports reference without declared type" do
+        y = <<~INPUT
+%{
+// Prologue
+%}
+
+%union {
+  int i;
+}
+
+%token tSTRING
+%type <i> stmt
+
+%%
+
+stmt : tSTRING
+        {
+          $$ = $1;
+        }
+    ;
+%%
+        INPUT
+        grammar = Lrama::Parser.new(y).parse
+        stmt = grammar.rules[1]
+        expect(stmt.lhs.id.s_value).to eq("stmt")
+        expect { stmt.translated_code }.to raise_error("$1 of `stmt' has no declared type")
+      end
     end
   end
 end


### PR DESCRIPTION
When using reference with no declared type mistakenly, it raise `NoMethodError` with ``undefined method `s_value' for nil`` currently.
Of course it is wrong code, but the message does not seem intentional.

```
./lib/lrama/grammar/code.rb:77:in `block in translated_user_code'
./lib/lrama/grammar/code.rb:63:in `each'
./lib/lrama/grammar/code.rb:63:in `translated_user_code'
./lib/lrama/grammar/code.rb:14:in `translated_code'
./lib/lrama/grammar/rule.rb:30:in `translated_code'
```