### PR TITLE
Use location for `#to_s`

### DIFF
--- a/lib/lrama/lexer/token.rb
+++ b/lib/lrama/lexer/token.rb
@@ -5,7 +5,7 @@ module Lrama
       attr_accessor :referred
 
       def to_s
-        "#{super} line: #{line}, column: #{column}"
+        "#{super} location: #{location}"
       end
 
       def referred_by?(string)


### PR DESCRIPTION
Some tokens doesn't have `location`. `#to_s` raises NoMethodError for such cases if the method uses `line` and `column`.