### PR TITLE
Rename `ParameterizingRuleBuilder#args` to `#parameters`

### DIFF
--- a/lib/lrama/grammar/parameterizing_rule_builder.rb
+++ b/lib/lrama/grammar/parameterizing_rule_builder.rb
@@ -1,13 +1,13 @@
 module Lrama
   class Grammar
     class ParameterizingRuleBuilder
-      attr_reader :name, :args, :rhs
+      attr_reader :name, :parameters, :rhs
 
-      def initialize(name, args, rhs)
+      def initialize(name, parameters, rhs)
         @name = name
-        @args = args
+        @parameters = parameters
         @rhs = rhs
-        @required_args_count = args.count
+        @required_parameters_count = parameters.count
       end
 
       def build_rules(token, rule_counter, lhs_tag, line)
@@ -23,8 +23,8 @@ module Lrama
       private
 
       def validate_argument_number!(token)
-        unless @required_args_count == token.args.count
-          raise "Invalid number of arguments. expect: #{@required_args_count} actual: #{token.args.count}"
+        unless @required_parameters_count == token.args.count
+          raise "Invalid number of arguments. expect: #{@required_parameters_count} actual: #{token.args.count}"
         end
       end
 
@@ -34,7 +34,7 @@ module Lrama
 
       def rhs_token(token, rhs)
         rhs.symbols.map do |sym|
-          idx = @args.index { |arg| arg.s_value == sym.s_value }
+          idx = @parameters.index { |parameter| parameter.s_value == sym.s_value }
           if idx.nil?
             sym
           else

--- a/sig/lrama/grammar/parameterizing_rule_builder.rbs
+++ b/sig/lrama/grammar/parameterizing_rule_builder.rbs
@@ -2,12 +2,12 @@ module Lrama
   class Grammar
     class ParameterizingRuleBuilder
       attr_reader name: String
-      attr_reader args: Array[Lexer::Token]
+      attr_reader parameters: Array[Lexer::Token]
       attr_reader rhs: Array[Grammar::ParameterizingRuleRhsBuilder]
 
-      @required_args_count: Integer
+      @required_parameters_count: Integer
 
-      def initialize: (String name, Array[Lexer::Token] args, Array[Grammar::ParameterizingRuleRhsBuilder] rhs) -> void
+      def initialize: (String name, Array[Lexer::Token] parameters, Array[Grammar::ParameterizingRuleRhsBuilder] rhs) -> void
       def build_rules: (Lexer::Token::Parameterizing token, Counter rule_counter, untyped lhs_tag, Integer? line) -> Grammar::ParameterizingRule
 
       private


### PR DESCRIPTION
To avoid confusing `args` with `token.args`.