### PR TITLE
Add spell checking GitHub Actions workflow

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,15 @@
+name: CodeSpell
+on:
+  - pull_request
+jobs:
+  codespell:
+    name: CodeSpell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: CodeSpell
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          check_hidden: true
+          ignore_words_file: .codespellignore

--- a/lib/lrama/context.rb
+++ b/lib/lrama/context.rb
@@ -170,7 +170,7 @@ module Lrama
       return a
     end
 
-    # Mapping from rule number to lenght of RHS.
+    # Mapping from rule number to length of RHS.
     # Dummy rule is appended as the first element whose value is 0
     # because 0 means error in yydefact.
     def yyr2

--- a/lib/lrama/context.rb
+++ b/lib/lrama/context.rb
@@ -259,7 +259,7 @@ module Lrama
           actions[conflict.symbol.number] = ErrorActionNumber
         end
 
-        # If default_reduction_rule, replase default_reduction_rule in
+        # If default_reduction_rule, replace default_reduction_rule in
         # actions with zero.
         if state.default_reduction_rule
           actions.map! do |e|
@@ -272,7 +272,7 @@ module Lrama
         end
 
         # If no default_reduction_rule, default behavior is an
-        # error then replase ErrorActionNumber with zero.
+        # error then replace ErrorActionNumber with zero.
         if !state.default_reduction_rule
           actions.map! do |e|
             if e == ErrorActionNumber

--- a/lib/lrama/context.rb
+++ b/lib/lrama/context.rb
@@ -214,7 +214,7 @@ module Lrama
       (rule_id + 1) * -1
     end
 
-    # Symbol number is assinged to term first then nterm.
+    # Symbol number is assigned to term first then nterm.
     # This method calculates sequence_number for nterm.
     def nterm_number_to_sequence_number(nterm_number)
       nterm_number - @states.terms.count


### PR DESCRIPTION
This PR adds spell checking GitHub Actions workflow and fixes typos.

How about the following spell check by CI?
- https://github.com/codespell-project/codespell

The run detected the following spelling errors:

https://github.com/ruby/lrama/actions/runs/6520864200/job/17708868735?pr=120
```
Error: ./lib/lrama/context.rb:173: lenght ==> length
Error: ./lib/lrama/context.rb:217: assinged ==> assigned
Error: ./lib/lrama/context.rb:262: replase ==> replace, relapse, rephase
Error: ./lib/lrama/context.rb:275: replase ==> replace, relapse, rephase
```