### PR TITLE
Do not need to call `#build_references` in `#build_code`

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -131,7 +131,6 @@ module Lrama
     end
 
     def build_code(type, token_code)
-      build_references(token_code)
       Code.new(type: type, token_code: token_code)
     end
 


### PR DESCRIPTION
`#build_references` is called inside of `#extract_references`.