### PR TITLE
Add Windows CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,20 @@ jobs:
           bundler-cache: true
       - run: bundle install
       - run: bundle exec rspec
+  test-windows:
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['head']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle install
+      - run: bundle exec rspec
   check-misc:
     runs-on: ubuntu-20.04
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ gemspec
 
 gem "rspec"
 gem "pry"
-gem "stackprof"
+# stackprof doesn't support Windows
+gem "stackprof", platforms: [:ruby]
 gem "rake"
 gem "rbs", require: false
 gem "steep", require: false

--- a/lib/lrama/command.rb
+++ b/lib/lrama/command.rb
@@ -32,6 +32,7 @@ module Lrama
 
       warning = Lrama::Warning.new
       grammar = Lrama::Parser.new(@y.read).parse
+      @y.close if @y != STDIN
       states = Lrama::States.new(grammar, warning, trace_state: (@trace_opts[:automaton] || @trace_opts[:closure]))
       states.compute
       context = Lrama::Context.new(states)


### PR DESCRIPTION
Add Add Windows CI to detect errors only happen on Windows environment, like https://github.com/ruby/lrama/pull/82.