### PR TITLE
Integration test for user defined parameterizing rules

### DIFF
--- a/spec/fixtures/integration/user_defined_parameterizing_rules.l
+++ b/spec/fixtures/integration/user_defined_parameterizing_rules.l
@@ -1,0 +1,53 @@
+%option noinput nounput noyywrap never-interactive yylineno bison-bridge bison-locations
+
+%{
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "user_defined_parameterizing_rules.h"
+
+int yycolumn = 0;
+
+#define YY_USER_ACTION \
+    yylloc->first_line = yylloc->last_line = yylineno; \
+    yylloc->first_column = yycolumn; \
+    yylloc->last_column = yycolumn + yyleng; \
+    yycolumn += yyleng; \
+
+%}
+
+ODD  [13579]
+EVEN [02468]
+
+%%
+
+{ODD} {
+    yylval->num = atoi(yytext);
+    return ODD;
+}
+
+{EVEN} {
+    yylval->num = atoi(yytext);
+    return EVEN;
+}
+
+[;] {
+    return yytext[0];
+}
+
+[\n|\r\n] {
+    return(YYEOF);
+}
+
+[[:space:]] {}
+
+<<EOF>> {
+    return(YYEOF);
+}
+
+. {
+    fprintf(stderr, "Illegal character '%s'\n", yytext);
+    return(YYEOF);
+}
+
+%%

--- a/spec/fixtures/integration/user_defined_parameterizing_rules.y
+++ b/spec/fixtures/integration/user_defined_parameterizing_rules.y
@@ -1,0 +1,56 @@
+%{
+
+#define YYDEBUG 1
+
+#include <stdio.h>
+
+#include "user_defined_parameterizing_rules.h"
+#include "user_defined_parameterizing_rules-lexer.h"
+
+static int yyerror(YYLTYPE *loc, const char *str);
+
+%}
+
+%expect 0
+
+%union {
+    int num;
+}
+
+%token <num> ODD EVEN
+
+%rule pair(X, Y): X Y { printf("(%d, %d)\n", $1, $2); }
+                ;
+
+%%
+
+program: stmts
+       ;
+
+stmts: separated_list(';', stmt)
+     ;
+
+stmt: pair(ODD, EVEN) { printf("pair odd even\n"); }
+    | pair(EVEN, ODD) { printf("pair even odd\n"); }
+    ;
+
+%%
+
+static int yyerror(YYLTYPE *loc, const char *str) {
+    fprintf(stderr, "parse error: %s\\n", str);
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    yydebug = 1;
+
+    if (argc == 2) {
+        yy_scan_string(argv[1]);
+    }
+
+    if (yyparse()) {
+        fprintf(stderr, "syntax error\n");
+        return 1;
+    }
+    return 0;
+}

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe "integration" do
     end
   end
 
+  describe "user defined parameterizing rules" do
+    it "prints messages corresponding to rules" do
+      expected = <<~STR
+        (0, 1)
+        pair even odd
+        (1, 0)
+        pair odd even
+      STR
+      test_parser("user_defined_parameterizing_rules", "0 1 ; 1 0", expected)
+    end
+  end
+
   describe "%printer" do
     it "prints messages" do
       expected = <<~STR.chomp


### PR DESCRIPTION
There are two blockers to merge this test case.
1. `#yyr2` assumes rules are sorted by id. But it's not ensured when rules are generated by parameterizing rule. This was solved by https://github.com/ruby/lrama/pull/288.
2. `ParameterizingRuleRhsBuilder` only accept one symbol for rhs (`#symbol`). But it should accept arbitrary number of symbols. https://github.com/ruby/lrama/pull/291 will fix this issue.