### PR TITLE
Fix unknown type error when using YYSTYPE or YYLTYPE

### DIFF
--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -67,8 +67,8 @@
 /* Pull parsers.  */
 #define YYPULL 1
 
-
-
+typedef struct YYLTYPE YYLTYPE;
+typedef union YYSTYPE YYSTYPE;
 
 <%# b4_user_pre_prologue -%>
 /* First part of user prologue.  */


### PR DESCRIPTION
```
❯ exe/lrama -d sample/parse.y -o calc.c && gcc -Wall calc.c -o calc
sample/parse.y:8:31: error: unknown type name 'YYSTYPE'
static enum yytokentype yylex(YYSTYPE *lval, YYLTYPE *yylloc);
                              ^
sample/parse.y:8:46: error: unknown type name 'YYLTYPE'
static enum yytokentype yylex(YYSTYPE *lval, YYLTYPE *yylloc);
                                             ^
sample/parse.y:9:21: error: unknown type name 'YYLTYPE'
static void yyerror(YYLTYPE *yylloc, const char *msg);
                    ^
calc.c:1201:9: warning: variable 'yynerrs' set but not used [-Wunused-but-set-variable]
    int yynerrs = 0;
        ^
1 warning and 3 errors generated.
```