### PR TITLE
Retry if choco install winflexbison fails

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: choco install winflexbison
+      - run: choco install winflexbison || choco install winflexbison
       - run: win_flex --help
       - run: bundle install
       - run: bundle exec rspec


### PR DESCRIPTION
Sometimes `choco install winflexbison` fails, so how about retrying?
- https://github.com/ruby/lrama/actions/runs/7019310484/job/19096471447