### PR TITLE
Remove unused method

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -482,14 +482,6 @@ module Lrama
       end
     end
 
-    def create_token(type, s_value, line, column)
-      t = Token.new(type: type, s_value: s_value)
-      t.line = line
-      t.column = column
-
-      return t
-    end
-
     private
 
     def find_nterm_by_id!(id)


### PR DESCRIPTION
```
❯ find ./ -type f -print | xargs grep 'create_token'
.//lib/lrama/grammar.rb:    def create_token(type, s_value, line, column)
```