### PR TITLE
Add `spec` and `steep check` to Rake's default tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,3 +11,5 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
+
+task default: %i[spec]

--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,9 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
-task default: %i[spec]
+desc "steep check"
+task :steep do
+  sh "bundle exec steep check"
+end
+
+task default: %i[spec steep]

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,8 @@ namespace "build" do
     sh "bundle exec racc parser.y --embedded -o lib/lrama/parser.rb -t --log-file=parser.output"
   end
 end
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*_spec.rb']
+end


### PR DESCRIPTION
This PR is add `spec` and `steep check` to Rake's default tasks.
How about just running the following command to check them all together?

```sh
❯ bundle exec rake   
```