### PR TITLE
Fix warnings

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -144,12 +144,12 @@ module Lrama
           @line += @scanner.matched.count("\n")
         when @scanner.scan(/'.*?'/)
           code += %Q(#{@scanner.matched})
+        when @scanner.scan(/[^\"'\{\}\n]+/)
+          code += @scanner.matched
+        when @scanner.scan(/#{Regexp.escape(@end_symbol)}/)
+          code += @scanner.matched
         else
-          if @scanner.scan(/[^\"'\{\}\n#{@end_symbol}]+/)
-            code += @scanner.matched
-          else
-            code += @scanner.getch
-          end
+          code += @scanner.getch
         end
       end
       raise ParseError, "Unexpected code: #{code}."


### PR DESCRIPTION
```
❯ ruby -w exe/lrama -d sample/parse.y --trace=time
/ydah/lrama/lib/lrama/lexer.rb:148: warning: character class has duplicated range: /[^\"'\{\}\n%}]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: character class has duplicated range: /[^\"'\{\}\n}]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: character class has duplicated range: /[^\"'\{\}\n}]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: character class has duplicated range: /[^\"'\{\}\n}]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: Unknown escape \Z is ignored: /[^\"'\{\}\n\Z]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: Unknown escape \Z is ignored: /[^\"'\{\}\n\Z]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: Unknown escape \Z is ignored: /[^\"'\{\}\n\Z]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: Unknown escape \Z is ignored: /[^\"'\{\}\n\Z]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: Unknown escape \Z is ignored: /[^\"'\{\}\n\Z]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: Unknown escape \Z is ignored: /[^\"'\{\}\n\Z]+/
/ydah/lrama/lib/lrama/lexer.rb:148: warning: Unknown escape \Z is ignored: /[^\"'\{\}\n\Z]+/
```