### PR TITLE
Add the starting position to the location information

### DIFF
--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -688,11 +688,10 @@ def next_token
 end
 
 def on_error(error_token_id, error_value, value_stack)
-  source = @text.split("\n")[error_value.line - 1]
   raise ParseError, <<~ERROR
-    #{@path}:#{@lexer.line}:#{@lexer.column}: parse error on value #{error_value.inspect} (#{token_to_str(error_token_id) || '?'})
-    #{source}
-    #{' ' * @lexer.column}^
+    #{@path}:#{@lexer.line}:#{error_value.column}: parse error on value #{error_value.inspect} (#{token_to_str(error_token_id) || '?'})
+    #{@text.split("\n")[error_value.line - 1]}
+    #{carrets(error_value)}
   ERROR
 end
 
@@ -711,6 +710,10 @@ end
 def end_c_declaration
   @lexer.status = :initial
   @lexer.end_symbol = nil
+end
+
+def carrets(error_value)
+  ' ' * (error_value.column + 1) + '^' * (@lexer.column - error_value.column)
 end
 ...end parser.y/module_eval...
 ##### State transition tables begin ###

--- a/parser.y
+++ b/parser.y
@@ -397,11 +397,10 @@ def next_token
 end
 
 def on_error(error_token_id, error_value, value_stack)
-  source = @text.split("\n")[error_value.line - 1]
   raise ParseError, <<~ERROR
-    #{@path}:#{@lexer.line}:#{@lexer.column}: parse error on value #{error_value.inspect} (#{token_to_str(error_token_id) || '?'})
-    #{source}
-    #{' ' * @lexer.column}^
+    #{@path}:#{@lexer.line}:#{error_value.column}: parse error on value #{error_value.inspect} (#{token_to_str(error_token_id) || '?'})
+    #{@text.split("\n")[error_value.line - 1]}
+    #{carrets(error_value)}
   ERROR
 end
 
@@ -420,4 +419,8 @@ end
 def end_c_declaration
   @lexer.status = :initial
   @lexer.end_symbol = nil
+end
+
+def carrets(error_value)
+  ' ' * (error_value.column + 1) + '^' * (@lexer.column - error_value.column)
 end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1511,9 +1511,9 @@ program: /* empty */
        ;
         INPUT
         expect { Lrama::Parser.new(y, "error_messages/parse.y").parse }.to raise_error(<<~ERROR)
-          error_messages/parse.y:5:14: parse error on value #<struct Lrama::Lexer::Token::Ident s_value="invalid", alias_name=nil> (IDENTIFIER)
+          error_messages/parse.y:5:7: parse error on value #<struct Lrama::Lexer::Token::Ident s_value="invalid", alias_name=nil> (IDENTIFIER)
           %expect invalid
-                        ^
+                  ^^^^^^^
         ERROR
       end
     end


### PR DESCRIPTION
```
❯ exe/lrama -d test.y                         
parser.y:400:in `on_error': a.y:5:7: parse error on value #<struct Lrama::Lexer::Token::Ident s_value="invalid", alias_name=nil> (IDENTIFIER) (Racc::ParseError)
%expect invalid
        ^^^^^^^
        from racc/parser.rb:276:in `_racc_do_parse_c'
        from racc/parser.rb:276:in `do_parse'
        from parser.y:386:in `block in parse'
        from /ydah/lrama/lib/lrama/report/duration.rb:14:in `report_duration'
        from parser.y:381:in `parse'
        from /ydah/lrama/lib/lrama/command.rb:11:in `run'
        from exe/lrama:6:in `<main>'
```