### PR TITLE
Make "spec/lrama/grammar/code_spec.rb" runnable independently

### DIFF
--- a/spec/lrama/grammar/code_spec.rb
+++ b/spec/lrama/grammar/code_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Lrama::Grammar::Code do
   let(:token_class) { Lrama::Lexer::Token }
-  let(:user_code_token) { token_class.new(type: T::User_code, s_value: "{ code 1 }") }
-  let(:initial_act_token) { token_class.new(type: T::P_initial_action, s_value: "%initial-action") }
+  let(:user_code_token) { token_class.new(type: token_class::User_code, s_value: "{ code 1 }") }
+  let(:initial_act_token) { token_class.new(type: token_class::P_initial_action, s_value: "%initial-action") }
 
   describe "#translated_code" do
     context "when the code type is :user_code" do


### PR DESCRIPTION
Before this commit, `rspec spec/lrama/grammar/code_spec.rb` failed with NameError.

```
NameError:
  uninitialized constant T
```