### PR TITLE
Make sure `z` to be not nil

### DIFF
--- a/lib/lrama/digraph.rb
+++ b/lib/lrama/digraph.rb
@@ -40,8 +40,7 @@ module Lrama
       end
 
       if @h[x] == d
-        while true do
-          z = @stack.pop
+        while (z = @stack.pop) do
           @h[z] = Float::INFINITY
           break if z == x
           @result[z] = @result[x] # F (Top of S) = F x

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -2,7 +2,7 @@
 sources:
 - type: git
   name: ruby/gem_rbs_collection
-  revision: b42e4de88058603a34446942143b3ac197b9685c
+  revision: 95ad664324500c9eec78569b45da98c65a27a511
   remote: https://github.com/ruby/gem_rbs_collection.git
   repo_dir: gems
 path: ".gem_rbs_collection"

--- a/sig/lrama/digraph.rbs
+++ b/sig/lrama/digraph.rbs
@@ -10,11 +10,11 @@ module Lrama
     # S in the paper
     @stack: Array[Integer]
     # N in the paper
-    @h: Hash[Integer?, (Integer|Float)?]
+    @h: Hash[Integer, (Integer|Float)?]
     # F in the paper
-    @result: Hash[Integer?, Integer]
+    @result: Hash[Integer, Integer]
 
-    def compute: () -> Hash[Integer?, Integer]
+    def compute: () -> Hash[Integer, Integer]
 
     private
 


### PR DESCRIPTION
`Digraph#traverse` push argment first. This means while loop stops before stack to be empty because it will be break if argment is popped. Checking the result of `@stack.pop` in while condition expr, so that we can ensure `z` to be not nil on semantics level.