### PR TITLE
Remove comma from expanded rule examples

### DIFF
--- a/lib/lrama/grammar/parameterizing_rules/builder/list.rb
+++ b/lib/lrama/grammar/parameterizing_rules/builder/list.rb
@@ -10,7 +10,7 @@ module Lrama
           #
           # program: list_number
           # list_number: ε
-          # list_number: list_number, number
+          # list_number: list_number number
           def build
             validate_argument_number!
 

--- a/lib/lrama/grammar/parameterizing_rules/builder/nonempty_list.rb
+++ b/lib/lrama/grammar/parameterizing_rules/builder/nonempty_list.rb
@@ -10,7 +10,7 @@ module Lrama
           #
           # program: nonempty_list_number
           # nonempty_list_number: number
-          # nonempty_list_number: nonempty_list_number, number
+          # nonempty_list_number: nonempty_list_number number
           def build
             validate_argument_number!
 

--- a/lib/lrama/grammar/parameterizing_rules/builder/separated_list.rb
+++ b/lib/lrama/grammar/parameterizing_rules/builder/separated_list.rb
@@ -17,7 +17,7 @@ module Lrama
           # program: separated_list_number
           # separated_list_number: ε
           # separated_list_number: number
-          # separated_list_number: separated_list_number, ',', number
+          # separated_list_number: separated_list_number ',' number
           def build
             validate_argument_number!
 

--- a/lib/lrama/grammar/parameterizing_rules/builder/separated_nonempty_list.rb
+++ b/lib/lrama/grammar/parameterizing_rules/builder/separated_nonempty_list.rb
@@ -16,7 +16,7 @@ module Lrama
           #
           # program: separated_nonempty_list_number
           # separated_nonempty_list_number: number
-          # separated_nonempty_list_number: separated_nonempty_list_number, ',', number
+          # separated_nonempty_list_number: separated_nonempty_list_number ',' number
           def build
             validate_argument_number!
 


### PR DESCRIPTION
Because these comma are not part of rule.