### PR TITLE
Lazy reference resolution

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -8,8 +8,7 @@ target :lib do
   check "lib/lrama/digraph.rb"
   check "lib/lrama/grammar/counter.rb"
   check "lib/lrama/grammar/percent_code.rb"
-  # TODO: Include this file once Lrama::Grammar::Symbol type is defined
-  # check "lib/lrama/grammar/reference.rb"
+  check "lib/lrama/grammar/reference.rb"
   check "lib/lrama/grammar/rule_builder.rb"
   check "lib/lrama/lexer/token/char.rb"
   check "lib/lrama/lexer/token/ident.rb"

--- a/lib/lrama/grammar/code/rule_action.rb
+++ b/lib/lrama/grammar/code/rule_action.rb
@@ -2,29 +2,59 @@ module Lrama
   class Grammar
     class Code
       class RuleAction < Code
+        def initialize(type: nil, token_code: nil, rule: nil)
+          super(type: type, token_code: token_code)
+          @rule = rule
+        end
+
         private
 
         # * ($$) yyval
         # * (@$) yyloc
         # * ($1) yyvsp[i]
         # * (@1) yylsp[i]
+        #
+        # "Rule"                class: keyword_class { $1 } tSTRING { $2 + $3 } keyword_end { $class = $1 + $keyword_end }
+        # "Position in grammar"                   $1    $2      $3          $4          $5                             $6
+        # "Index for yyvsp"                       -4    -3      -2          -1           0
         def reference_to_c(ref)
           case
           when ref.type == :dollar && ref.name == "$" # $$
-            member = ref.tag.member
-            "(yyval.#{member})"
+            tag = ref.ex_tag || lhs.tag
+            raise_tag_not_found_error(ref) unless tag
+            "(yyval.#{tag.member})"
           when ref.type == :at && ref.name == "$" # @$
             "(yyloc)"
           when ref.type == :dollar # $n
-            i = -ref.position_in_rhs + ref.index
-            member = ref.tag.member
-            "(yyvsp[#{i}].#{member})"
+            i = -position_in_rhs + ref.index
+            tag = ref.ex_tag || rhs[ref.index - 1].tag
+            raise_tag_not_found_error(ref) unless tag
+            "(yyvsp[#{i}].#{tag.member})"
           when ref.type == :at # @n
-            i = -ref.position_in_rhs + ref.index
+            i = -position_in_rhs + ref.index
             "(yylsp[#{i}])"
           else
             raise "Unexpected. #{self}, #{ref}"
           end
+        end
+
+        def position_in_rhs
+          # If rule is not derived rule, User Code is only action at
+          # the end of rule RHS. In such case, the action is located on
+          # `@rule.rhs.count`.
+          @rule.position_in_original_rule_rhs || @rule.rhs.count
+        end
+
+        def rhs
+          (@rule.original_rule || @rule).rhs
+        end
+
+        def lhs
+          (@rule.original_rule || @rule).lhs
+        end
+
+        def raise_tag_not_found_error(ref)
+          raise "Tag is not specified for '$#{ref.value}' in '#{@rule.to_s}'"
         end
       end
     end

--- a/lib/lrama/grammar/reference.rb
+++ b/lib/lrama/grammar/reference.rb
@@ -4,23 +4,9 @@ module Lrama
     # name: String (e.g. $$, $foo, $expr.right)
     # index: Integer (e.g. $1)
     # ex_tag: "$<tag>1" (Optional)
-    class Reference < Struct.new(:type, :name, :index, :ex_tag, :first_column, :last_column, :referring_symbol, :position_in_rhs, keyword_init: true)
+    class Reference < Struct.new(:type, :name, :index, :ex_tag, :first_column, :last_column, keyword_init: true)
       def value
         name || index
-      end
-
-      def tag
-        if ex_tag
-          ex_tag
-        else
-          # FIXME: Remove this class check
-          if referring_symbol.is_a?(Symbol)
-            referring_symbol.tag
-          else
-            # Lrama::Lexer::Token (User_code) case
-            nil
-          end
-        end
       end
     end
   end

--- a/lib/lrama/grammar/rule.rb
+++ b/lib/lrama/grammar/rule.rb
@@ -1,6 +1,6 @@
 module Lrama
   class Grammar
-    class Rule < Struct.new(:id, :lhs, :rhs, :token_code, :nullable, :precedence_sym, :lineno, keyword_init: true)
+    class Rule < Struct.new(:id, :lhs, :rhs, :token_code, :position_in_original_rule_rhs, :nullable, :precedence_sym, :lineno, keyword_init: true)
       attr_accessor :original_rule
 
       # TODO: Change this to display_name
@@ -36,7 +36,7 @@ module Lrama
       def translated_code
         return nil unless token_code
 
-        Code::RuleAction.new(type: :rule_action, token_code: token_code).translated_code
+        Code::RuleAction.new(type: :rule_action, token_code: token_code, rule: self).translated_code
       end
     end
   end

--- a/lib/lrama/grammar/rule.rb
+++ b/lib/lrama/grammar/rule.rb
@@ -1,6 +1,8 @@
 module Lrama
   class Grammar
     class Rule < Struct.new(:id, :lhs, :rhs, :token_code, :nullable, :precedence_sym, :lineno, keyword_init: true)
+      attr_accessor :original_rule
+
       # TODO: Change this to display_name
       def to_s
         l = lhs.id.s_value

--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -67,9 +67,7 @@ module Lrama
       end
 
       def midrule_action_rules
-        @midrule_action_rules ||= @rule_builders_for_midrule_action.map do |rule_builder|
-          rule_builder.rules
-        end.flatten
+        @midrule_action_rules
       end
 
       def rules
@@ -93,10 +91,14 @@ module Lrama
         # Expand Parameterizing rules
         if tokens.any? {|r| r.is_a?(Lrama::Lexer::Token::Parameterizing) }
           @rules = @parameterizing_rules
+          @midrule_action_rules = []
         else
           rule = Rule.new(id: @rule_counter.increment, lhs: lhs, rhs: tokens, token_code: user_code, precedence_sym: precedence_sym, lineno: line)
           @rules = [rule]
-          midrule_action_rules.each do |r|
+          @midrule_action_rules = @rule_builders_for_midrule_action.map do |rule_builder|
+            rule_builder.rules
+          end.flatten
+          @midrule_action_rules.each do |r|
             r.original_rule = rule
           end
         end

--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -94,7 +94,11 @@ module Lrama
         if tokens.any? {|r| r.is_a?(Lrama::Lexer::Token::Parameterizing) }
           @rules = @parameterizing_rules
         else
-          @rules = [Rule.new(id: @rule_counter.increment, lhs: lhs, rhs: tokens, token_code: user_code, precedence_sym: precedence_sym, lineno: line)]
+          rule = Rule.new(id: @rule_counter.increment, lhs: lhs, rhs: tokens, token_code: user_code, precedence_sym: precedence_sym, lineno: line)
+          @rules = [rule]
+          midrule_action_rules.each do |r|
+            r.original_rule = rule
+          end
         end
       end
 

--- a/sig/lrama/grammar/reference.rbs
+++ b/sig/lrama/grammar/reference.rbs
@@ -1,20 +1,18 @@
 module Lrama
   class Grammar
     class Reference
-      # TODO: Replace untyped referring_symbol with (Grammar::Symbol|Lexer::Token)
       attr_accessor type: Symbol
       attr_accessor name: String
       attr_accessor index: Integer
       attr_accessor ex_tag: Lexer::Token?
       attr_accessor first_column: Integer
       attr_accessor last_column: Integer
-      attr_accessor referring_symbol: untyped
       attr_accessor position_in_rhs: Integer?
 
       def initialize: (
         type: Symbol, ?name: String, ?index: Integer, ?ex_tag: Lexer::Token?,
         first_column: Integer, last_column: Integer,
-        ?referring_symbol: untyped, ?position_in_rhs: Integer?
+        ?position_in_rhs: Integer?
       ) -> void
 
       def value: () -> (String|Integer)

--- a/sig/lrama/grammar/rule.rbs
+++ b/sig/lrama/grammar/rule.rbs
@@ -1,6 +1,8 @@
 module Lrama
   class Grammar
     class Rule
+      attr_accessor original_rule: Rule
+
       def initialize: (
         ?id: untyped, ?lhs: untyped, ?rhs: untyped,
         ?token_code: untyped, ?nullable: untyped,

--- a/sig/lrama/grammar/rule.rbs
+++ b/sig/lrama/grammar/rule.rbs
@@ -5,7 +5,7 @@ module Lrama
 
       def initialize: (
         ?id: untyped, ?lhs: untyped, ?rhs: untyped,
-        ?token_code: untyped, ?nullable: untyped,
+        ?token_code: untyped, ?position_in_original_rule_rhs: untyped, ?nullable: untyped,
         ?precedence_sym: untyped, ?lineno: untyped
       ) -> void
     end

--- a/sig/lrama/grammar/rule_builder.rbs
+++ b/sig/lrama/grammar/rule_builder.rbs
@@ -9,17 +9,19 @@ module Lrama
 
       @user_code: Lexer::Token::UserCode?
 
-      def initialize: (Counter rule_counter, Counter midrule_action_counter) -> void
+      def initialize: (Counter rule_counter, Counter midrule_action_counter, ?skip_preprocess_references: bool) -> void
       def add_rhs: (Lexer::Token rhs) -> void
       def user_code=: (Lexer::Token::UserCode user_code) -> void
       def precedence_sym=: (Lexer::Token user_code) -> void
-      def freeze_rhs: () -> void
+      def complete_input: () -> void
+      def setup_rules: () -> void
       def preprocess_references: () -> void
       def midrule_action_rules: () -> Array[Rule]
       def rhs_with_new_tokens: () -> Array[Lexer::Token]
 
       private
 
+      def freeze_rhs: () -> void
       def process_rhs: () -> void
       def numberize_references: () -> void
       def setup_references: () -> void

--- a/sig/lrama/grammar/rule_builder.rbs
+++ b/sig/lrama/grammar/rule_builder.rbs
@@ -9,7 +9,7 @@ module Lrama
 
       @user_code: Lexer::Token::UserCode?
 
-      def initialize: (Counter rule_counter, Counter midrule_action_counter, ?skip_preprocess_references: bool) -> void
+      def initialize: (Counter rule_counter, Counter midrule_action_counter, ?Integer position_in_original_rule_rhs, ?skip_preprocess_references: bool) -> void
       def add_rhs: (Lexer::Token rhs) -> void
       def user_code=: (Lexer::Token::UserCode user_code) -> void
       def precedence_sym=: (Lexer::Token user_code) -> void

--- a/spec/lrama/grammar/code_spec.rb
+++ b/spec/lrama/grammar/code_spec.rb
@@ -80,4 +80,118 @@ RSpec.describe Lrama::Grammar::Code do
       end
     end
   end
+
+  describe Lrama::Grammar::Code::RuleAction do
+    let(:y) do
+      <<~Grammar
+%union {
+    int i;
+    int str;
+    int l;
+    int expr;
+    int integer;
+    int rule1;
+    int rule2;
+    int rule3;
+    int rule4;
+    int rule5;
+    int rule6;
+}
+
+%token <i> keyword_class
+%token <str> tSTRING
+%token <l> keyword_end
+%token <expr> expr
+
+%type <rule1> rule1
+%type <rule2> rule2
+%type <rule3> rule3
+%type <rule4> rule4
+%type <rule5> rule5
+%type <rule6> rule6
+
+%%
+
+program: rule1
+       | rule2
+       | rule3
+       | rule4
+       | rule5
+       | rule6
+       | rule7
+       ;
+
+rule1: expr '+' expr { $$ = 0; }
+     ;
+
+rule2: expr '+' expr { @$ = 0; }
+     ;
+
+rule3: expr '+' expr[expr-right] { $1 + $[expr-right]; }
+     ;
+
+rule4: expr '+' expr[expr-right] { @1 + @[expr-right]; }
+     ;
+
+rule5: expr '+' expr { $1 + $<integer>3; }
+     ;
+
+rule6: expr '+' { $<integer>$ = $1; @$ = @1; } expr { $1 + $<integer>4; }
+     ;
+
+rule7: expr { $$ = $1 } '+' expr { $3; }
+     ;
+
+%%
+      Grammar
+    end
+    let(:grammar) { Lrama::Parser.new(y, "parse.y").parse }
+
+    describe "#translated_code" do
+      it "translats '$$' to '(yyval)' with member" do
+        code = grammar.rules.find {|r| r.lhs.id.s_value == "rule1" }
+        expect(code.translated_code).to eq(" (yyval.rule1) = 0; ")
+      end
+
+      it "translats '@$' to '(yyloc)'" do
+        code = grammar.rules.find {|r| r.lhs.id.s_value == "rule2" }
+        expect(code.translated_code).to eq(" (yyloc) = 0; ")
+      end
+
+      it "translats '$n' to '(yyvsp)' with index and member" do
+        code = grammar.rules.find {|r| r.lhs.id.s_value == "rule3" }
+        expect(code.translated_code).to eq(" (yyvsp[-2].expr) + (yyvsp[0].expr); ")
+      end
+
+      it "translats '@n' to '(yylsp)' with index" do
+        code = grammar.rules.find {|r| r.lhs.id.s_value == "rule4" }
+        expect(code.translated_code).to eq(" (yylsp[-2]) + (yylsp[0]); ")
+      end
+
+      it "respects explicit tag in a rule" do
+        code = grammar.rules.find {|r| r.lhs.id.s_value == "rule5" }
+        expect(code.translated_code).to eq(" (yyvsp[-2].expr) + (yyvsp[0].integer); ")
+      end
+
+      context "midrule action exists" do
+        it "uses index on the original rule (-1)" do
+          code = grammar.rules.find {|r| r.lhs.id.s_value == "$@1" }
+          expect(code.translated_code).to eq(" (yyval.integer) = (yyvsp[-1].expr); (yyloc) = (yylsp[-1]); ")
+
+          code = grammar.rules.find {|r| r.lhs.id.s_value == "rule6" }
+          expect(code.translated_code).to eq(" (yyvsp[-3].expr) + (yyvsp[0].integer); ")
+        end
+      end
+
+      context "can not resolve tag of references" do
+        it "raises error" do
+          code = grammar.rules.find {|r| r.lhs.id.s_value == "$@2" }
+          expect { code.translated_code }.to raise_error("Tag is not specified for '$$' in '$@2 -> ε'")
+
+          code = grammar.rules.find {|r| r.lhs.id.s_value == "rule7" }
+          expect { code.translated_code }.to raise_error("Tag is not specified for '$3' in 'rule7 -> expr, $@2, '+', expr'")
+        end
+      end
+    end
+  end
 end

--- a/spec/lrama/grammar/rule_builder_spec.rb
+++ b/spec/lrama/grammar/rule_builder_spec.rb
@@ -323,13 +323,16 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
       rule_builder.complete_input
       rule_builder.setup_rules
 
+      rule = rule_builder.rules.first
       rules = rule_builder.midrule_action_rules
 
       expect(rules.count).to eq 2
       expect(rules[0].lhs.s_value).to eq '@1'
       expect(rules[0].token_code.s_value).to eq '$1'
+      expect(rules[0].original_rule).to eq rule
       expect(rules[1].lhs.s_value).to eq '$@2'
       expect(rules[1].token_code.s_value).to eq '$2 + $3'
+      expect(rules[1].original_rule).to eq rule
     end
   end
 

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -275,6 +275,7 @@ RSpec.describe Lrama::Parser do
           lhs: grammar.find_symbol_by_s_value!("$@1"),
           rhs: [],
           token_code: T::UserCode.new(s_value: " code 2 "),
+          position_in_original_rule_rhs: 1,
           nullable: true,
           precedence_sym: nil,
           lineno: 64,
@@ -284,6 +285,7 @@ RSpec.describe Lrama::Parser do
           lhs: grammar.find_symbol_by_s_value!("$@2"),
           rhs: [],
           token_code: T::UserCode.new(s_value: " code 3 "),
+          position_in_original_rule_rhs: 5,
           nullable: true,
           precedence_sym: nil,
           lineno: 64,
@@ -309,6 +311,7 @@ RSpec.describe Lrama::Parser do
           lhs: grammar.find_symbol_by_s_value!("$@3"),
           rhs: [],
           token_code: T::UserCode.new(s_value: " code 4 "),
+          position_in_original_rule_rhs: 1,
           nullable: true,
           precedence_sym: nil,
           lineno: 65,
@@ -318,6 +321,7 @@ RSpec.describe Lrama::Parser do
           lhs: grammar.find_symbol_by_s_value!("$@4"),
           rhs: [],
           token_code: T::UserCode.new(s_value: " code 5 "),
+          position_in_original_rule_rhs: 5,
           nullable: true,
           precedence_sym: nil,
           lineno: 65,
@@ -1200,6 +1204,7 @@ class : keyword_class { code 1 } tSTRING { code 2 } keyword_end { code 3 }
           lhs: grammar.find_symbol_by_s_value!("$@1"),
           rhs: [],
           token_code: T::UserCode.new(s_value: " code 1 "),
+          position_in_original_rule_rhs: 1,
           nullable: true,
           precedence_sym: nil,
           lineno: 31,
@@ -1209,6 +1214,7 @@ class : keyword_class { code 1 } tSTRING { code 2 } keyword_end { code 3 }
           lhs: grammar.find_symbol_by_s_value!("$@2"),
           rhs: [],
           token_code: T::UserCode.new(s_value: " code 2 "),
+          position_in_original_rule_rhs: 3,
           nullable: true,
           precedence_sym: nil,
           lineno: 31,
@@ -1522,6 +1528,7 @@ lambda: tLAMBDA
               lhs: grammar.find_symbol_by_s_value!("@1"),
               rhs: [],
               token_code: T::UserCode.new(s_value: " $<i>1 = 1; $<i>$ = 2; "),
+              position_in_original_rule_rhs: 1,
               nullable: true,
               precedence_sym: nil,
               lineno: 17,
@@ -1531,6 +1538,7 @@ lambda: tLAMBDA
               lhs: grammar.find_symbol_by_s_value!("@2"),
               rhs: [],
               token_code: T::UserCode.new(s_value: " $<i>$ = 3; "),
+              position_in_original_rule_rhs: 2,
               nullable: true,
               precedence_sym: nil,
               lineno: 18,
@@ -1540,6 +1548,7 @@ lambda: tLAMBDA
               lhs: grammar.find_symbol_by_s_value!("$@3"),
               rhs: [],
               token_code: T::UserCode.new(s_value: " $<i>$ = 4; "),
+              position_in_original_rule_rhs: 3,
               nullable: true,
               precedence_sym: nil,
               lineno: 19,
@@ -1549,6 +1558,7 @@ lambda: tLAMBDA
               lhs: grammar.find_symbol_by_s_value!("$@4"),
               rhs: [],
               token_code: T::UserCode.new(s_value: " 5; "),
+              position_in_original_rule_rhs: 5,
               nullable: true,
               precedence_sym: nil,
               lineno: 21,
@@ -1963,57 +1973,7 @@ class : keyword_class tSTRING keyword_end
         expect(codes[0]).to be nil
         expect(codes[1]).to be nil
         expect(codes[2].references.count).to eq(1)
-        expect(codes[2].references[0].tag.s_value).to eq("<l>")
-      end
-    end
-  end
-
-  describe "Grammar#validate!" do
-    describe "#validate_no_declared_type_reference!" do
-      it "raises error when referred nterm, term and action have no tag so that type is not declared" do
-        y = <<~INPUT
-%{
-// Prologue
-%}
-
-%union {
-    int val;
-}
-
-%token NUM
-
-%%
-
-program : stmt
-        ;
-
-stmt : {} {} expr { $$ = $1 + $<val>2; }
-     ;
-
-expr : expr1
-     | expr2
-     ;
-
-expr1 : NUM { $$ = $1; }
-      ;
-
-expr2 : expr '+' expr { $$ = $1 + $3; }
-      ;
-
-%%
-        INPUT
-
-        expect { Lrama::Parser.new(y, "parse.y").parse }.to raise_error(RuntimeError) do |e|
-          expect(e.message).to eq(<<~MSG.chomp)
-            $$ of 'stmt' has no declared type
-            $1 of 'stmt' has no declared type
-            $$ of 'expr1' has no declared type
-            $1 of 'expr1' has no declared type
-            $$ of 'expr2' has no declared type
-            $1 of 'expr2' has no declared type
-            $3 of 'expr2' has no declared type
-          MSG
-        end
+        expect(codes[2].references[0].ex_tag.s_value).to eq("<l>")
       end
     end
   end


### PR DESCRIPTION
Rule build process is a bit complicated. `new_token` (`"@1"`) is created
when derived rule is created. Original rule requires `new_token`, but
derived rule needs to refer to original rule.
We can avoid such complex order of rule generation by lazy reference resolution.

This PR also fixes a bug of derived rule for mid rule action referring to wrong LHS, mentioned by https://github.com/ruby/lrama/pull/195#issuecomment-1806217091