### PR TITLE
Fix the location of `end`

### DIFF
--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -106,7 +106,6 @@
 <%- else -%>
 /* Use api.header.include to #include this header
    instead of duplicating it here.  */
-<%- end -%>
 <%# b4_shared_declarations -%>
   <%-# b4_cpp_guard_open([b4_spec_mapped_header_file]) -%>
     <%- if output.spec_mapped_header_file -%>
@@ -178,6 +177,7 @@ int yyparse (<%= output.parse_param %>);
     <%- if output.spec_mapped_header_file -%>
 #endif /* !<%= output.b4_cpp_guard__b4_spec_mapped_header_file %>  */
     <%- end -%>
+<%- end -%>
 <%# b4_declare_symbol_enum -%>
 /* Symbol kind.  */
 enum yysymbol_kind_t


### PR DESCRIPTION
If `output.include_header` is not defined, all contents in yacc.h are expanded to C file. Therefore `end` should be just before `b4_declare_symbol_enum`.