### PR TITLE
Implement %precedence Operator Precedence

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -103,6 +103,10 @@ module Lrama
       set_precedence(sym, Precedence.new(type: :right, precedence: precedence))
     end
 
+    def add_precedence(sym, precedence)
+      set_precedence(sym, Precedence.new(type: :precedence, precedence: precedence))
+    end
+
     def set_precedence(sym, precedence)
       raise "" if sym.nterm?
       sym.precedence = precedence

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -154,6 +154,8 @@ module Lrama
           tokens << create_token(Token::P_left, ss[0], line, ss.pos - column)
         when ss.scan(/%right/)
           tokens << create_token(Token::P_right, ss[0], line, ss.pos - column)
+        when ss.scan(/%precedence/)
+          tokens << create_token(Token::P_precedence, ss[0], line, ss.pos - column)
         when ss.scan(/%prec/)
           tokens << create_token(Token::P_prec, ss[0], line, ss.pos - column)
         when ss.scan(/{/)

--- a/lib/lrama/lexer/token.rb
+++ b/lib/lrama/lexer/token.rb
@@ -61,6 +61,7 @@ module Lrama
       define_type(:P_nonassoc)       # %nonassoc
       define_type(:P_left)           # %left
       define_type(:P_right)          # %right
+      define_type(:P_precedence)     # %precedence
       define_type(:P_prec)           # %prec
       define_type(:User_code)        # { ... }
       define_type(:Tag)              # <int>

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -159,6 +159,14 @@ module Lrama
             grammar.add_right(sym, precedence_number)
           end
           precedence_number += 1
+        when T::P_precedence
+          # %precedence (ident|char|string)+
+          ts.next
+          while (id = ts.consume(T::Ident, T::Char, T::String)) do
+            sym = grammar.add_term(id: id)
+            grammar.add_precedence(sym, precedence_number)
+          end
+          precedence_number += 1
         when nil
           # end of input
           raise "Reach to end of input within declarations"

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -455,6 +455,11 @@ module Lrama
 
             # shift_prec == reduce_prec, then check associativity
             case sym.precedence.type
+            when :precedence
+              # %precedence only specifies precedence and not specify associativity
+              # then a conflict is unresolved if precedence is same.
+              state.conflicts << State::ShiftReduceConflict.new(symbols: [sym], shift: shift, reduce: reduce)
+              next
             when :right
               # Shift is selected
               state.resolved_conflicts << State::ResolvedConflict.new(symbol: sym, reduce: reduce, which: :shift, same_prec: true)


### PR DESCRIPTION
This only specifies precedence and not specify associativity then a conflict is unresolved if precedence is same.