### PR TITLE
Better error message

### DIFF
--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -151,8 +151,15 @@ module Lrama
               else
                 candidates = rhs.each_with_index.select {|token, i| token.referred_by?(ref_name) }
 
-                raise token.location.generate_error_message("Referring symbol `#{ref_name}` is duplicated.") if candidates.size >= 2
-                raise token.location.generate_error_message("Referring symbol `#{ref_name}` is not found.") unless referring_symbol = candidates.first
+                if candidates.size >= 2
+                  location = token.location.partial_location(ref.first_column, ref.last_column)
+                  raise location.generate_error_message("Referring symbol `#{ref_name}` is duplicated.")
+                end
+
+                unless referring_symbol = candidates.first
+                  location = token.location.partial_location(ref.first_column, ref.last_column)
+                  raise location.generate_error_message("Referring symbol `#{ref_name}` is not found.")
+                end
 
                 ref.index = referring_symbol[1] + 1
               end

--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -151,8 +151,8 @@ module Lrama
               else
                 candidates = rhs.each_with_index.select {|token, i| token.referred_by?(ref_name) }
 
-                raise "Referring symbol `#{ref_name}` is duplicated.\n#{token.location.line_with_carrets}" if candidates.size >= 2
-                raise "Referring symbol `#{ref_name}` is not found.\n#{token.location.line_with_carrets}" unless referring_symbol = candidates.first
+                raise token.location.generate_error_message("Referring symbol `#{ref_name}` is duplicated.") if candidates.size >= 2
+                raise token.location.generate_error_message("Referring symbol `#{ref_name}` is not found.") unless referring_symbol = candidates.first
 
                 ref.index = referring_symbol[1] + 1
               end

--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -151,8 +151,8 @@ module Lrama
               else
                 candidates = rhs.each_with_index.select {|token, i| token.referred_by?(ref_name) }
 
-                raise "Referring symbol `#{ref_name}` is duplicated. #{token}" if candidates.size >= 2
-                raise "Referring symbol `#{ref_name}` is not found. #{token}" unless referring_symbol = candidates.first
+                raise "Referring symbol `#{ref_name}` is duplicated.\n#{token.location.line_with_carrets}" if candidates.size >= 2
+                raise "Referring symbol `#{ref_name}` is not found.\n#{token.location.line_with_carrets}" unless referring_symbol = candidates.first
 
                 ref.index = referring_symbol[1] + 1
               end

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -31,7 +31,8 @@ module Lrama
       %rule
     )
 
-    def initialize(text)
+    def initialize(path, text)
+      @path = path
       @scanner = StringScanner.new(text)
       @head_column = @head = @scanner.pos
       @head_line = @line = 1
@@ -58,6 +59,7 @@ module Lrama
 
     def location
       Location.new(
+        grammar_file_path: @path,
         first_line: @head_line, first_column: @head_column,
         last_line: line, last_column: column
       )

--- a/lib/lrama/lexer/location.rb
+++ b/lib/lrama/lexer/location.rb
@@ -1,9 +1,10 @@
 module Lrama
   class Lexer
     class Location
-      attr_reader :first_line, :first_column, :last_line, :last_column
+      attr_reader :grammar_file_path, :first_line, :first_column, :last_line, :last_column
 
-      def initialize(first_line:, first_column:, last_line:, last_column:)
+      def initialize(grammar_file_path:, first_line:, first_column:, last_line:, last_column:)
+        @grammar_file_path = grammar_file_path
         @first_line = first_line
         @first_column = first_column
         @last_line = last_line
@@ -12,6 +13,7 @@ module Lrama
 
       def ==(other)
         self.class == other.class &&
+        self.grammar_file_path == other.grammar_file_path &&
         self.first_line == other.first_line &&
         self.first_column == other.first_column &&
         self.last_line == other.last_line &&
@@ -19,7 +21,7 @@ module Lrama
       end
 
       def to_s
-        "(#{first_line},#{first_column})-(#{last_line},#{last_column})"
+        "#{grammar_file_path} (#{first_line},#{first_column})-(#{last_line},#{last_column})"
       end
     end
   end

--- a/lib/lrama/lexer/location.rb
+++ b/lib/lrama/lexer/location.rb
@@ -20,6 +20,36 @@ module Lrama
         self.last_column == other.last_column
       end
 
+      def partial_location(left, right)
+        offset = -first_column
+        new_first_line = -1
+        new_first_column = -1
+        new_last_line = -1
+        new_last_column = -1
+
+        _text.each.with_index do |line, index|
+          new_offset = offset + line.length + 1
+
+          if offset <= left && left <= new_offset
+            new_first_line = first_line + index
+            new_first_column = left - offset
+          end
+
+          if offset <= right && right <= new_offset
+            new_last_line = first_line + index
+            new_last_column = right - offset
+          end
+
+          offset = new_offset
+        end
+
+        Location.new(
+          grammar_file_path: grammar_file_path,
+          first_line: new_first_line, first_column: new_first_column,
+          last_line: new_last_line, last_column: new_last_column
+        )
+      end
+
       def to_s
         "#{grammar_file_path} (#{first_line},#{first_column})-(#{last_line},#{last_column})"
       end
@@ -49,10 +79,16 @@ module Lrama
       end
 
       def text
-        return @text if @text
+        _text.join("\n")
+      end
 
-        @text = File.read(grammar_file_path).split("\n")[first_line - 1]
-        @text
+      def _text
+        return @_text if @_text
+
+        offset = 0
+
+        @_text = File.read(grammar_file_path).split("\n")[(first_line - 1)...last_line]
+        @_text
       end
     end
   end

--- a/lib/lrama/lexer/location.rb
+++ b/lib/lrama/lexer/location.rb
@@ -24,6 +24,13 @@ module Lrama
         "#{grammar_file_path} (#{first_line},#{first_column})-(#{last_line},#{last_column})"
       end
 
+      def generate_error_message(error_message)
+        <<~ERROR.chomp
+          #{grammar_file_path}:#{first_line}:#{first_column}: #{error_message}
+          #{line_with_carrets}
+        ERROR
+      end
+
       def line_with_carrets
         <<~TEXT
           #{text}

--- a/lib/lrama/lexer/location.rb
+++ b/lib/lrama/lexer/location.rb
@@ -23,6 +23,30 @@ module Lrama
       def to_s
         "#{grammar_file_path} (#{first_line},#{first_column})-(#{last_line},#{last_column})"
       end
+
+      def line_with_carrets
+        <<~TEXT
+          #{text}
+          #{carrets}
+        TEXT
+      end
+
+      private
+
+      def blanks
+        (text[0...first_column] or raise "#{first_column} is invalid").gsub(/[^\t]/, ' ')
+      end
+
+      def carrets
+        blanks + '^' * (last_column - first_column)
+      end
+
+      def text
+        return @text if @text
+
+        @text = File.read(grammar_file_path).split("\n")[first_line - 1]
+        @text
+      end
     end
   end
 end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -672,7 +672,7 @@ end
 
 def parse
   report_duration(:parse) do
-    @lexer = Lrama::Lexer.new(@text)
+    @lexer = Lrama::Lexer.new(@path, @text)
     @grammar = Lrama::Grammar.new(@rule_counter)
     @precedence_number = 0
     reset_precs

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -689,30 +689,26 @@ end
 
 def on_error(error_token_id, error_value, value_stack)
   if error_value.is_a?(Lrama::Lexer::Token)
-    line = error_value.first_line
     location = error_value.location
     value = "'#{error_value.s_value}'"
   else
-    line = @lexer.line
     location = @lexer.location
     value = error_value.inspect
   end
 
   error_message = "parse error on value #{value} (#{token_to_str(error_token_id) || '?'})"
 
-  raise_parse_error(error_message, line, location)
+  raise_parse_error(error_message, location)
 end
 
 def on_action_error(error_message, error_value)
   if error_value.is_a?(Lrama::Lexer::Token)
-    line = error_value.first_line
     location = error_value.location
   else
-    line = @lexer.line
     location = @lexer.location
   end
 
-  raise_parse_error(error_message, line, location)
+  raise_parse_error(error_message, location)
 end
 
 private
@@ -732,9 +728,9 @@ def end_c_declaration
   @lexer.end_symbol = nil
 end
 
-def raise_parse_error(error_message, line, location)
+def raise_parse_error(error_message, location)
   raise ParseError, <<~ERROR
-    #{@path}:#{line}:#{location.first_column}: #{error_message}
+    #{location.grammar_file_path}:#{location.first_line}:#{location.first_column}: #{error_message}
     #{location.line_with_carrets}
   ERROR
 end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -690,33 +690,29 @@ end
 def on_error(error_token_id, error_value, value_stack)
   if error_value.is_a?(Lrama::Lexer::Token)
     line = error_value.first_line
-    first_column = error_value.first_column
-    last_column = error_value.last_column
+    location = error_value.location
     value = "'#{error_value.s_value}'"
   else
     line = @lexer.line
-    first_column = @lexer.head_column
-    last_column = @lexer.column
+    location = @lexer.location
     value = error_value.inspect
   end
 
   error_message = "parse error on value #{value} (#{token_to_str(error_token_id) || '?'})"
 
-  raise_parse_error(error_message, line, first_column, last_column)
+  raise_parse_error(error_message, line, location)
 end
 
 def on_action_error(error_message, error_value)
   if error_value.is_a?(Lrama::Lexer::Token)
     line = error_value.first_line
-    first_column = error_value.first_column
-    last_column = error_value.last_column
+    location = error_value.location
   else
     line = @lexer.line
-    first_column = @lexer.head_column
-    last_column = @lexer.column
+    location = @lexer.location
   end
 
-  raise_parse_error(error_message, line, first_column, last_column)
+  raise_parse_error(error_message, line, location)
 end
 
 private
@@ -736,22 +732,11 @@ def end_c_declaration
   @lexer.end_symbol = nil
 end
 
-def raise_parse_error(error_message, line, first_column, last_column)
-  text = @text.split("\n")[line - 1]
-
+def raise_parse_error(error_message, line, location)
   raise ParseError, <<~ERROR
-    #{@path}:#{line}:#{first_column}: #{error_message}
-    #{text}
-    #{carrets(text, first_column, last_column)}
+    #{@path}:#{line}:#{location.first_column}: #{error_message}
+    #{location.line_with_carrets}
   ERROR
-end
-
-def blanks(text, first_column)
-  text[0...first_column].gsub(/[^\t]/, ' ')
-end
-
-def carrets(text, first_column, last_column)
-  blanks(text, first_column) + '^' * (last_column - first_column)
 end
 ...end parser.y/module_eval...
 ##### State transition tables begin ###

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -729,10 +729,7 @@ def end_c_declaration
 end
 
 def raise_parse_error(error_message, location)
-  raise ParseError, <<~ERROR
-    #{location.grammar_file_path}:#{location.first_line}:#{location.first_column}: #{error_message}
-    #{location.line_with_carrets}
-  ERROR
+  raise ParseError, location.generate_error_message(error_message)
 end
 ...end parser.y/module_eval...
 ##### State transition tables begin ###

--- a/parser.y
+++ b/parser.y
@@ -527,30 +527,26 @@ end
 
 def on_error(error_token_id, error_value, value_stack)
   if error_value.is_a?(Lrama::Lexer::Token)
-    line = error_value.first_line
     location = error_value.location
     value = "'#{error_value.s_value}'"
   else
-    line = @lexer.line
     location = @lexer.location
     value = error_value.inspect
   end
 
   error_message = "parse error on value #{value} (#{token_to_str(error_token_id) || '?'})"
 
-  raise_parse_error(error_message, line, location)
+  raise_parse_error(error_message, location)
 end
 
 def on_action_error(error_message, error_value)
   if error_value.is_a?(Lrama::Lexer::Token)
-    line = error_value.first_line
     location = error_value.location
   else
-    line = @lexer.line
     location = @lexer.location
   end
 
-  raise_parse_error(error_message, line, location)
+  raise_parse_error(error_message, location)
 end
 
 private
@@ -570,9 +566,9 @@ def end_c_declaration
   @lexer.end_symbol = nil
 end
 
-def raise_parse_error(error_message, line, location)
+def raise_parse_error(error_message, location)
   raise ParseError, <<~ERROR
-    #{@path}:#{line}:#{location.first_column}: #{error_message}
+    #{location.grammar_file_path}:#{location.first_line}:#{location.first_column}: #{error_message}
     #{location.line_with_carrets}
   ERROR
 end

--- a/parser.y
+++ b/parser.y
@@ -528,33 +528,29 @@ end
 def on_error(error_token_id, error_value, value_stack)
   if error_value.is_a?(Lrama::Lexer::Token)
     line = error_value.first_line
-    first_column = error_value.first_column
-    last_column = error_value.last_column
+    location = error_value.location
     value = "'#{error_value.s_value}'"
   else
     line = @lexer.line
-    first_column = @lexer.head_column
-    last_column = @lexer.column
+    location = @lexer.location
     value = error_value.inspect
   end
 
   error_message = "parse error on value #{value} (#{token_to_str(error_token_id) || '?'})"
 
-  raise_parse_error(error_message, line, first_column, last_column)
+  raise_parse_error(error_message, line, location)
 end
 
 def on_action_error(error_message, error_value)
   if error_value.is_a?(Lrama::Lexer::Token)
     line = error_value.first_line
-    first_column = error_value.first_column
-    last_column = error_value.last_column
+    location = error_value.location
   else
     line = @lexer.line
-    first_column = @lexer.head_column
-    last_column = @lexer.column
+    location = @lexer.location
   end
 
-  raise_parse_error(error_message, line, first_column, last_column)
+  raise_parse_error(error_message, line, location)
 end
 
 private
@@ -574,20 +570,9 @@ def end_c_declaration
   @lexer.end_symbol = nil
 end
 
-def raise_parse_error(error_message, line, first_column, last_column)
-  text = @text.split("\n")[line - 1]
-
+def raise_parse_error(error_message, line, location)
   raise ParseError, <<~ERROR
-    #{@path}:#{line}:#{first_column}: #{error_message}
-    #{text}
-    #{carrets(text, first_column, last_column)}
+    #{@path}:#{line}:#{location.first_column}: #{error_message}
+    #{location.line_with_carrets}
   ERROR
-end
-
-def blanks(text, first_column)
-  text[0...first_column].gsub(/[^\t]/, ' ')
-end
-
-def carrets(text, first_column, last_column)
-  blanks(text, first_column) + '^' * (last_column - first_column)
 end

--- a/parser.y
+++ b/parser.y
@@ -567,8 +567,5 @@ def end_c_declaration
 end
 
 def raise_parse_error(error_message, location)
-  raise ParseError, <<~ERROR
-    #{location.grammar_file_path}:#{location.first_line}:#{location.first_column}: #{error_message}
-    #{location.line_with_carrets}
-  ERROR
+  raise ParseError, location.generate_error_message(error_message)
 end

--- a/parser.y
+++ b/parser.y
@@ -510,7 +510,7 @@ end
 
 def parse
   report_duration(:parse) do
-    @lexer = Lrama::Lexer.new(@text)
+    @lexer = Lrama::Lexer.new(@path, @text)
     @grammar = Lrama::Grammar.new(@rule_counter)
     @precedence_number = 0
     reset_precs

--- a/sig/lrama/lexer/location.rbs
+++ b/sig/lrama/lexer/location.rbs
@@ -10,6 +10,7 @@ module Lrama
       def initialize: (grammar_file_path: String, first_line: Integer, first_column: Integer, last_line: Integer, last_column: Integer) -> void
 
       def ==: (Location other) -> bool
+      def generate_error_message: (String) -> String
       def line_with_carrets: () -> String
 
       private

--- a/sig/lrama/lexer/location.rbs
+++ b/sig/lrama/lexer/location.rbs
@@ -10,6 +10,7 @@ module Lrama
       def initialize: (grammar_file_path: String, first_line: Integer, first_column: Integer, last_line: Integer, last_column: Integer) -> void
 
       def ==: (Location other) -> bool
+      def partial_location: (Integer, Integer) -> Location
       def generate_error_message: (String) -> String
       def line_with_carrets: () -> String
 
@@ -18,6 +19,7 @@ module Lrama
       def blanks: () -> String
       def carrets: () -> String
       def text: () -> String
+      def _text: () -> Array[String]
     end
   end
 end

--- a/sig/lrama/lexer/location.rbs
+++ b/sig/lrama/lexer/location.rbs
@@ -1,12 +1,13 @@
 module Lrama
   class Lexer
     class Location
+      attr_reader grammar_file_path: String
       attr_reader first_line: Integer
       attr_reader first_column: Integer
       attr_reader last_line: Integer
       attr_reader last_column: Integer
 
-      def initialize: (first_line: Integer, first_column: Integer, last_line: Integer, last_column: Integer) -> void
+      def initialize: (grammar_file_path: String, first_line: Integer, first_column: Integer, last_line: Integer, last_column: Integer) -> void
 
       def ==: (Location other) -> bool
     end

--- a/sig/lrama/lexer/location.rbs
+++ b/sig/lrama/lexer/location.rbs
@@ -10,6 +10,13 @@ module Lrama
       def initialize: (grammar_file_path: String, first_line: Integer, first_column: Integer, last_line: Integer, last_column: Integer) -> void
 
       def ==: (Location other) -> bool
+      def line_with_carrets: () -> String
+
+      private
+
+      def blanks: () -> String
+      def carrets: () -> String
+      def text: () -> String
     end
   end
 end

--- a/spec/fixtures/lexer/location.y
+++ b/spec/fixtures/lexer/location.y
@@ -34,7 +34,12 @@ expr : NUM
      | expr '-' expr { $$ = $1 - $3; }
      | expr '*' expr { $$ = $1 * $3; }
      | expr '/' expr { $$ = $1 / $3; }
-     | '(' expr ')'  { $$ = $2; }
+     | '(' expr ')'
+         {
+           printf("debug %d\n", $1);
+           $$ = $2;
+           printf("debug %d\n", $3);
+         }
      ;
 
 %%

--- a/spec/fixtures/lexer/location.y
+++ b/spec/fixtures/lexer/location.y
@@ -1,0 +1,90 @@
+/*
+ * This is a valid　sample grammar file.
+ * It works as simple calculator.
+ */
+
+%{
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#include "calc.h"
+
+static int yylex(YYSTYPE *val, YYLTYPE *loc);
+static int yyerror(YYLTYPE *loc, const char *str);
+%}
+
+%union {
+    int val;
+}
+%token LF
+%token <val> NUM
+%type <val> expr
+%left '+' '-'
+%left '*' '/'
+
+%%
+
+list : /* empty */
+     | list LF
+     | list expr LF { printf("=> %d\n", $2); }
+     ;
+expr : NUM
+     | expr '+' expr { $$ = $1 + $3; }
+     | expr '-' expr { $$ = $1 - $3; }
+     | expr '*' expr { $$ = $1 * $3; }
+     | expr '/' expr { $$ = $1 / $3; }
+     | '(' expr ')'  { $$ = $2; }
+     ;
+
+%%
+
+static int yylex(YYSTYPE *yylval, YYLTYPE *loc) {
+    int c = getchar();
+    int val;
+
+    switch (c) {
+    case ' ': case '\t':
+        return yylex(yylval, loc);
+
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+        val = c - '0';
+        while (1) {
+            c = getchar();
+            if (isdigit(c)) {
+                val = val * 10 + (c - '0');
+            }
+            else {
+                ungetc(c, stdin);
+                break;
+            }
+        }
+        yylval->val = val;
+        return NUM;
+
+    case '\n':
+        return LF;
+
+    case '+': case '-': case '*': case '/': case '(': case ')':
+        return c;
+
+    case EOF:
+        exit(0);
+
+    default:
+        fprintf(stderr, "unknown character: %c\n", c);
+        exit(1);
+    }
+}
+
+static int yyerror(YYLTYPE *loc, const char *str) {
+    fprintf(stderr, "parse error: %s\n", str);
+    return 0;
+}
+
+int main() {
+    printf("Enter the formula:\n");
+    yyparse();
+    return 0;
+}

--- a/spec/lrama/grammar/rule_builder_spec.rb
+++ b/spec/lrama/grammar/rule_builder_spec.rb
@@ -2,10 +2,11 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
   let(:rule_counter) { Lrama::Grammar::Counter.new(1) }
   let(:midrule_action_counter) { Lrama::Grammar::Counter.new(1) }
   let(:rule_builder) { Lrama::Grammar::RuleBuilder.new(rule_counter, midrule_action_counter) }
+  let(:grammar_file_path) { "parse.y" }
 
   describe "#add_rhs" do
     describe "@line" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
 
       context "@line is nil" do
@@ -33,7 +34,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
 
   describe "#user_code=" do
     describe "@user_code" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token_1) { Lrama::Lexer::Token::UserCode.new(s_value: "code 1", location: location) }
       let(:token_2) { Lrama::Lexer::Token::UserCode.new(s_value: "code 2", location: location) }
 
@@ -62,7 +63,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
     end
 
     describe "@line" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token) { Lrama::Lexer::Token::UserCode.new(s_value: "code 1", location: location) }
 
       context "@line is nil" do
@@ -90,7 +91,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
 
   describe "#precedence_sym=" do
     describe "@user_code" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token_1) { Lrama::Lexer::Token::UserCode.new(s_value: "code 1", location: location) }
       let(:sym) { Lrama::Grammar::Symbol.new(id: Lrama::Lexer::Token::Ident.new(s_value: "tPLUS"), term: true) }
 
@@ -109,7 +110,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
   end
 
   describe "#freeze_rhs" do
-    let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+    let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
     let(:token) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
 
     it "can not add rhs after #freeze_rhs is called" do
@@ -121,7 +122,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
 
   describe "#preprocess_references" do
     context "variables refer to correct name and correct position" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
       let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
       let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location) }
@@ -167,7 +168,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
     end
 
     context "variables in mid action rule refer to correct name and correct position" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
       let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
       let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location) }
@@ -213,7 +214,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
     end
 
     context "variables refer to wrong position" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
       let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
       let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location) }
@@ -234,7 +235,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
     end
 
     context "variables in mid action rule refer to following component" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
       let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
       let(:token_3) { Lrama::Lexer::Token::UserCode.new(s_value: "$3;", location: location) }
@@ -257,7 +258,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
     end
 
     context "variables refer with wrong name" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
       let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
       let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location) }
@@ -278,7 +279,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
     end
 
     context "component name is duplicated" do
-      let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
       let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
       let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
       let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location) }
@@ -302,7 +303,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
   end
 
   describe "#midrule_action_rules" do
-    let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+    let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
     let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
     let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
     let(:token_3) { Lrama::Lexer::Token::UserCode.new(s_value: "$1", location: location) }
@@ -337,7 +338,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
   end
 
   describe "@replaced_rhs" do
-    let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
+    let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
     let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
     let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
     let(:token_3) { Lrama::Lexer::Token::UserCode.new(s_value: "$1", location: location) }

--- a/spec/lrama/grammar/rule_builder_spec.rb
+++ b/spec/lrama/grammar/rule_builder_spec.rb
@@ -263,18 +263,16 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
       let(:location_2) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 8, last_line: 1, last_column: 21) }
       let(:location_3) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 22, last_line: 1, last_column: 29) }
       let(:location_4) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 30, last_line: 1, last_column: 41) }
-      let(:location_5) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 42, last_line: 1, last_column: 60) }
+      let(:location_5) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 43, last_line: 1, last_column: 59) }
       let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location_1) }
       let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location_2) }
       let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location_3) }
       let(:token_4) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_end", location: location_4) }
-      let(:token_5) { Lrama::Lexer::Token::UserCode.new(s_value: "$classes = $1;", location: location_5) }
+      let(:token_5) { Lrama::Lexer::Token::UserCode.new(s_value: " $classes = $1; ", location: location_5) }
 
       it "raises error" do
         # class : keyword_class tSTRING keyword_end { $classes = $1; }
-        [location_1, location_2, location_3, location_4, location_5].each do |location|
-          allow(location).to receive(:text).and_return(text)
-        end
+        allow_any_instance_of(Lrama::Lexer::Location).to receive(:_text).and_return([text])
 
         rule_builder.lhs = token_1
         rule_builder.add_rhs(token_2)
@@ -284,9 +282,9 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
         rule_builder.complete_input
 
         expected = <<-TEXT
-parse.y:1:42: Referring symbol `classes` is not found.
+parse.y:1:44: Referring symbol `classes` is not found.
 class : keyword_class tSTRING keyword_end { $classes = $1; }
-                                          ^^^^^^^^^^^^^^^^^^
+                                            ^^^^^^^^
         TEXT
 
         expect { rule_builder.send(:preprocess_references) }.to raise_error(expected)
@@ -300,19 +298,17 @@ class : keyword_class tSTRING keyword_end { $classes = $1; }
       let(:location_3) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 22, last_line: 1, last_column: 29) }
       let(:location_4) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 30, last_line: 1, last_column: 37) }
       let(:location_5) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 38, last_line: 1, last_column: 49) }
-      let(:location_6) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 50, last_line: 1, last_column: 72) }
+      let(:location_6) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 51, last_line: 1, last_column: 71) }
       let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location_1) }
       let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location_2) }
       let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location_3) }
       let(:token_4) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location_4) }
       let(:token_5) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_end", location: location_5) }
-      let(:token_6) { Lrama::Lexer::Token::UserCode.new(s_value: "$class = $tSTRING;", location: location_6) }
+      let(:token_6) { Lrama::Lexer::Token::UserCode.new(s_value: " $class = $tSTRING; ", location: location_6) }
 
       it "raises error" do
         # class : keyword_class tSTRING tSTRING keyword_end { $class = $tSTRING; }
-        [location_1, location_2, location_3, location_4, location_5, location_6].each do |location|
-          allow(location).to receive(:text).and_return(text)
-        end
+        allow_any_instance_of(Lrama::Lexer::Location).to receive(:_text).and_return([text])
 
         rule_builder.lhs = token_1
         rule_builder.add_rhs(token_2)
@@ -323,9 +319,9 @@ class : keyword_class tSTRING keyword_end { $classes = $1; }
         rule_builder.complete_input
 
         expected = <<-TEXT
-parse.y:1:50: Referring symbol `tSTRING` is duplicated.
+parse.y:1:61: Referring symbol `tSTRING` is duplicated.
 class : keyword_class tSTRING tSTRING keyword_end { $class = $tSTRING; }
-                                                  ^^^^^^^^^^^^^^^^^^^^^^
+                                                             ^^^^^^^^
         TEXT
 
         expect { rule_builder.send(:preprocess_references) }.to raise_error(expected)

--- a/spec/lrama/grammar/rule_builder_spec.rb
+++ b/spec/lrama/grammar/rule_builder_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
         rule_builder.complete_input
 
         expected = <<-TEXT
-Referring symbol `classes` is not found.
+parse.y:1:42: Referring symbol `classes` is not found.
 class : keyword_class tSTRING keyword_end { $classes = $1; }
                                           ^^^^^^^^^^^^^^^^^^
         TEXT
@@ -323,7 +323,7 @@ class : keyword_class tSTRING keyword_end { $classes = $1; }
         rule_builder.complete_input
 
         expected = <<-TEXT
-Referring symbol `tSTRING` is duplicated.
+parse.y:1:50: Referring symbol `tSTRING` is duplicated.
 class : keyword_class tSTRING tSTRING keyword_end { $class = $tSTRING; }
                                                   ^^^^^^^^^^^^^^^^^^^^^^
         TEXT

--- a/spec/lrama/grammar/rule_builder_spec.rb
+++ b/spec/lrama/grammar/rule_builder_spec.rb
@@ -258,15 +258,24 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
     end
 
     context "variables refer with wrong name" do
-      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
-      let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
-      let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
-      let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location) }
-      let(:token_4) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_end", location: location) }
-      let(:token_5) { Lrama::Lexer::Token::UserCode.new(s_value: "$classes = $1;", location: location) }
+      let(:text) { "class : keyword_class tSTRING keyword_end { $classes = $1; }" }
+      let(:location_1) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 5) }
+      let(:location_2) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 8, last_line: 1, last_column: 21) }
+      let(:location_3) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 22, last_line: 1, last_column: 29) }
+      let(:location_4) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 30, last_line: 1, last_column: 41) }
+      let(:location_5) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 42, last_line: 1, last_column: 60) }
+      let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location_1) }
+      let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location_2) }
+      let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location_3) }
+      let(:token_4) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_end", location: location_4) }
+      let(:token_5) { Lrama::Lexer::Token::UserCode.new(s_value: "$classes = $1;", location: location_5) }
 
       it "raises error" do
         # class : keyword_class tSTRING keyword_end { $classes = $1; }
+        [location_1, location_2, location_3, location_4, location_5].each do |location|
+          allow(location).to receive(:text).and_return(text)
+        end
+
         rule_builder.lhs = token_1
         rule_builder.add_rhs(token_2)
         rule_builder.add_rhs(token_3)
@@ -274,21 +283,37 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
         rule_builder.user_code = token_5
         rule_builder.complete_input
 
-        expect { rule_builder.send(:preprocess_references) }.to raise_error(/Referring symbol `classes` is not found\./)
+        expected = <<-TEXT
+Referring symbol `classes` is not found.
+class : keyword_class tSTRING keyword_end { $classes = $1; }
+                                          ^^^^^^^^^^^^^^^^^^
+        TEXT
+
+        expect { rule_builder.send(:preprocess_references) }.to raise_error(expected)
       end
     end
 
     context "component name is duplicated" do
-      let(:location) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 4) }
-      let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location) }
-      let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location) }
-      let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location) }
-      let(:token_4) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location) }
-      let(:token_5) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_end", location: location) }
-      let(:token_6) { Lrama::Lexer::Token::UserCode.new(s_value: "$class = $tSTRING;", location: location) }
+      let(:text) { "class : keyword_class tSTRING tSTRING keyword_end { $class = $tSTRING; }" }
+      let(:location_1) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 0, last_line: 1, last_column: 5) }
+      let(:location_2) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 8, last_line: 1, last_column: 21) }
+      let(:location_3) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 22, last_line: 1, last_column: 29) }
+      let(:location_4) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 30, last_line: 1, last_column: 37) }
+      let(:location_5) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 38, last_line: 1, last_column: 49) }
+      let(:location_6) { Lrama::Lexer::Location.new(grammar_file_path: grammar_file_path, first_line: 1, first_column: 50, last_line: 1, last_column: 72) }
+      let(:token_1) { Lrama::Lexer::Token::Ident.new(s_value: "class", location: location_1) }
+      let(:token_2) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_class", location: location_2) }
+      let(:token_3) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location_3) }
+      let(:token_4) { Lrama::Lexer::Token::Ident.new(s_value: "tSTRING", location: location_4) }
+      let(:token_5) { Lrama::Lexer::Token::Ident.new(s_value: "keyword_end", location: location_5) }
+      let(:token_6) { Lrama::Lexer::Token::UserCode.new(s_value: "$class = $tSTRING;", location: location_6) }
 
       it "raises error" do
         # class : keyword_class tSTRING tSTRING keyword_end { $class = $tSTRING; }
+        [location_1, location_2, location_3, location_4, location_5, location_6].each do |location|
+          allow(location).to receive(:text).and_return(text)
+        end
+
         rule_builder.lhs = token_1
         rule_builder.add_rhs(token_2)
         rule_builder.add_rhs(token_3)
@@ -297,7 +322,13 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
         rule_builder.user_code = token_6
         rule_builder.complete_input
 
-        expect { rule_builder.send(:preprocess_references) }.to raise_error(/Referring symbol `tSTRING` is duplicated\./)
+        expected = <<-TEXT
+Referring symbol `tSTRING` is duplicated.
+class : keyword_class tSTRING tSTRING keyword_end { $class = $tSTRING; }
+                                                  ^^^^^^^^^^^^^^^^^^^^^^
+        TEXT
+
+        expect { rule_builder.send(:preprocess_references) }.to raise_error(expected)
       end
     end
   end

--- a/spec/lrama/lexer/location_spec.rb
+++ b/spec/lrama/lexer/location_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe Lrama::Lexer::Location do
     end
   end
 
+  describe "#partial_location" do
+    it "creates new partial location" do
+      path = fixture_path("lexer/location.y")
+      location = Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 38, first_column: 10, last_line: 42, last_column: 9)
+
+      expect(location.partial_location(49, 57)).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 40, first_column: 11, last_line: 40, last_column: 19)
+    end
+  end
+
   describe "#generate_error_message" do
     it "returns decorated error message" do
       path = fixture_path("lexer/location.y")

--- a/spec/lrama/lexer/location_spec.rb
+++ b/spec/lrama/lexer/location_spec.rb
@@ -6,6 +6,20 @@ RSpec.describe Lrama::Lexer::Location do
     end
   end
 
+  describe "#generate_error_message" do
+    it "returns decorated error message" do
+      path = fixture_path("lexer/location.y")
+      location = Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 33, first_column: 12, last_line: 33, last_column: 15)
+      expected = <<-TEXT
+#{path}:33:12: ERROR
+     | expr '+' expr { $$ = $1 + $3; }
+            ^^^
+      TEXT
+
+      expect(location.generate_error_message("ERROR")).to eq expected
+    end
+  end
+
   describe "#line_with_carrets" do
     it "returns line text with carrets" do
       path = fixture_path("lexer/location.y")

--- a/spec/lrama/lexer/location_spec.rb
+++ b/spec/lrama/lexer/location_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Lrama::Lexer::Location do
+  describe "#to_s" do
+    it "returns location information" do
+      location = Lrama::Lexer::Location.new(grammar_file_path: "test.y", first_line: 1, first_column: 0, last_line: 1, last_column: 4)
+      expect(location.to_s).to eq "test.y (1,0)-(1,4)"
+    end
+  end
+
+  describe "#line_with_carrets" do
+    it "returns line text with carrets" do
+      path = fixture_path("lexer/location.y")
+      location = Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 33, first_column: 12, last_line: 33, last_column: 15)
+      expected = <<-TEXT
+     | expr '+' expr { $$ = $1 + $3; }
+            ^^^
+      TEXT
+
+      expect(location.line_with_carrets).to eq expected
+    end
+  end
+end

--- a/spec/lrama/lexer/token/user_code_spec.rb
+++ b/spec/lrama/lexer/token/user_code_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Lrama::Lexer::Token::UserCode do
   describe "#references" do
-    let(:location) { Lrama::Lexer::Location.new(first_line: 1, first_column: 0, last_line: 1, last_column: 2) }
+    let(:location) { Lrama::Lexer::Location.new(grammar_file_path: "test.y", first_line: 1, first_column: 0, last_line: 1, last_column: 2) }
 
     it "returns references in user code" do
       # $$

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe Lrama::Lexer do
   describe '#next_token' do
     context 'basic.y' do
       it do
-        text = File.read(fixture_path("common/basic.y"))
-        lexer = Lrama::Lexer.new(text)
+        path = fixture_path("common/basic.y")
+        text = File.read(path)
+        lexer = Lrama::Lexer.new(path, text)
 
         expect(lexer.next_token).to eq(['%require', '%require'])
         expect(lexer.next_token).to eq([:STRING, '"3.0"'])
@@ -14,7 +15,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '%}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n// Prologue\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 7, first_column: 2, last_line: 9, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 7, first_column: 2, last_line: 9, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['%}', '%}'])
@@ -31,7 +32,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n    print_int();\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 15, first_column: 10, last_line: 17, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 15, first_column: 10, last_line: 17, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -42,7 +43,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n    print_token();\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 18, first_column: 10, last_line: 20, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 18, first_column: 10, last_line: 20, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -54,7 +55,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: 'struct lex_params *p')])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 22, first_column: 12, last_line: 22, last_column: 32)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 22, first_column: 12, last_line: 22, last_column: 32)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -64,7 +65,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: 'struct parse_params *p')])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 23, first_column: 14, last_line: 23, last_column: 36)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 23, first_column: 14, last_line: 23, last_column: 36)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -74,7 +75,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n    initial_action_func(@$);\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 26, first_column: 1, last_line: 28, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 26, first_column: 1, last_line: 28, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -85,7 +86,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n    int i;\n    long l;\n    char *str;\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 30, first_column: 8, last_line: 34, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 30, first_column: 8, last_line: 34, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -163,7 +164,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 1 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 63, first_column: 11, last_line: 63, last_column: 19)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 63, first_column: 11, last_line: 63, last_column: 19)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -174,7 +175,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 2 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 64, first_column: 23, last_line: 64, last_column: 31)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 64, first_column: 23, last_line: 64, last_column: 31)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -186,7 +187,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 3 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 64, first_column: 58, last_line: 64, last_column: 66)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 64, first_column: 58, last_line: 64, last_column: 66)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -199,7 +200,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 4 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 65, first_column: 23, last_line: 65, last_column: 31)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 65, first_column: 23, last_line: 65, last_column: 31)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -211,7 +212,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 5 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 65, first_column: 58, last_line: 65, last_column: 66)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 65, first_column: 58, last_line: 65, last_column: 66)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -248,8 +249,9 @@ RSpec.describe Lrama::Lexer do
 
     context 'nullable.y' do
       it do
-        text = File.read(fixture_path("common/nullable.y"))
-        lexer = Lrama::Lexer.new(text)
+        path = fixture_path("common/nullable.y")
+        text = File.read(path)
+        lexer = Lrama::Lexer.new(path, text)
 
         expect(lexer.next_token).to eq(['%require', '%require'])
         expect(lexer.next_token).to eq([:STRING, '"3.0"'])
@@ -258,7 +260,7 @@ RSpec.describe Lrama::Lexer do
         lexer.status = :c_declaration; lexer.end_symbol = '%}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n// Prologue\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(first_line: 7, first_column: 2, last_line: 9, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file_path: path, first_line: 7, first_column: 2, last_line: 9, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['%}', '%}'])
@@ -306,22 +308,23 @@ RSpec.describe Lrama::Lexer do
 
   context 'unexpected_token.y' do
     it do
-      text = File.read(fixture_path("common/unexpected_token.y"))
-      lexer = Lrama::Lexer.new(text)
+      path = fixture_path("common/unexpected_token.y")
+      text = File.read(path)
+      lexer = Lrama::Lexer.new(path, text)
       expect { lexer.next_token }.to raise_error(ParseError, "Unexpected token: @invalid.")
     end
   end
 
   context 'unexpected_c_code.y' do
     it do
-      lexer = Lrama::Lexer.new("@invalid")
+      lexer = Lrama::Lexer.new("invalid.y", "@invalid")
       lexer.status = :c_declaration; lexer.end_symbol = "%}"
       expect { lexer.next_token }.to raise_error(ParseError, "Unexpected code: @invalid.")
     end
   end
 
   it 'lex a line comment without newline' do
-    lexer = Lrama::Lexer.new("// foo")
+    lexer = Lrama::Lexer.new("comment.y", "// foo")
     expect(lexer.next_token).to be_nil
   end
 end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe Lrama::Parser do
   Printer = Lrama::Grammar::Printer
   Code = Lrama::Grammar::Code
 
+  module ParserSpecHelper
+    private
+
+    def create_grammar_file(file_name, content)
+      Tempfile.create(file_name) do |f|
+        f << content
+        f.close
+
+        yield f, content if block_given?
+      end
+    end
+  end
+
+  include ParserSpecHelper
+
   let(:header) do
     <<~HEADER
 %{
@@ -1794,13 +1809,17 @@ class : keyword_class tSTRING %prec tPLUS keyword_end { code 1 }
 %%
 
         INPUT
-        parser = Lrama::Parser.new(y, "parse.y")
 
-        expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
-          parse.y:31:42: ident after %prec
-          class : keyword_class tSTRING %prec tPLUS keyword_end { code 1 }
-                                                    ^^^^^^^^^^^
-        ERROR
+        create_grammar_file("parse.y", y) do |file, content|
+          parser = Lrama::Parser.new(content, file.path)
+
+          expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
+            #{file.path}:31:42: ident after %prec
+            class : keyword_class tSTRING %prec tPLUS keyword_end { code 1 }
+                                                      ^^^^^^^^^^^
+
+          ERROR
+        end
       end
 
       it "raises error if char exists after %prec" do
@@ -1815,13 +1834,17 @@ class : keyword_class { code 2 } tSTRING %prec "=" '!' keyword_end { code 3 }
 %%
 
         INPUT
-        parser = Lrama::Parser.new(y, "parse.y")
 
-        expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
-          parse.y:31:51: char after %prec
-          class : keyword_class { code 2 } tSTRING %prec "=" '!' keyword_end { code 3 }
-                                                             ^^^
-        ERROR
+        create_grammar_file("parse.y", y) do |file, content|
+          parser = Lrama::Parser.new(content, file.path)
+
+          expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
+            #{file.path}:31:51: char after %prec
+            class : keyword_class { code 2 } tSTRING %prec "=" '!' keyword_end { code 3 }
+                                                               ^^^
+
+          ERROR
+        end
       end
 
       it "raises error if code exists after %prec" do
@@ -1836,13 +1859,17 @@ class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { 
 %%
 
         INPUT
-        parser = Lrama::Parser.new(y, "parse.y")
 
-        expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
-          parse.y:31:78: multiple User_code after %prec
-          class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { code 6 }
-                                                                                        ^
-        ERROR
+        create_grammar_file("parse.y", y) do |file, content|
+          parser = Lrama::Parser.new(content, file.path)
+
+          expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
+            #{file.path}:31:78: multiple User_code after %prec
+            class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { code 6 }
+                                                                                          ^
+
+          ERROR
+        end
       end
     end
 
@@ -2371,11 +2398,8 @@ Referring symbol `results` is not found.
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             ERROR
 
-            Tempfile.create("parse.y") do |f|
-              f << y
-              f.close
-
-              expect { Lrama::Parser.new(y, f.path).parse }.to raise_error(expected)
+            create_grammar_file("parse.y", y) do |file, content|
+              expect { Lrama::Parser.new(content, file.path).parse }.to raise_error(expected)
             end
           end
         end
@@ -2397,11 +2421,17 @@ Referring symbol `results` is not found.
 program: /* empty */
        ;
           INPUT
-          expect { Lrama::Parser.new(y, "error_messages/parse.y").parse }.to raise_error(ParseError, <<~ERROR)
-            error_messages/parse.y:5:8: parse error on value 'invalid' (IDENTIFIER)
-            %expect invalid
-                    ^^^^^^^
-          ERROR
+
+          create_grammar_file("error_messages/parse.y", y) do |file, content|
+            parser = Lrama::Parser.new(content, file.path)
+
+            expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
+              #{file.path}:5:8: parse error on value 'invalid' (IDENTIFIER)
+              %expect invalid
+                      ^^^^^^^
+
+            ERROR
+          end
         end
       end
 
@@ -2419,11 +2449,17 @@ program: /* empty */
 program: /* empty */
        ;
           INPUT
-          expect { Lrama::Parser.new(y, "error_messages/parse.y").parse }.to raise_error(ParseError, <<~ERROR)
-            error_messages/parse.y:5:10: parse error on value 10 (INTEGER)
-            %expect 0 10
-                      ^^
-          ERROR
+
+          create_grammar_file("error_messages/parse.y", y) do |file, content|
+            parser = Lrama::Parser.new(content, file.path)
+
+            expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
+              #{file.path}:5:10: parse error on value 10 (INTEGER)
+              %expect 0 10
+                        ^^
+
+            ERROR
+          end
         end
       end
 
@@ -2441,11 +2477,17 @@ program: /* empty */
 program: /* empty */
        ;
           INPUT
-          expect { Lrama::Parser.new(y, "error_messages/parse.y").parse }.to raise_error(ParseError, <<~ERROR)
-            error_messages/parse.y:5:9: parse error on value 'invalid' (IDENTIFIER)
-            %expect\t\tinvalid
-                   \t\t^^^^^^^
-          ERROR
+
+          create_grammar_file("error_messages/parse.y", y) do |file, content|
+            parser = Lrama::Parser.new(content, file.path)
+
+            expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
+              #{file.path}:5:9: parse error on value 'invalid' (IDENTIFIER)
+              %expect\t\tinvalid
+                     \t\t^^^^^^^
+
+            ERROR
+          end
         end
       end
     end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -2383,7 +2383,11 @@ line        : '\\n'
 
 expr[result]: NUM
             | expr[left] expr[right] '+'
-                { $results = $left + $right; }
+                {
+                  // comment
+                  $results = $left + $right;
+                  // comment
+                }
             | expr expr '-'
                 { $$ = $1 - $2; }
 ;
@@ -2391,9 +2395,9 @@ expr[result]: NUM
 
             create_grammar_file("parse.y", y) do |file, content|
               expected = <<-ERROR
-#{file.path}:25:17: Referring symbol `results` is not found.
-                { $results = $left + $right; }
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#{file.path}:27:18: Referring symbol `results` is not found.
+                  $results = $left + $right;
+                  ^^^^^^^^
               ERROR
 
               expect { Lrama::Parser.new(content, file.path).parse }.to raise_error(expected)

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1,3 +1,5 @@
+require "tempfile"
+
 RSpec.describe Lrama::Parser do
   T ||= Lrama::Lexer::Token
   Type = Lrama::Grammar::Type
@@ -2363,7 +2365,18 @@ expr[result]: NUM
 ;
             INPUT
 
-            expect { Lrama::Parser.new(y, "parse.y").parse }.to raise_error(/Referring symbol `results` is not found\./)
+            expected = <<-ERROR
+Referring symbol `results` is not found.
+                { $results = $left + $right; }
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            ERROR
+
+            Tempfile.create("parse.y") do |f|
+              f << y
+              f.close
+
+              expect { Lrama::Parser.new(y, f.path).parse }.to raise_error(expected)
+            end
           end
         end
       end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1817,7 +1817,6 @@ class : keyword_class tSTRING %prec tPLUS keyword_end { code 1 }
             #{file.path}:31:42: ident after %prec
             class : keyword_class tSTRING %prec tPLUS keyword_end { code 1 }
                                                       ^^^^^^^^^^^
-
           ERROR
         end
       end
@@ -1842,7 +1841,6 @@ class : keyword_class { code 2 } tSTRING %prec "=" '!' keyword_end { code 3 }
             #{file.path}:31:51: char after %prec
             class : keyword_class { code 2 } tSTRING %prec "=" '!' keyword_end { code 3 }
                                                                ^^^
-
           ERROR
         end
       end
@@ -1867,7 +1865,6 @@ class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { 
             #{file.path}:31:78: multiple User_code after %prec
             class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { code 6 }
                                                                                           ^
-
           ERROR
         end
       end
@@ -2392,13 +2389,13 @@ expr[result]: NUM
 ;
             INPUT
 
-            expected = <<-ERROR
-Referring symbol `results` is not found.
+            create_grammar_file("parse.y", y) do |file, content|
+              expected = <<-ERROR
+#{file.path}:25:17: Referring symbol `results` is not found.
                 { $results = $left + $right; }
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            ERROR
+              ERROR
 
-            create_grammar_file("parse.y", y) do |file, content|
               expect { Lrama::Parser.new(content, file.path).parse }.to raise_error(expected)
             end
           end
@@ -2429,7 +2426,6 @@ program: /* empty */
               #{file.path}:5:8: parse error on value 'invalid' (IDENTIFIER)
               %expect invalid
                       ^^^^^^^
-
             ERROR
           end
         end
@@ -2457,7 +2453,6 @@ program: /* empty */
               #{file.path}:5:10: parse error on value 10 (INTEGER)
               %expect 0 10
                         ^^
-
             ERROR
           end
         end
@@ -2485,7 +2480,6 @@ program: /* empty */
               #{file.path}:5:9: parse error on value 'invalid' (IDENTIFIER)
               %expect\t\tinvalid
                      \t\t^^^^^^^
-
             ERROR
           end
         end


### PR DESCRIPTION
Before

```
Referring symbol `bodystmts` is not found. #<Lrama::Lexer::Token::UserCode:0x000000011cf324c0> location: (2572,21)-(2583,20) (RuntimeError)
```

After

```
tmp/parse.tmp.y:2578:50: Referring symbol `bodystmts` is not found. (RuntimeError)
                        RNODE_DEFS($$)->nd_defn = $bodystmts;
                                                  ^^^^^^^^^^
```