### PR TITLE
add lexer/token/type.rbs

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -8,5 +8,6 @@ target :lib do
   check "lib/lrama/digraph.rb"
   check "lib/lrama/report/duration.rb"
   check "lib/lrama/report/profile.rb"
+  check "lib/lrama/token/type.rb"
   check "lib/lrama/warning.rb"
 end

--- a/sig/lrama/lexer/token/type.rbs
+++ b/sig/lrama/lexer/token/type.rbs
@@ -1,0 +1,15 @@
+module Lrama
+  class Lexer
+    class Token
+      attr_accessor type: Type
+      attr_accessor s_value: String
+      attr_accessor alias: String
+      attr_accessor keyword_init: bool
+      class Type
+        attr_accessor id: Integer
+        attr_accessor name: String
+        attr_accessor keyword_init: bool
+      end
+    end
+  end
+end


### PR DESCRIPTION
I was planning to type-check `symbol.rb`, but I realized that I need `grammar.rb`, `lexer/token.rb`, and `lexer/token/type.rb`.
I'm working on preparing them in order, and this is going to be the first step in that process.