### PR TITLE
Use `sh` method defined by Rake to execute racc commmand

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,11 +3,11 @@ require "bundler/gem_tasks"
 namespace "build" do
   desc "build parser from parser.y by using Racc"
   task :racc_parser do
-    `bundle exec racc parser.y --embedded -o lib/lrama/parser.rb`
+    sh "bundle exec racc parser.y --embedded -o lib/lrama/parser.rb"
   end
 
   desc "build parser for debugging"
   task :racc_verbose_parser do
-    `bundle exec racc parser.y --embedded -o lib/lrama/parser.rb -t --log-file=parser.output`
+    sh "bundle exec racc parser.y --embedded -o lib/lrama/parser.rb -t --log-file=parser.output"
   end
 end


### PR DESCRIPTION
So that CI check-misc job fails when racc command fails because of "terminal XXX not declared as terminal" error for example.