### PR TITLE
Iterate over symbols to get the number to avoid array creation

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -663,8 +663,8 @@ module Lrama
       nterm_token_id = 0
       used_numbers = {}
 
-      @symbols.map(&:number).each do |n|
-        used_numbers[n] = true
+      @symbols.each do |symbol|
+        used_numbers[symbol.number] = true
       end
 
       (@symbols.select(&:term?) + @symbols.select(&:nterm?)).each do |sym|


### PR DESCRIPTION
A tiny optimisation that reduces the memory usage by eliminating an array that it not used later anyway.

For parsing `spec/fixtures/context/basic.y` it reduces one object:

Before:
```
Calculating -------------------------------------
              master   133.668k memsize (     2.481k retained)
                         1.976k objects (     1.000  retained)
                        50.000  strings (     1.000  retained)
```

After:
```
Calculating -------------------------------------
              master   133.348k memsize (     2.481k retained)
                         1.975k objects (     1.000  retained)
                        50.000  strings (     1.000  retained)
```