### PR TITLE
Improve an error message for ParseError

### DIFF
--- a/lib/lrama/command.rb
+++ b/lib/lrama/command.rb
@@ -8,7 +8,7 @@ module Lrama
       warning = Lrama::Warning.new
       text = options.y.read
       options.y.close if options.y != STDIN
-      grammar = Lrama::Parser.new(text).parse
+      grammar = Lrama::Parser.new(text, options.grammar_file).parse
       states = Lrama::States.new(grammar, warning, trace_state: (options.trace_opts[:automaton] || options.trace_opts[:closure]))
       states.compute
       context = Lrama::Context.new(states)

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -672,8 +672,9 @@ module_eval(<<'...end parser.y/module_eval...', 'parser.y', 387)
 
 include Lrama::Report::Duration
 
-def initialize(text)
+def initialize(text, path)
   @text = text
+  @path = path
 end
 
 def parse
@@ -696,8 +697,12 @@ def next_token
 end
 
 def on_error(error_token_id, error_value, value_stack)
-  raise ParseError, sprintf("\n%d:%d: parse error on value %s (%s)",
-                            @lexer.line, @lexer.column, error_value.inspect, token_to_str(error_token_id) || '?')
+  source = @text.split("\n")[error_value.line - 1]
+  raise ParseError, <<~ERROR
+    #{@path}:#{@lexer.line}:#{@lexer.column}: parse error on value #{error_value.inspect} (#{token_to_str(error_token_id) || '?'})
+    #{source}
+    #{' ' * @lexer.column}^
+  ERROR
 end
 ...end parser.y/module_eval...
 ##### State transition tables begin ###

--- a/parser.y
+++ b/parser.y
@@ -387,8 +387,9 @@ end
 
 include Lrama::Report::Duration
 
-def initialize(text)
+def initialize(text, path)
   @text = text
+  @path = path
 end
 
 def parse
@@ -411,6 +412,10 @@ def next_token
 end
 
 def on_error(error_token_id, error_value, value_stack)
-  raise ParseError, sprintf("\n%d:%d: parse error on value %s (%s)",
-                            @lexer.line, @lexer.column, error_value.inspect, token_to_str(error_token_id) || '?')
+  source = @text.split("\n")[error_value.line - 1]
+  raise ParseError, <<~ERROR
+    #{@path}:#{@lexer.line}:#{@lexer.column}: parse error on value #{error_value.inspect} (#{token_to_str(error_token_id) || '?'})
+    #{source}
+    #{' ' * @lexer.column}^
+  ERROR
 end

--- a/spec/lrama/context_spec.rb
+++ b/spec/lrama/context_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe Lrama::Context do
 
   describe "basic" do
     it do
-      y = File.read(fixture_path("context/basic.y"))
-      grammar = Lrama::Parser.new(y).parse
+      path = "context/basic.y"
+      y = File.read(fixture_path(path))
+      grammar = Lrama::Parser.new(y, path).parse
       states = Lrama::States.new(grammar, warning)
       states.compute
       context = Lrama::Context.new(states)
@@ -181,7 +182,7 @@ arg: tNUMBER ;
 %%
         INPUT
 
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
         context = Lrama::Context.new(states)
@@ -230,7 +231,7 @@ expr2: tNUMBER ;
 %%
         INPUT
 
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
         context = Lrama::Context.new(states)

--- a/spec/lrama/counterexamples_spec.rb
+++ b/spec/lrama/counterexamples_spec.rb
@@ -50,7 +50,7 @@ num  : digit
       end
 
       it "build counterexamples of S/R conflicts" do
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
         counterexamples = Lrama::Counterexamples.new(states)
@@ -249,7 +249,7 @@ expr2 : digit '+' digit
       end
 
       it "build counterexamples of R/R conflicts" do
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
         counterexamples = Lrama::Counterexamples.new(states)
@@ -326,7 +326,7 @@ expr : digit '+' digit
       end
 
       it "build counterexamples of S/R conflicts" do
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
         counterexamples = Lrama::Counterexamples.new(states)
@@ -407,7 +407,7 @@ opt_nl : /* none */
       end
 
       it "build counterexamples of S/R and R/R conflicts" do
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
         counterexamples = Lrama::Counterexamples.new(states)

--- a/spec/lrama/output_spec.rb
+++ b/spec/lrama/output_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Lrama::Output do
   let(:header_out) { StringIO.new }
   let(:warning) { Lrama::Warning.new(StringIO.new) } # suppress warnings
   let(:text) { File.read(grammar_file_path) }
-  let(:grammar) { Lrama::Parser.new(text).parse }
+  let(:grammar) { Lrama::Parser.new(text, grammar_file_path).parse }
   let(:states) { s = Lrama::States.new(grammar, warning); s.compute; s }
   let(:context) { Lrama::Context.new(states) }
   let(:grammar_file_path) { fixture_path("common/basic.y") }

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -40,8 +40,9 @@ RSpec.describe Lrama::Parser do
 
   describe '#parse' do
     it "basic" do
-      y = File.read(fixture_path("common/basic.y"))
-      grammar = Lrama::Parser.new(y).parse
+      path = "common/basic.y"
+      y = File.read(fixture_path(path))
+      grammar = Lrama::Parser.new(y, path).parse
 
       expect(grammar.union.code.s_value).to eq(<<-CODE.chomp)
 
@@ -407,8 +408,9 @@ RSpec.describe Lrama::Parser do
     end
 
     it "nullable" do
-      y = File.read(fixture_path("common/nullable.y"))
-      grammar = Lrama::Parser.new(y).parse
+      path = "common/nullable.y"
+      y = File.read(fixture_path(path))
+      grammar = Lrama::Parser.new(y, path).parse
 
       expect(grammar.nterms.sort_by(&:number)).to eq([
         Sym.new(id: T.new(type: T::Ident, s_value: "$accept"),       alias_name: nil, number:  6, tag: nil, term: false, token_id: 0, nullable: false),
@@ -562,7 +564,7 @@ class : keyword_class tSTRING keyword_end { code 1 }
 %%
       INPUT
 
-      grammar = Lrama::Parser.new(y).parse
+      grammar = Lrama::Parser.new(y, "parse.y").parse
 
       expect(grammar._rules).to eq([
         [
@@ -605,7 +607,7 @@ class : keyword_class tSTRING keyword_end { code 1 }
 %%
 
       INPUT
-      grammar = Lrama::Parser.new(y).parse
+      grammar = Lrama::Parser.new(y, "parse.y").parse
 
       expect(grammar.terms.sort_by(&:number)).to eq([
         Sym.new(id: T.new(type: T::Ident, s_value: "EOI"),           alias_name: "\"EOI\"",           number:  0, tag: nil,                                   term: true, token_id:   0, nullable: false, precedence: nil),
@@ -661,7 +663,7 @@ class : keyword_class { code 1 } tSTRING { code 2 } keyword_end { code 3 }
 %%
 
       INPUT
-      grammar = Lrama::Parser.new(y).parse
+      grammar = Lrama::Parser.new(y, "parse.y").parse
 
       expect(grammar.nterms.sort_by(&:number)).to eq([
         Sym.new(id: T.new(type: T::Ident, s_value: "$accept"), alias_name: nil, number: 11, tag: nil,                                 term: false, token_id: 0, nullable: false),
@@ -756,7 +758,7 @@ class : keyword_class tSTRING %prec tPLUS keyword_end { code 1 }
 %%
 
         INPUT
-        parser = Lrama::Parser.new(y)
+        parser = Lrama::Parser.new(y, "parse.y")
 
         expect { parser.parse }.to raise_error("Ident after %prec")
       end
@@ -773,7 +775,7 @@ class : keyword_class { code 2 } tSTRING %prec "=" '!' keyword_end { code 3 }
 %%
 
         INPUT
-        parser = Lrama::Parser.new(y)
+        parser = Lrama::Parser.new(y, "parse.y")
 
         expect { parser.parse }.to raise_error("Char after %prec")
       end
@@ -790,7 +792,7 @@ class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { 
 %%
 
         INPUT
-        parser = Lrama::Parser.new(y)
+        parser = Lrama::Parser.new(y, "parse.y")
 
         expect { parser.parse }.to raise_error("Multiple User_code after %prec")
       end
@@ -811,7 +813,7 @@ class : keyword_class
 
 %%
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         codes = grammar.rules.map(&:code).compact
 
         expect(codes.count).to eq(1)
@@ -838,7 +840,7 @@ class : keyword_class
 
 %%
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         codes = grammar.rules.map(&:code).compact
 
         expect(codes.count).to eq(1)
@@ -883,7 +885,7 @@ class : keyword_class tSTRING keyword_end { code 1 }
 %%
 
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
 
         expect(grammar.terms.sort_by(&:number)).to eq([
           Sym.new(id: T.new(type: T::Ident, s_value: "EOI"),           alias_name: "\"EOI\"",           number:  0, tag: nil,                                   term: true, token_id:   0, nullable: false),
@@ -932,7 +934,7 @@ class : keyword_class tSTRING keyword_end { code 1 }
 %%
 
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
 
         expect(grammar.terms.sort_by(&:number)).to eq([
           Sym.new(id: T.new(type: T::Ident, s_value: "EOI"),           alias_name: "\"EOI\"",           number: 0, tag: nil,                                   term: true, token_id:   0, nullable: false, precedence: nil),
@@ -978,7 +980,7 @@ lambda: tLAMBDA
         ;
 %%
           INPUT
-          grammar = Lrama::Parser.new(y).parse
+          grammar = Lrama::Parser.new(y, "parse.y").parse
 
           expect(grammar.rules).to eq([
             Rule.new(
@@ -1086,7 +1088,7 @@ emp: /* none */
    ;
 %%
           INPUT
-          grammar = Lrama::Parser.new(y).parse
+          grammar = Lrama::Parser.new(y, "parse.y").parse
 
           expect(grammar.rules).to eq([
             Rule.new(
@@ -1177,7 +1179,7 @@ expr[result]: NUM
                 { $$ = $1 - $2; }
 ;
             INPUT
-            grammar = Lrama::Parser.new(y).parse
+            grammar = Lrama::Parser.new(y, "parse.y").parse
 
             expect(grammar.rules).to eq([
               Rule.new(
@@ -1311,7 +1313,7 @@ expr[result]: NUM
 ;
             INPUT
 
-            expect { Lrama::Parser.new(y).parse }.to raise_error("'results' is invalid name.")
+            expect { Lrama::Parser.new(y, "parse.y").parse }.to raise_error("'results' is invalid name.")
           end
         end
       end
@@ -1332,7 +1334,11 @@ program: /* empty */
        ;
         INPUT
 
-        expect { Lrama::Parser.new(y).parse }.to raise_error(/5:14: parse error/)
+        expect { Lrama::Parser.new(y, "error_messages/parse.y").parse }.to raise_error(<<~ERROR)
+          error_messages/parse.y:5:14: parse error on value #<struct Lrama::Lexer::Token type=#<struct Lrama::Lexer::Token::Type id=19, name="Ident">, s_value="invalid", alias=nil> (IDENTIFIER)
+          %expect invalid
+                        ^
+        ERROR
       end
     end
   end
@@ -1367,7 +1373,7 @@ class : keyword_class tSTRING keyword_end ;
 
 %%
       INPUT
-      grammar = Lrama::Parser.new(y).parse
+      grammar = Lrama::Parser.new(y, "parse.y").parse
       terms = grammar.terms.sort_by(&:number).map do |term|
         [term.id.s_value, term.token_id]
       end
@@ -1416,7 +1422,7 @@ class : keyword_class tSTRING keyword_end
 
 %%
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "parse.y").parse
         codes = grammar.rules.map(&:code)
 
         expect(codes.count).to eq(3)
@@ -1463,7 +1469,7 @@ expr2 : expr '+' expr { $$ = $1 + $3; }
 %%
         INPUT
 
-        expect { Lrama::Parser.new(y).parse }.to raise_error(RuntimeError) do |e|
+        expect { Lrama::Parser.new(y, "parse.y").parse }.to raise_error(RuntimeError) do |e|
           expect(e.message).to eq(<<~MSG.chomp)
             $$ of 'stmt' has no declared type
             $1 of 'stmt' has no declared type

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe Lrama::States do
 
   describe '#compute' do
     it "basic" do
-      y = File.read(fixture_path("common/basic.y"))
-      grammar = Lrama::Parser.new(y).parse
+      path = "common/basic.y"
+      y = File.read(fixture_path(path))
+      grammar = Lrama::Parser.new(y, path).parse
       states = Lrama::States.new(grammar, warning)
       states.compute
 
@@ -297,8 +298,9 @@ State 27
     end
 
     it '#State#accessing_symbol' do
-      y = File.read(fixture_path("common/basic.y"))
-      grammar = Lrama::Parser.new(y).parse
+      path = "common/basic.y"
+      y = File.read(fixture_path(path))
+      grammar = Lrama::Parser.new(y, path).parse
       states = Lrama::States.new(grammar, warning)
       states.compute
 
@@ -337,8 +339,9 @@ State 27
 
   describe '#reads_relation' do
     it do
-      y = File.read(fixture_path("states/reads_relation.y"))
-      grammar = Lrama::Parser.new(y).parse
+      path = "states/reads_relation.y"
+      y = File.read(fixture_path(path))
+      grammar = Lrama::Parser.new(y, path).parse
       states = Lrama::States.new(grammar, warning)
       states.compute
 
@@ -604,8 +607,9 @@ State 8
 
   describe '#includes_relation' do
     it do
-      y = File.read(fixture_path("states/includes_relation.y"))
-      grammar = Lrama::Parser.new(y).parse
+      path = "states/includes_relation.y"
+      y = File.read(fixture_path(path))
+      grammar = Lrama::Parser.new(y, path).parse
       states = Lrama::States.new(grammar, warning)
       states.compute
 
@@ -904,7 +908,7 @@ expr: tNUMBER
 
 %%
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "states/compute_look_ahead_sets.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
 
@@ -973,7 +977,7 @@ expr: tNUMBER
 
 %%
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "states/compute_look_ahead_sets.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
 
@@ -1063,7 +1067,7 @@ expr: tUPLUS expr
 
 %%
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "states/compute_conflicts.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
 
@@ -1180,7 +1184,7 @@ expr: expr tEQ expr
 
 %%
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "states/compute_conflicts.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
 
@@ -1277,7 +1281,7 @@ expr: expr '+' expr
 
 %%
         INPUT
-        grammar = Lrama::Parser.new(y).parse
+        grammar = Lrama::Parser.new(y, "states/compute_conflicts.y").parse
         states = Lrama::States.new(grammar, warning)
         states.compute
 
@@ -1426,7 +1430,7 @@ ident: tID ;
 
 %%
       INPUT
-      grammar = Lrama::Parser.new(y).parse
+      grammar = Lrama::Parser.new(y, "states/compute_default_reduction.y").parse
       states = Lrama::States.new(grammar, warning)
       states.compute
 
@@ -1598,7 +1602,7 @@ ident: tID ;
 
 %%
       INPUT
-      grammar = Lrama::Parser.new(y).parse
+      grammar = Lrama::Parser.new(y, "states/compute_default_reduction.y").parse
       states = Lrama::States.new(grammar, warning)
       states.compute
 
@@ -1816,7 +1820,7 @@ string: tSTRING
           end
 
           it "has errors for r/r conflicts" do
-            grammar = Lrama::Parser.new(header + y).parse
+            grammar = Lrama::Parser.new(header + y, "states/check_conflicts.y").parse
             states = Lrama::States.new(grammar, warning)
             states.compute
 
@@ -1840,7 +1844,7 @@ string: tSTRING
           end
 
           it "has errors for s/r conflicts and r/r conflicts" do
-            grammar = Lrama::Parser.new(header + y).parse
+            grammar = Lrama::Parser.new(header + y, "states/check_conflicts.y").parse
             states = Lrama::States.new(grammar, warning)
             states.compute
 
@@ -1864,7 +1868,7 @@ string: tSTRING
         end
 
         it "has warns for s/r conflicts and r/r conflicts" do
-          grammar = Lrama::Parser.new(header + y).parse
+          grammar = Lrama::Parser.new(header + y, "states/check_conflicts.y").parse
           states = Lrama::States.new(grammar, warning)
           states.compute
 


### PR DESCRIPTION
This PR is improve an error message for ParseError.
The file name and the source of the error location are now displayed.

When you have a file named `parse.y` like this:
```
%{
// Prologue
%}

%expect invalid

%%

program: /* empty */
       ;
        INPUT
```

When lrama is executed, it displays an error as follows:
```
❯ lrama parse.y 
parser.y:416:in `on_error': parse.y:5:14: parse error on value #<struct Lrama::Lexer::Token type=#<struct Lrama::Lexer::Token::Type id=19, name="Ident">, s_value="invalid", alias=nil> (IDENTIFIER) (Racc::ParseError)
%expect invalid
              ^
        from racc/parser.rb:286:in `_racc_do_parse_c'
        from racc/parser.rb:286:in `do_parse'
        from parser.y:400:in `block in parse'
        from /Users/yudai.takada/ydah/lrama/lib/lrama/report/duration.rb:14:in `report_duration'
        from parser.y:396:in `parse'
        from /Users/yudai.takada/ydah/lrama/lib/lrama/command.rb:11:in `run'
        from exe/lrama:6:in `<main>'
```