### PR TITLE
Fix warning for assigned but unused variable

### DIFF
--- a/lib/lrama/context.rb
+++ b/lib/lrama/context.rb
@@ -367,7 +367,7 @@ module Lrama
         end
 
         j = @sorted_actions.count - 1
-        state_id, froms_and_tos, count, width = action
+        _state_id, _froms_and_tos, count, width = action
 
         while (j >= 0) do
           case


### PR DESCRIPTION
```
❯ ruby -w exe/lrama -d sample/parse.y
/ydah/lrama/lib/lrama/context.rb:370: warning: assigned but unused variable - state_id
/ydah/lrama/lib/lrama/context.rb:370: warning: assigned but unused variable - froms_and_tos
```