### PR TITLE
Allow `-H` option to also generate a header file with the specified name

### DIFF
--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -60,7 +60,8 @@ module Lrama
         o.on('-t', 'reserved, do nothing') { }
         o.separator ''
         o.separator 'Output:'
-        o.on('-h', '--header=[FILE]', 'also produce a header file named FILE') {|v| @options.header = true; @options.header_file = v }
+        o.on('-H', '--header=[FILE]', 'also produce a header file named FILE') {|v| @options.header = true; @options.header_file = v }
+        o.on('-h=[FILE]', 'also produce a header file named FILE (deprecated)') {|v| @options.header = true; @options.header_file = v }
         o.on('-d', 'also produce a header file') { @options.header = true }
         o.on('-r', '--report=THINGS', Array, 'also produce details on the automaton') {|v| @report = v }
         o.on('--report-file=FILE', 'also produce details on the automaton output to a file named FILE') {|v| @options.report_file = v }

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Lrama::OptionParser do
             -t                               reserved, do nothing
 
         Output:
-            -h, --header=[FILE]              also produce a header file named FILE
+            -H, --header=[FILE]              also produce a header file named FILE
+            -h=[FILE]                        also produce a header file named FILE (deprecated)
             -d                               also produce a header file
             -r, --report=THINGS              also produce details on the automaton
                 --report-file=FILE           also produce details on the automaton output to a file named FILE
@@ -139,6 +140,15 @@ RSpec.describe Lrama::OptionParser do
       context "outfile option is passed" do
         it "@header_file is set based on outfile" do
           option_parser = Lrama::OptionParser.new
+          option_parser.send(:parse, ["-H", "-o", "parse.c", "-", "test.y"])
+          options = option_parser.instance_variable_get(:@options)
+          expect(options.header_file).to eq "./parse.h"
+        end
+      end
+
+      context "deprecated outfile option is passed" do
+        it "@header_file is set based on outfile" do
+          option_parser = Lrama::OptionParser.new
           option_parser.send(:parse, ["-h", "-o", "parse.c", "-", "test.y"])
           options = option_parser.instance_variable_get(:@options)
           expect(options.header_file).to eq "./parse.h"
@@ -148,7 +158,7 @@ RSpec.describe Lrama::OptionParser do
       context "outfile option is not passed" do
         it "@header_file is set based on outfile default value" do
           option_parser = Lrama::OptionParser.new
-          option_parser.send(:parse, ["-h", "-", "test.y"])
+          option_parser.send(:parse, ["-H", "-", "test.y"])
           options = option_parser.instance_variable_get(:@options)
           expect(options.header_file).to eq "./y.tab.h"
         end
@@ -158,7 +168,7 @@ RSpec.describe Lrama::OptionParser do
     context "header file name is passed" do
       it "@header_file is same with passed value" do
         option_parser = Lrama::OptionParser.new
-        option_parser.send(:parse, ["-hparse.h", "-", "test.y"])
+        option_parser.send(:parse, ["-Hparse.h", "-", "test.y"])
         options = option_parser.instance_variable_get(:@options)
         expect(options.header_file).to eq "parse.h"
       end


### PR DESCRIPTION
In bison it is `-H` but in lrama it is `-h`.
How about making it available in `-H` as well?

Also, how about indicating that `-h` is deprecated in the help command as a soft deprecation?