### PR TITLE
Fix trivial formatting

### DIFF
--- a/exe/lrama
+++ b/exe/lrama
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-
 $LOAD_PATH << File.join(__dir__, "../lib")
 require "lrama"
 

--- a/lib/lrama/context.rb
+++ b/lib/lrama/context.rb
@@ -401,14 +401,12 @@ module Lrama
       end
       print sprintf("]\n\n")
 
-
       print sprintf("width [\n")
       vectors_count.times do |i|
         print sprintf("%d, ", ary[i] ? ary[i][3] : 0)
         print "\n" if i % 10 == 9
       end
       print sprintf("]\n\n")
-
 
       print sprintf("tally [\n")
       vectors_count.times do |i|

--- a/lib/lrama/counterexamples.rb
+++ b/lib/lrama/counterexamples.rb
@@ -205,7 +205,7 @@ module Lrama
     end
 
     def build_paths_from_state_items(state_items)
-      paths = state_items.zip([nil] + state_items).map do |si, prev_si|
+      state_items.zip([nil] + state_items).map do |si, prev_si|
         case
         when prev_si.nil?
           StartPath.new(si)
@@ -215,8 +215,6 @@ module Lrama
           TransitionPath.new(prev_si, si)
         end
       end
-
-      paths
     end
 
     def shortest_path(conflict_state, conflict_reduce_item, conflict_term)

--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -310,7 +310,6 @@ module Lrama
       end || (raise "Nterm not found: #{id}")
     end
 
-
     def append_special_symbols
       # YYEMPTY (token_id: -2, number: -2) is added when a template is evaluated
       # term = add_term(id: Token.new(Token::Ident, "YYEMPTY"), token_id: -2)

--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -511,7 +511,7 @@ module Lrama
               sym.token_id = 11
             when "\""
               sym.token_id = 34
-            when "\'"
+            when "'"
               sym.token_id = 39
             when "\\\\"
               sym.token_id = 92

--- a/lib/lrama/grammar/code.rb
+++ b/lib/lrama/grammar/code.rb
@@ -50,7 +50,6 @@ module Lrama
       end
       alias :translated_error_token_code :translated_printer_code
 
-
       private
 
       # * ($1) yyvsp[i]

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -314,8 +314,6 @@ module Lrama
           str << ss.getch
           next
         end
-
-        str << ss[0]
       end
 
       line # Reach to end of input

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -30,7 +30,6 @@ module Lrama
       @grammar_rules = []
       @epilogue = []
 
-      #
       @bison_declarations_tokens = []
       @grammar_rules_tokens = []
 

--- a/lib/lrama/state.rb
+++ b/lib/lrama/state.rb
@@ -62,7 +62,6 @@ module Lrama
       @items_to_state[items] = next_state
     end
 
-    #
     def set_look_ahead(rule, look_ahead)
       reduce = reduces.find do |r|
         r.rule == rule

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -515,9 +515,9 @@ module Lrama
 
         state.default_reduction_rule = state.reduces.map do |r|
           [r.rule, r.rule.id, (r.look_ahead || []).count]
-        end.sort_by do |rule, rule_id, count|
+        end.min_by do |rule, rule_id, count|
           [-count, rule_id]
-        end.first.first
+        end.first
       end
     end
 

--- a/lib/lrama/states_reporter.rb
+++ b/lib/lrama/states_reporter.rb
@@ -197,7 +197,7 @@ module Lrama
           # Report counterexamples
           examples = cex.compute(state)
           examples.each do |example|
-            label0 = example.type == :shift_reduce ? "shift/reduce"  : "reduce/reduce"
+            label0 = example.type == :shift_reduce ? "shift/reduce" : "reduce/reduce"
             label1 = example.type == :shift_reduce ? "Shift derivation"  : "First Reduce derivation"
             label2 = example.type == :shift_reduce ? "Reduce derivation" : "Second Reduce derivation"
 

--- a/lib/lrama/states_reporter.rb
+++ b/lib/lrama/states_reporter.rb
@@ -110,7 +110,6 @@ module Lrama
         end
         io << "\n"
 
-
         # Report shifts
         tmp = state.term_transitions.select do |shift, _|
           !shift.not_selected
@@ -122,7 +121,6 @@ module Lrama
           io << "    #{term.display_name.ljust(max_len)}  shift, and go to state #{state_id}\n"
         end
         io << "\n" if !tmp.empty?
-
 
         # Report error caused by %nonassoc
         nl = false
@@ -137,7 +135,6 @@ module Lrama
           io << "    #{name.ljust(max_len)}  error (nonassociative)\n"
         end
         io << "\n" if !tmp.empty?
-
 
         # Report reduces
         nl = false
@@ -171,7 +168,6 @@ module Lrama
         end
         io << "\n" if nl
 
-
         # Report nonterminal transitions
         tmp = []
         max_len = 0
@@ -188,7 +184,6 @@ module Lrama
           io << "    #{nterm.id.s_value.ljust(max_len)}  go to state #{state_id}\n"
         end
         io << "\n" if !tmp.empty?
-
 
         if solved
           # Report conflict resolutions
@@ -234,7 +229,6 @@ module Lrama
           end
           io << "\n"
 
-
           # Report reads_relation
           io << "  [Reads Relation]\n"
           @states.nterms.each do |nterm|
@@ -247,7 +241,6 @@ module Lrama
             end
           end
           io << "\n"
-
 
           # Report read_sets
           io << "  [Read sets]\n"
@@ -263,7 +256,6 @@ module Lrama
           end
           io << "\n"
 
-
           # Report includes_relation
           io << "  [Includes Relation]\n"
           @states.nterms.each do |nterm|
@@ -276,7 +268,6 @@ module Lrama
             end
           end
           io << "\n"
-
 
           # Report lookback_relation
           io << "  [Lookback Relation]\n"
@@ -291,7 +282,6 @@ module Lrama
           end
           io << "\n"
 
-
           # Report follow_sets
           io << "  [Follow sets]\n"
           follow_sets = @states.follow_sets
@@ -305,7 +295,6 @@ module Lrama
             end
           end
           io << "\n"
-
 
           # Report LA
           io << "  [Look-Ahead Sets]\n"
@@ -325,7 +314,6 @@ module Lrama
           end
           io << "\n" if !tmp.empty?
         end
-
 
         # End of Report State
         io << "\n"

--- a/lib/lrama/states_reporter.rb
+++ b/lib/lrama/states_reporter.rb
@@ -202,8 +202,8 @@ module Lrama
             label2 = example.type == :shift_reduce ? "Reduce derivation" : "Second Reduce derivation"
 
             io << "    #{label0} conflict on token #{example.conflict_symbol.id.s_value}:\n"
-            io << "        #{example.path1_item.to_s}\n"
-            io << "        #{example.path2_item.to_s}\n"
+            io << "        #{example.path1_item}\n"
+            io << "        #{example.path2_item}\n"
             io << "      #{label1}\n"
             example.derivations1.render_strings_for_report.each do |str|
               io << "        #{str}\n"
@@ -277,7 +277,7 @@ module Lrama
 
             a.each do |state_id2, nterm_id2|
               n = @states.nterms.find {|n| n.token_id == nterm_id2 }
-              io << "    (Rule: #{rule.to_s}) -> (State #{state_id2}, #{n.id.s_value})\n"
+              io << "    (Rule: #{rule}) -> (State #{state_id2}, #{n.id.s_value})\n"
             end
           end
           io << "\n"

--- a/spec/lrama/command_spec.rb
+++ b/spec/lrama/command_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Lrama::Command do
   describe "#run" do
-    describe "a grammar file is specified " do
+    describe "a grammar file is specified" do
       it "ends successfully" do
         command = Lrama::Command.new([fixture_path("command/basic.y")])
         expect(command.run).to be_nil

--- a/spec/lrama/counterexamples_spec.rb
+++ b/spec/lrama/counterexamples_spec.rb
@@ -114,7 +114,6 @@ num  : digit
                                                                       7:   • digit
         STR
 
-
         # State 16
         #
         #     6 expr: expr • '+' expr
@@ -162,7 +161,6 @@ num  : digit
                 6:  expr                 '+' expr
                     6: expr '+' expr  •
         STR
-
 
         # State 17
         #

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -212,7 +212,6 @@ RSpec.describe Lrama::Lexer do
         T.new(type: T::Ident, s_value: "strings_2"),
         T.new(type: T::Semicolon, s_value: ";"),
 
-
         T.new(type: T::Ident_Colon, s_value: "class"),
         T.new(type: T::Ident, s_value: "keyword_class"),
         T.new(type: T::Ident, s_value: "tSTRING"),
@@ -242,11 +241,9 @@ RSpec.describe Lrama::Lexer do
         T.new(type: T::Char, s_value: "'>'"),
         T.new(type: T::Semicolon, s_value: ";"),
 
-
         T.new(type: T::Ident_Colon, s_value: "strings_1"),
         T.new(type: T::Ident, s_value: "string_1"),
         T.new(type: T::Semicolon, s_value: ";"),
-
 
         T.new(type: T::Ident_Colon, s_value: "strings_2"),
         T.new(type: T::Ident, s_value: "string_1"),
@@ -255,17 +252,14 @@ RSpec.describe Lrama::Lexer do
         T.new(type: T::Ident, s_value: "string_2"),
         T.new(type: T::Semicolon, s_value: ";"),
 
-
         T.new(type: T::Ident_Colon, s_value: "string_1"),
         T.new(type: T::Ident, s_value: "string"),
         T.new(type: T::Semicolon, s_value: ";"),
-
 
         T.new(type: T::Ident_Colon, s_value: "string_2"),
         T.new(type: T::Ident, s_value: "string"),
         T.new(type: T::Char, s_value: "'+'"),
         T.new(type: T::Semicolon, s_value: ";"),
-
 
         T.new(type: T::Ident_Colon, s_value: "string"),
         T.new(type: T::Ident, s_value: "tSTRING"),

--- a/spec/lrama/output_spec.rb
+++ b/spec/lrama/output_spec.rb
@@ -26,13 +26,11 @@ RSpec.describe Lrama::Output do
       allow(grammar).to receive(:parse_param).and_return("{ struct parser_params *p  }")
       expect(output.parse_param).to eq("struct parser_params *p")
 
-
       allow(grammar).to receive(:parse_param).and_return("{int i}")
       expect(output.parse_param).to eq("int i")
 
       allow(grammar).to receive(:parse_param).and_return("{ int i  }")
       expect(output.parse_param).to eq("int i")
-
 
       allow(grammar).to receive(:parse_param).and_return("{int parse_param}")
       expect(output.parse_param).to eq("int parse_param")
@@ -51,13 +49,11 @@ RSpec.describe Lrama::Output do
         allow(grammar).to receive(:parse_param).and_return("{ struct parser_params *p  }")
         expect(output.user_formals).to eq(", struct parser_params *p")
 
-
         allow(grammar).to receive(:parse_param).and_return("{int i}")
         expect(output.user_formals).to eq(", int i")
 
         allow(grammar).to receive(:parse_param).and_return("{ int i  }")
         expect(output.user_formals).to eq(", int i")
-
 
         allow(grammar).to receive(:parse_param).and_return("{int parse_param}")
         expect(output.user_formals).to eq(", int parse_param")
@@ -84,13 +80,11 @@ RSpec.describe Lrama::Output do
         allow(grammar).to receive(:parse_param).and_return("{ struct parser_params *p  }")
         expect(output.user_args).to eq(", p")
 
-
         allow(grammar).to receive(:parse_param).and_return("{int i}")
         expect(output.user_args).to eq(", i")
 
         allow(grammar).to receive(:parse_param).and_return("{ int i  }")
         expect(output.user_args).to eq(", i")
-
 
         allow(grammar).to receive(:parse_param).and_return("{int parse_param}")
         expect(output.user_args).to eq(", parse_param")
@@ -116,13 +110,11 @@ RSpec.describe Lrama::Output do
       allow(grammar).to receive(:parse_param).and_return("{ struct parser_params *p  }")
       expect(output.parse_param_name).to eq("p")
 
-
       allow(grammar).to receive(:parse_param).and_return("{int i}")
       expect(output.parse_param_name).to eq("i")
 
       allow(grammar).to receive(:parse_param).and_return("{ int i  }")
       expect(output.parse_param_name).to eq("i")
-
 
       allow(grammar).to receive(:parse_param).and_return("{int parse_param}")
       expect(output.parse_param_name).to eq("parse_param")
@@ -140,13 +132,11 @@ RSpec.describe Lrama::Output do
       allow(grammar).to receive(:lex_param).and_return("{ struct parser_params *p  }")
       expect(output.lex_param_name).to eq("p")
 
-
       allow(grammar).to receive(:lex_param).and_return("{int i}")
       expect(output.lex_param_name).to eq("i")
 
       allow(grammar).to receive(:lex_param).and_return("{ int i  }")
       expect(output.lex_param_name).to eq("i")
-
 
       allow(grammar).to receive(:lex_param).and_return("{int lex_param}")
       expect(output.lex_param_name).to eq("lex_param")

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -648,7 +648,7 @@ class : keyword_class tSTRING keyword_end { code 1 }
       ])
     end
 
-    it "action in the middle of RHS " do
+    it "action in the middle of RHS" do
       y = header + <<~INPUT
 %%
 
@@ -823,7 +823,7 @@ class : keyword_class
       end
     end
 
-    describe " ' in user code" do
+    describe "' in user code" do
       it do
         y = header + <<~INPUT
 %%


### PR DESCRIPTION
This PR fix trivial formatting

- Remove unnecessary empty lines
- Remove redundant Object#to_s
- Remove unreachable code
- Remove redundant assignment
- Use min_by instead of sort_by...first
- Remove redundant string escape
- Remove excessive whitespace
- Remove unnecessary spacing
- Remove empty comment
