### PR TITLE
Rename Aux to Auxiliary

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -1,4 +1,4 @@
-require "lrama/grammar/aux"
+require "lrama/grammar/auxiliary"
 require "lrama/grammar/code"
 require "lrama/grammar/error_token"
 require "lrama/grammar/precedence"
@@ -36,7 +36,7 @@ module Lrama
       @error_symbol = nil
       @undef_symbol = nil
       @accept_symbol = nil
-      @aux = Aux.new
+      @aux = Auxiliary.new
 
       append_special_symbols
     end

--- a/lib/lrama/grammar/aux.rb
+++ b/lib/lrama/grammar/aux.rb
@@ -1,7 +1,0 @@
-module Lrama
-  class Grammar
-    # Grammar file information not used by States but by Output
-    class Aux < Struct.new(:prologue_first_lineno, :prologue, :epilogue_first_lineno, :epilogue, keyword_init: true)
-    end
-  end
-end

--- a/lib/lrama/grammar/auxiliary.rb
+++ b/lib/lrama/grammar/auxiliary.rb
@@ -1,0 +1,7 @@
+module Lrama
+  class Grammar
+    # Grammar file information not used by States but by Output
+    class Auxiliary < Struct.new(:prologue_first_lineno, :prologue, :epilogue_first_lineno, :epilogue, keyword_init: true)
+    end
+  end
+end


### PR DESCRIPTION
Can not use "aux" for file name in Windows.