### PR TITLE
Add description of STDIN mode to help command

### DIFF
--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -52,6 +52,9 @@ module Lrama
           Usage: lrama [options] FILE
         BANNER
         o.separator ''
+        o.separator 'STDIN mode:'
+        o.separator 'lrama [options] - FILE               read grammar from STDIN'
+        o.separator ''
         o.separator 'Tuning the Parser:'
         o.on('-S', '--skeleton=FILE', 'specify the skeleton to use') {|v| @options.skeleton = v }
         o.on('-t', 'reserved, do nothing') { }

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Lrama::OptionParser do
 
         Usage: lrama [options] FILE
 
+        STDIN mode:
+        lrama [options] - FILE               read grammar from STDIN
+
         Tuning the Parser:
             -S, --skeleton=FILE              specify the skeleton to use
             -t                               reserved, do nothing


### PR DESCRIPTION
```diff
❯ exe/lrama --help                                     
Lrama is LALR (1) parser generator written by Ruby.

Usage: lrama [options] FILE

+STDIN mode:
+lrama [options] - FILE               read grammar from STDIN

Tuning the Parser:
    -S, --skeleton=FILE              specify the skeleton to use
    -t                               reserved, do nothing

Output:
    -h, --header=[FILE]              also produce a header file named FILE
    -d                               also produce a header file
    -r, --report=THINGS              also produce details on the automaton
        --report-file=FILE           also produce details on the automaton output to a file named FILE
    -o, --output=FILE                leave output to FILE
        --trace=THINGS               also output trace logs at runtime
    -v                               reserved, do nothing

Error Recovery:
    -e                               enable error recovery

Other options:
    -V, --version                    output version information and exit
        --help                       display this help and exit
```