### PR TITLE
Fix the codes line numbers in prologue and epilogue

### DIFF
--- a/spec/fixtures/integration/line_number.l
+++ b/spec/fixtures/integration/line_number.l
@@ -1,0 +1,45 @@
+%option noinput nounput noyywrap never-interactive yylineno bison-bridge bison-locations
+
+%{
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "line_number.h"
+
+int yycolumn = 0;
+
+#define YY_USER_ACTION \
+    yylloc->first_line = yylloc->last_line = yylineno; \
+    yylloc->first_column = yycolumn; \
+    yylloc->last_column = yycolumn + yyleng; \
+    yycolumn += yyleng; \
+
+%}
+
+NUMBER [0-9]+
+
+%%
+
+{NUMBER} {
+    yylval->i = atoi(yytext);
+    return NUM;
+}
+
+[+\-\*\/\(\)] {
+    return yytext[0];
+}
+
+[\n|\r\n] {}
+
+[[:space:]] {}
+
+<<EOF>> {
+    return(YYEOF);
+}
+
+. {
+    fprintf(stderr, "Illegal character '%s'\n", yytext);
+    return(YYEOF);
+}
+
+%%

--- a/spec/fixtures/integration/line_number.y
+++ b/spec/fixtures/integration/line_number.y
@@ -1,0 +1,68 @@
+%{
+
+#define YYDEBUG 1
+
+#include <stdio.h>
+#include "line_number.h"
+#include "line_number-lexer.h"
+
+static int yyerror(YYLTYPE *loc, const char *str);
+static void line_2(void);
+
+static void
+line_1(void)
+{
+    printf("line_1: %d\n", __LINE__);
+}
+
+%}
+
+%union {
+    int i;
+}
+
+%expect 0
+
+%token <i> NUM
+
+%%
+
+program :   {
+              printf("line_pre_program: %d\n", __LINE__);
+              line_1();
+              line_2();
+            }
+          expr
+            {
+              printf("line_post_program: %d\n", __LINE__);
+            }
+        ;
+
+expr : NUM
+     ;
+
+%%
+
+static int
+yyerror(YYLTYPE *loc, const char *str) {
+    fprintf(stderr, "parse error: %s\\n", str);
+    return 0;
+}
+
+static void
+line_2(void)
+{
+    printf("line_2: %d\n", __LINE__);
+}
+
+int
+main(int argc, char *argv[]) {
+    yydebug = 1;
+
+    if (argc == 2) {
+        yy_scan_string(argv[1]);
+    }
+
+    yyparse();
+    return 0;
+}

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -107,6 +107,19 @@ RSpec.describe "integration" do
     end
   end
 
+  describe "__LINE__ of each place" do
+    it "prints line number of each place" do
+      expected = <<~STR
+        line_pre_program: 31
+        line_1: 15
+        line_2: 55
+        line_post_program: 37
+      STR
+
+      test_parser("line_number", "1 + 2", expected)
+    end
+  end
+
   # TODO: Add test case for "(1+2"
   describe "error_recovery" do
     it "returns 101 for '(1+)'" do

--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -72,7 +72,6 @@
 <%- if output.aux.prologue -%>
 /* First part of user prologue.  */
 #line <%= output.aux.prologue_first_lineno %> "<%= output.grammar_file_path %>"
-
 <%= output.aux.prologue %>
 #line [@oline@] [@ofile@]
 <%- end -%>
@@ -2048,7 +2047,6 @@ yyreturnlab:
 <%# b4_percent_code_get([[epilogue]]) -%>
 <%- if output.aux.epilogue -%>
 #line <%= output.aux.epilogue_first_lineno - 1 %> "<%= output.grammar_file_path %>"
-
 <%= output.aux.epilogue -%>
 <%- end -%>
 


### PR DESCRIPTION
`C_DECLARATION` includes new line after `"%{"` (prologue) or `"%%"` (epilogue) then adjust `#line` directive and source codes in template.