### PR TITLE
Prefer transform_values in Lrama::States

### DIFF
--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -102,43 +102,27 @@ module Lrama
     end
 
     def direct_read_sets
-      h = {}
-
-      @direct_read_sets.each do |k, v|
-        h[k] = bitmap_to_terms(v)
+      @direct_read_sets.transform_values do |v|
+        bitmap_to_terms(v)
       end
-
-      return h
     end
 
     def read_sets
-      h = {}
-
-      @read_sets.each do |k, v|
-        h[k] = bitmap_to_terms(v)
+      @read_sets.transform_values do |v|
+        bitmap_to_terms(v)
       end
-
-      return h
     end
 
     def follow_sets
-      h = {}
-
-      @follow_sets.each do |k, v|
-        h[k] = bitmap_to_terms(v)
+      @follow_sets.transform_values do |v|
+        bitmap_to_terms(v)
       end
-
-      return h
     end
 
     def la
-      h = {}
-
-      @la.each do |k, v|
-        h[k] = bitmap_to_terms(v)
+      @la.transform_values |v|
+        bitmap_to_terms(v)
       end
-
-      return h
     end
 
     private

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -120,7 +120,7 @@ module Lrama
     end
 
     def la
-      @la.transform_values |v|
+      @la.transform_values do |v|
         bitmap_to_terms(v)
       end
     end


### PR DESCRIPTION
Replace each with transform_values in direct_read_sets, read_sets, follow_sets and la methods.