### PR TITLE
Improved lexer speed

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -144,7 +144,11 @@ module Lrama
           matched = @scanner.scan_until(/'/)
           code += %Q('#{matched})
         else
-          code += @scanner.getch
+          if @scanner.scan(/[^\"'\{\}\n#{@end_symbol}]+/)
+            code += @scanner.matched
+          else
+            code += @scanner.getch
+          end
         end
       end
       raise ParseError, "Unexpected code: #{code}."


### PR DESCRIPTION
## Execution time

### Before

```
❯ exe/lrama --trace=time -o parse.tmp.c --header=parse.tmp.h parse.tmp.y
parse    4.38929 s
compute_lr0_states    0.88006 s
compute_direct_read_sets    0.06813 s
compute_reads_relation    0.01174 s
compute_read_sets    0.04809 s
compute_includes_relation    0.72033 s
compute_lookback_relation    1.40715 s
compute_follow_sets    0.12471 s
compute_look_ahead_sets    1.00162 s
compute_conflicts    0.06503 s
compute_default_reduction    0.00617 s
compute_yydefact    0.08520 s
compute_yydefgoto    0.07973 s
sort_actions    0.00674 s
compute_packed_table    0.41180 s
render    0.09383 s
```

### After

```
❯ exe/lrama --trace=time -o parse.tmp.c --header=parse.tmp.h parse.tmp.y
parse    0.93149 s
compute_lr0_states    0.90139 s
compute_direct_read_sets    0.07115 s
compute_reads_relation    0.01218 s
compute_read_sets    0.04671 s
compute_includes_relation    0.69610 s
compute_lookback_relation    1.35323 s
compute_follow_sets    0.11844 s
compute_look_ahead_sets    1.01038 s
compute_conflicts    0.06607 s
compute_default_reduction    0.00666 s
compute_yydefact    0.08754 s
compute_yydefgoto    0.08042 s
sort_actions    0.00655 s
compute_packed_table    0.45709 s
render    0.08769 s
```

## stackprof

### Before

```
❯ bundle exec stackprof --limit 10 tmp/stackprof-cpu-myapp.dump
==================================
  Mode: cpu(1000)
  Samples: 6449 (3.30% miss rate)
  GC: 1784 (27.66%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1858  (28.8%)        1858  (28.8%)     (sweeping)
      1305  (20.2%)        1216  (18.9%)     Lrama::Lexer#lex_c_code
       531   (8.2%)         371   (5.8%)     Struct#==
       785  (12.2%)         339   (5.3%)     Lrama::States#compute_look_ahead_sets
       294   (4.6%)         252   (3.9%)     Lrama::Context#compute_packed_table
       192   (3.0%)         192   (3.0%)     Integer#>>
       186   (2.9%)         186   (2.9%)     Integer#&
       188   (2.9%)         158   (2.4%)     Lrama::Lexer::Token#==
      3027  (46.9%)         147   (2.3%)     Array#each
       637   (9.9%)         138   (2.1%)     Lrama::States#compute_lookback_relation
```

### After

```
❯ bundle exec stackprof --limit 10 tmp/stackprof-cpu-myapp.dump
==================================
  Mode: cpu(1000)
  Samples: 3711 (0.51% miss rate)
  GC: 186 (5.01%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       797  (21.5%)         338   (9.1%)     Lrama::States#compute_look_ahead_sets
       474  (12.8%)         307   (8.3%)     Struct#==
       329   (8.9%)         290   (7.8%)     Lrama::Context#compute_packed_table
       246   (6.6%)         240   (6.5%)     Lrama::Lexer#lex_c_code
       191   (5.1%)         191   (5.1%)     Integer#>>
       180   (4.9%)         180   (4.9%)     Integer#&
       187   (5.0%)         157   (4.2%)     Lrama::Lexer::Token#==
       592  (16.0%)         146   (3.9%)     Lrama::States#compute_lookback_relation
      3037  (81.8%)         138   (3.7%)     Array#each
       137   (3.7%)         137   (3.7%)     Lrama::States::Item#hash
```