### PR TITLE
Silence compiler warnings

### DIFF
--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -116,7 +116,7 @@ int main() {
 
   %%
 
-  program : { (void)yynerrs; }
+  program : /* empty */
        | expr { printf("=> %d", $1); }
        ;
   expr : NUM
@@ -149,7 +149,7 @@ int main() {
 
   %%
 
-  program : { }
+  program : /* empty */
           ;
 
     Grammar
@@ -195,7 +195,7 @@ int main() {
 
   %%
 
-  program : { (void)yynerrs; }
+  program : /* empty */
        | expr { printf("=> %d", $1); }
        ;
   expr : NUM
@@ -290,8 +290,6 @@ int main() {
 
   line: expr
           {
-            (void)yynerrs;
-
             printf("line (%d): ", @expr.first_line);
             print_location(&@expr);
 
@@ -411,7 +409,7 @@ int main() {
 
   %%
 
-  program : { (void)yynerrs; }
+  program : /* empty */
        | expr { printf("=> %d", $1); }
        ;
 
@@ -457,7 +455,7 @@ int main() {
 
   %%
 
-  program : { (void)yynerrs; }
+  program : /* empty */
        | expr { printf("=> %d", $1); }
        ;
   expr : NUM

--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -1485,7 +1485,7 @@ YYLTYPE yylloc = yyloc_default;
 <%# b4_declare_parser_state_variables -%>
     /* Number of syntax errors so far.  */
     int yynerrs = 0;
-    (void) yynerrs; /* Silence compiler warning.  */
+    YY_USE (yynerrs); /* Silence compiler warning.  */
 
     yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */

--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -1485,6 +1485,7 @@ YYLTYPE yylloc = yyloc_default;
 <%# b4_declare_parser_state_variables -%>
     /* Number of syntax errors so far.  */
     int yynerrs = 0;
+    (void) yynerrs; /* Silence compiler warning.  */
 
     yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */


### PR DESCRIPTION
Before
```
❯ bundle exec rspec                    
....................................................../var/folders/91/c1qqv7c94yz_cp1dz10bmwq00000gp/T/test.c:1179:9: warning: variable 'yynerrs' set but not used [-Wunused-but-set-variable]
    int yynerrs = 0;
        ^
1 warning generated.
....../var/folders/91/c1qqv7c94yz_cp1dz10bmwq00000gp/T/test.c:1208:9: warning: variable 'yynerrs' set but not used [-Wunused-but-set-variable]
    int yynerrs = 0;
        ^
1 warning generated.
./var/folders/91/c1qqv7c94yz_cp1dz10bmwq00000gp/T/test.c:1196:9: warning: variable 'yynerrs' set but not used [-Wunused-but-set-variable]
    int yynerrs = 0;
        ^
1 warning generated.
..........................................................................

Finished in 6.89 seconds (files took 0.51071 seconds to load)
135 examples, 0 failures
```

After
```
❯ bundle exec rspec
.......................................................................................................................................

Finished in 5.9 seconds (files took 0.39775 seconds to load)
135 examples, 0 failures

Coverage report generated for RSpec to /Users/yudai.takada/ydah/lrama/coverage. 2482 / 2608 LOC (95.17%) covered.
```