### PR TITLE
Refactor #extract_param_name

### DIFF
--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -252,7 +252,7 @@ module Lrama
     end
 
     def extract_param_name(param)
-      /\A(\W*)([a-zA-Z0-9_]+)\z/.match(param.split.last)[2]
+      param[/\b([a-zA-Z0-9_]+)(?=\s*\z)/]
     end
 
     def parse_param_name


### PR DESCRIPTION
String#split without arg depends on "$;", however it's better to not depend on "$;" for supporting multiple ruby version.

This is based on suggestion by nobu
https://github.com/ruby/lrama/commit/518aefd11527514b42dbdb5402694e37a34b9d00#r124738493