### PR TITLE
Added gem to help tracking the code coverage of the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .irbrc
 /Gemfile.lock
 /pkg/
+coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem "stackprof"
 gem "rake"
 gem "rbs", require: false
 gem "steep", require: false
+gem "simplecov", require: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,21 @@
+require "simplecov"
+
+SimpleCov.start do
+  track_files "lib/**/*.rb"
+
+  # Created Groups based on the folder structures
+  add_group "Grammar", "lib/lrama/grammar"
+  add_group "Lexer", "lib/lrama/lexer"
+  add_group "Parser", "lib/lrama/parser"
+  add_group "Report", "lib/lrama/report"
+  add_group "State", "lib/lrama/state/"
+  add_group "States", "lib/lrama/states/"
+
+  add_filter "spec/"
+
+  enable_coverage :branch
+end
+
 require "lrama"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Hello, 

I have added `simplecov` to help tracking the tests coverage.

![image](https://github.com/ruby/lrama/assets/6237738/ac3da9cd-e2af-48c2-be65-f5c3a97dcb43)


(Please let me know if you would prefer me to follow any structure when opening a PR.)