### PR TITLE
Move lhs_tag from RuleBuilder to InstantiateRule

### DIFF
--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -3,18 +3,18 @@ require 'lrama/grammar/parameterizing_rules/builder'
 module Lrama
   class Grammar
     class RuleBuilder
-      attr_accessor :lhs, :lhs_tag, :line
-      attr_reader :rhs, :user_code, :precedence_sym
+      attr_accessor :lhs, :line
+      attr_reader :lhs_tag, :rhs, :user_code, :precedence_sym
 
-      def initialize(rule_counter, midrule_action_counter, position_in_original_rule_rhs = nil, skip_preprocess_references: false)
+      def initialize(rule_counter, midrule_action_counter, position_in_original_rule_rhs = nil, lhs_tag: nil, skip_preprocess_references: false)
         @rule_counter = rule_counter
         @midrule_action_counter = midrule_action_counter
         @position_in_original_rule_rhs = position_in_original_rule_rhs
         @skip_preprocess_references = skip_preprocess_references
 
         @lhs = nil
+        @lhs_tag = lhs_tag
         @rhs = []
-        @lhs_tag = nil
         @user_code = nil
         @precedence_sym = nil
         @line = nil
@@ -103,12 +103,12 @@ module Lrama
             @replaced_rhs << token
           when Lrama::Lexer::Token::InstantiateRule
             if parameterizing_resolver.defined?(token.rule_name)
-              parameterizing = parameterizing_resolver.build_rules(token, @rule_counter, @lhs_tag, line)
+              parameterizing = parameterizing_resolver.build_rules(token, @rule_counter, token.lhs_tag, line)
               @parameterizing_rules = @parameterizing_rules + parameterizing.map(&:rules).flatten
               @replaced_rhs = @replaced_rhs + parameterizing.map(&:token).flatten.uniq
             else
               # TODO: Delete when the standard library will defined as a grammar file.
-              parameterizing = ParameterizingRules::Builder.new(token, @rule_counter, @lhs_tag, user_code, precedence_sym, line)
+              parameterizing = ParameterizingRules::Builder.new(token, @rule_counter, token.lhs_tag, user_code, precedence_sym, line)
               @parameterizing_rules = @parameterizing_rules + parameterizing.build
               @replaced_rhs << parameterizing.build_token
             end

--- a/lib/lrama/lexer/token/instantiate_rule.rb
+++ b/lib/lrama/lexer/token/instantiate_rule.rb
@@ -3,10 +3,12 @@ module Lrama
     class Token
       class InstantiateRule < Token
         attr_accessor :args
+        attr_reader :lhs_tag
 
-        def initialize(s_value:, alias_name: nil, location: nil, args: [])
+        def initialize(s_value:, alias_name: nil, location: nil, args: [], lhs_tag: nil)
           super s_value: s_value, alias_name: alias_name, location: location
           @args = args
+          @lhs_tag = lhs_tag
         end
 
         def rule_name

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -658,7 +658,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 500)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 498)
 
 include Lrama::Report::Duration
 
@@ -1933,10 +1933,9 @@ module_eval(<<'.,.,', 'parser.y', 402)
 
 module_eval(<<'.,.,', 'parser.y', 410)
   def _reduce_99(val, _values, result)
-               token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
+               token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]], lhs_tag: val[3])
            builder = val[0]
            builder.add_rhs(token)
-           builder.lhs_tag = val[3]
            builder.line = val[1].first_line
            result = builder
 
@@ -1944,12 +1943,11 @@ module_eval(<<'.,.,', 'parser.y', 410)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 419)
+module_eval(<<'.,.,', 'parser.y', 418)
   def _reduce_100(val, _values, result)
-               token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3])
+               token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
            builder = val[0]
            builder.add_rhs(token)
-           builder.lhs_tag = val[5]
            builder.line = val[1].first_line
            result = builder
 
@@ -1957,7 +1955,7 @@ module_eval(<<'.,.,', 'parser.y', 419)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 428)
+module_eval(<<'.,.,', 'parser.y', 426)
   def _reduce_101(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
@@ -1969,7 +1967,7 @@ module_eval(<<'.,.,', 'parser.y', 428)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 436)
+module_eval(<<'.,.,', 'parser.y', 434)
   def _reduce_102(val, _values, result)
                end_c_declaration
 
@@ -1977,7 +1975,7 @@ module_eval(<<'.,.,', 'parser.y', 436)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 440)
+module_eval(<<'.,.,', 'parser.y', 438)
   def _reduce_103(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
@@ -1989,7 +1987,7 @@ module_eval(<<'.,.,', 'parser.y', 440)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 448)
+module_eval(<<'.,.,', 'parser.y', 446)
   def _reduce_104(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
@@ -2007,14 +2005,14 @@ module_eval(<<'.,.,', 'parser.y', 448)
 
 # reduce 107 omitted
 
-module_eval(<<'.,.,', 'parser.y', 459)
+module_eval(<<'.,.,', 'parser.y', 457)
   def _reduce_108(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 460)
+module_eval(<<'.,.,', 'parser.y', 458)
   def _reduce_109(val, _values, result)
      result = val[0].append(val[2])
     result
@@ -2023,7 +2021,7 @@ module_eval(<<'.,.,', 'parser.y', 460)
 
 # reduce 110 omitted
 
-module_eval(<<'.,.,', 'parser.y', 463)
+module_eval(<<'.,.,', 'parser.y', 461)
   def _reduce_111(val, _values, result)
      result = val[1].s_value
     result
@@ -2034,7 +2032,7 @@ module_eval(<<'.,.,', 'parser.y', 463)
 
 # reduce 113 omitted
 
-module_eval(<<'.,.,', 'parser.y', 470)
+module_eval(<<'.,.,', 'parser.y', 468)
   def _reduce_114(val, _values, result)
                         begin_c_declaration('\Z')
                     @grammar.epilogue_first_lineno = @lexer.line + 1
@@ -2043,7 +2041,7 @@ module_eval(<<'.,.,', 'parser.y', 470)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 475)
+module_eval(<<'.,.,', 'parser.y', 473)
   def _reduce_115(val, _values, result)
                         end_c_declaration
                     @grammar.epilogue = val[2].s_value
@@ -2062,14 +2060,14 @@ module_eval(<<'.,.,', 'parser.y', 475)
 
 # reduce 120 omitted
 
-module_eval(<<'.,.,', 'parser.y', 486)
+module_eval(<<'.,.,', 'parser.y', 484)
   def _reduce_121(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 487)
+module_eval(<<'.,.,', 'parser.y', 485)
   def _reduce_122(val, _values, result)
      result = val[0].append(val[1])
     result
@@ -2080,7 +2078,7 @@ module_eval(<<'.,.,', 'parser.y', 487)
 
 # reduce 124 omitted
 
-module_eval(<<'.,.,', 'parser.y', 492)
+module_eval(<<'.,.,', 'parser.y', 490)
   def _reduce_125(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result

--- a/parser.y
+++ b/parser.y
@@ -408,19 +408,17 @@ rule
          }
      | rhs symbol parameterizing_suffix tag_opt
          {
-           token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
+           token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]], lhs_tag: val[3])
            builder = val[0]
            builder.add_rhs(token)
-           builder.lhs_tag = val[3]
            builder.line = val[1].first_line
            result = builder
          }
      | rhs IDENTIFIER "(" parameterizing_args ")" tag_opt
          {
-           token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3])
+           token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
            builder = val[0]
            builder.add_rhs(token)
-           builder.lhs_tag = val[5]
            builder.line = val[1].first_line
            result = builder
          }

--- a/sig/lrama/grammar/rule_builder.rbs
+++ b/sig/lrama/grammar/rule_builder.rbs
@@ -2,8 +2,8 @@ module Lrama
   class Grammar
     class RuleBuilder
       attr_accessor lhs: Lexer::Token
-      attr_accessor lhs_tag: untyped
       attr_accessor line: Integer?
+      attr_reader lhs_tag: Lexer::Token::Tag?
       attr_reader rhs: Array[Lexer::Token]
       attr_reader user_code: Lexer::Token::UserCode?
       attr_reader precedence_sym: Lexer::Token?
@@ -19,7 +19,7 @@ module Lrama
       @parameterizing_rules: Array[Rule]
       @midrule_action_rules: Array[Rule]
 
-      def initialize: (Counter rule_counter, Counter midrule_action_counter, ?Integer position_in_original_rule_rhs, ?skip_preprocess_references: bool) -> void
+      def initialize: (Counter rule_counter, Counter midrule_action_counter, ?Integer position_in_original_rule_rhs, ?lhs_tag: Lexer::Token::Tag?, ?skip_preprocess_references: bool) -> void
       def add_rhs: (Lexer::Token rhs) -> void
       def user_code=: (Lexer::Token::UserCode user_code) -> void
       def precedence_sym=: (Lexer::Token user_code) -> void

--- a/sig/lrama/lexer/token/instantiate_rule.rbs
+++ b/sig/lrama/lexer/token/instantiate_rule.rbs
@@ -3,8 +3,9 @@ module Lrama
     class Token
       class InstantiateRule < Token
         attr_accessor args: Array[Lexer::Token]
+        attr_reader lhs_tag: Lexer::Token::Tag?
 
-        def initialize: (s_value: String, ?alias_name: String, ?location: Location, ?args: Array[Lexer::Token]) -> void
+        def initialize: (s_value: String, ?alias_name: String, ?location: Location, ?args: Array[Lexer::Token], ?lhs_tag: Lexer::Token::Tag?) -> void
         def rule_name: () -> String
       end
     end


### PR DESCRIPTION
This tag specifies not type of lhs of the rule
but type of generated rule lhs. Therefore change it to be managed by InstantiateRule.