### PR TITLE
Add 2.5 for test-ruby CI job target

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,7 +79,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        baseruby: ['3.0']
+        # '3.0' is the oldest living ruby version
+        # '2.5' is for BASERUBY
+        baseruby: ['3.0', '2.5']
         ruby_branch: ['master']
     defaults:
       run:


### PR DESCRIPTION
2.5 is current BASERUBY.