### PR TITLE
Refactor Lrama::Grammar::Symbol

### DIFF
--- a/lib/lrama/grammar/symbol.rb
+++ b/lib/lrama/grammar/symbol.rb
@@ -34,11 +34,7 @@ module Lrama
       end
 
       def display_name
-        if alias_name
-          alias_name
-        else
-          id.s_value
-        end
+        alias_name || id.s_value
       end
 
       # name for yysymbol_kind_t
@@ -51,11 +47,7 @@ module Lrama
         when eof_symbol?
           name = "YYEOF"
         when term? && id.type == Token::Char
-          if alias_name
-            name = number.to_s + alias_name
-          else
-            name = number.to_s + id.s_value
-          end
+          name = number.to_s + display_name
         when term? && id.type == Token::Ident
           name = id.s_value
         when nterm? && (id.s_value.include?("$") || id.s_value.include?("@"))
@@ -66,7 +58,7 @@ module Lrama
           raise "Unexpected #{self}"
         end
 
-        "YYSYMBOL_" + name.gsub(/[^a-zA-Z_0-9]+/, "_")
+        "YYSYMBOL_" + name.gsub(/\W+/, "_")
       end
 
       # comment for yysymbol_kind_t


### PR DESCRIPTION
Simplify display_name and enum_name methods by removing if-else and using non-word character class.