### PR TITLE
Fix separated_list expansion

### DIFF
--- a/lib/lrama/grammar/parameterizing_rules/builder/separated_list.rb
+++ b/lib/lrama/grammar/parameterizing_rules/builder/separated_list.rb
@@ -16,17 +16,20 @@ module Lrama
           #
           # program: separated_list_number
           # separated_list_number: ε
-          # separated_list_number: number
-          # separated_list_number: separated_list_number ',' number
+          # separated_list_number: separated_nonempty_list_number
+          # separated_nonempty_list_number: number
+          # separated_nonempty_list_number: separated_nonempty_list_number ',' number
           def build
             validate_argument_number!
 
             rules = []
             separated_list_token = Lrama::Lexer::Token::Ident.new(s_value: "separated_list_#{@token.s_value}")
+            separated_nonempty_list_token = Lrama::Lexer::Token::Ident.new(s_value: "separated_nonempty_list_#{@token.s_value}")
             rules << Rule.new(id: @rule_counter.increment, _lhs: @lhs, _rhs: [separated_list_token], token_code: @user_code, precedence_sym: @precedence_sym, lineno: @line)
             rules << Rule.new(id: @rule_counter.increment, _lhs: separated_list_token, _rhs: [], token_code: @user_code, precedence_sym: @precedence_sym, lineno: @line)
-            rules << Rule.new(id: @rule_counter.increment, _lhs: separated_list_token, _rhs: [@token], token_code: @user_code, precedence_sym: @precedence_sym, lineno: @line)
-            rules << Rule.new(id: @rule_counter.increment, _lhs: separated_list_token, _rhs: [separated_list_token, @separator, @token], token_code: @user_code, precedence_sym: @precedence_sym, lineno: @line)
+            rules << Rule.new(id: @rule_counter.increment, _lhs: separated_list_token, _rhs: [separated_nonempty_list_token], token_code: @user_code, precedence_sym: @precedence_sym, lineno: @line)
+            rules << Rule.new(id: @rule_counter.increment, _lhs: separated_nonempty_list_token, _rhs: [@token], token_code: @user_code, precedence_sym: @precedence_sym, lineno: @line)
+            rules << Rule.new(id: @rule_counter.increment, _lhs: separated_nonempty_list_token, _rhs: [separated_nonempty_list_token, @separator, @token], token_code: @user_code, precedence_sym: @precedence_sym, lineno: @line)
             rules
           end
         end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -990,6 +990,7 @@ RSpec.describe Lrama::Parser do
           Sym.new(id: T::Ident.new(s_value: "$accept"), alias_name: nil, number:  5, tag: nil, term: false, token_id: 0, nullable: false),
           Sym.new(id: T::Ident.new(s_value: "program"), alias_name: nil, number:  6, tag: nil, term: false, token_id: 1, nullable: true),
           Sym.new(id: T::Ident.new(s_value: "separated_list_number"), alias_name: nil, number:  7, tag: nil, term: false, token_id: 2, nullable: true),
+          Sym.new(id: T::Ident.new(s_value: "separated_nonempty_list_number"), alias_name: nil, number:  8, tag: nil, term: false, token_id: 3, nullable: false),
         ])
 
         expect(grammar.rules).to eq([
@@ -1029,7 +1030,18 @@ RSpec.describe Lrama::Parser do
             id: 3,
             lhs: grammar.find_symbol_by_s_value!("separated_list_number"),
             rhs: [
-              grammar.find_symbol_by_s_value!("number"),
+              grammar.find_symbol_by_s_value!("separated_nonempty_list_number"),
+            ],
+            token_code: nil,
+            nullable: false,
+            precedence_sym: nil,
+            lineno: 20,
+          ),
+          Rule.new(
+            id: 4,
+            lhs: grammar.find_symbol_by_s_value!("separated_nonempty_list_number"),
+            rhs: [
+              grammar.find_symbol_by_s_value!("number")
             ],
             token_code: nil,
             nullable: false,
@@ -1037,10 +1049,10 @@ RSpec.describe Lrama::Parser do
             lineno: 20,
           ),
           Rule.new(
-            id: 4,
-            lhs: grammar.find_symbol_by_s_value!("separated_list_number"),
+            id: 5,
+            lhs: grammar.find_symbol_by_s_value!("separated_nonempty_list_number"),
             rhs: [
-              grammar.find_symbol_by_s_value!("separated_list_number"),
+              grammar.find_symbol_by_s_value!("separated_nonempty_list_number"),
               grammar.find_symbol_by_number!(4),
               grammar.find_symbol_by_s_value!("number"),
             ],


### PR DESCRIPTION
Before
```
program: separated_list(',', number)
↓
program: separated_list_number
separated_list_number: ε
separated_list_number: number
separated_list_number: separated_list_number ',' number
```

After
```
program: separated_list(',', number)
↓
program: separated_list_number
separated_list_number: ε
separated_list_number: separated_nonempty_list_number
separated_nonempty_list_number: number
separated_nonempty_list_number: separated_nonempty_list_number ',' number
```