### PR TITLE
Lex a line comment without newline correctly

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -71,9 +71,8 @@ module Lrama
           # noop
         when @scanner.scan(/\/\*/)
           lex_comment
-        when @scanner.scan(/\/\//)
-          @scanner.scan_until(/\n/)
-          newline
+        when @scanner.scan(/\/\/.*(?<newline>\n)?/)
+          newline if @scanner[:newline]
         else
           break
         end

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -293,4 +293,9 @@ RSpec.describe Lrama::Lexer do
       expect { lexer.next_token }.to raise_error(ParseError, "Unexpected code: @invalid.")
     end
   end
+
+  it 'lex a line comment without newline' do
+    lexer = Lrama::Lexer.new("// foo")
+    expect(lexer.next_token).to be_nil
+  end
 end


### PR DESCRIPTION
Currently, the lexer produces an identifier token for `// foo <EOF>` because it only skips `//` when a line comment has no newline.

We can create such a funny example:

```
$ ruby -e 'print ?/*20_000' > p.y
$ exe/lrama p.y
parser.y:459:in `on_error': p.y:10001:-1: parse error on value "$" ($end) (Racc::ParseError)

...
```

Why the reported line number is `10001`??