### PR TITLE
Fix an infinite loop issue with recurrent calls to parameterizing rule

### DIFF
--- a/lib/lrama/grammar/binding.rb
+++ b/lib/lrama/grammar/binding.rb
@@ -4,8 +4,6 @@ module Lrama
       attr_reader :actual_args, :count
 
       def initialize(parameterizing_rule, actual_args)
-        @rule_name = parameterizing_rule.name
-        @required_parameters_count = parameterizing_rule.required_parameters_count
         @parameters = parameterizing_rule.parameters
         @actual_args = actual_args
         @parameter_to_arg = @parameters.zip(actual_args).map do |param, arg|
@@ -13,14 +11,10 @@ module Lrama
         end.to_h
       end
 
-      def resolve_symbol(symbol, lhs_token = nil)
+      def resolve_symbol(symbol)
         if symbol.is_a?(Lexer::Token::InstantiateRule)
-          if symbol.s_value == @rule_name && symbol.args_count == @required_parameters_count
-            lhs_token
-          else
-            resolved_args = symbol.args.map { |arg| resolve_symbol(arg) }
-            Lrama::Lexer::Token::InstantiateRule.new(s_value: symbol.s_value, location: symbol.location, args: resolved_args, lhs_tag: symbol.lhs_tag)
-          end
+          resolved_args = symbol.args.map { |arg| resolve_symbol(arg) }
+          Lrama::Lexer::Token::InstantiateRule.new(s_value: symbol.s_value, location: symbol.location, args: resolved_args, lhs_tag: symbol.lhs_tag)
         else
           @parameter_to_arg[symbol.s_value] || symbol
         end

--- a/lib/lrama/grammar/binding.rb
+++ b/lib/lrama/grammar/binding.rb
@@ -3,19 +3,24 @@ module Lrama
     class Binding
       attr_reader :actual_args, :count
 
-      def initialize(parameters, actual_args)
-        @parameters = parameters
+      def initialize(parameterizing_rule, actual_args)
+        @rule_name = parameterizing_rule.name
+        @required_parameters_count = parameterizing_rule.required_parameters_count
+        @parameters = parameterizing_rule.parameters
         @actual_args = actual_args
-        @count = parameters.count
-        @parameter_to_arg = parameters.zip(actual_args).map do |param, arg|
+        @parameter_to_arg = @parameters.zip(actual_args).map do |param, arg|
           [param.s_value, arg]
         end.to_h
       end
 
-      def resolve_symbol(symbol)
+      def resolve_symbol(symbol, lhs_token = nil)
         if symbol.is_a?(Lexer::Token::InstantiateRule)
-          resolved_args = symbol.args.map { |arg| resolve_symbol(arg) }
-          Lrama::Lexer::Token::InstantiateRule.new(s_value: symbol.s_value, location: symbol.location, args: resolved_args, lhs_tag: symbol.lhs_tag)
+          if symbol.s_value == @rule_name && symbol.args_count == @required_parameters_count
+            lhs_token
+          else
+            resolved_args = symbol.args.map { |arg| resolve_symbol(arg) }
+            Lrama::Lexer::Token::InstantiateRule.new(s_value: symbol.s_value, location: symbol.location, args: resolved_args, lhs_tag: symbol.lhs_tag)
+          end
         else
           @parameter_to_arg[symbol.s_value] || symbol
         end

--- a/lib/lrama/grammar/parameterizing_rule/resolver.rb
+++ b/lib/lrama/grammar/parameterizing_rule/resolver.rb
@@ -2,8 +2,11 @@ module Lrama
   class Grammar
     class ParameterizingRule
       class Resolver
+        attr_accessor :created_lhs_list
+
         def initialize
           @rules = []
+          @created_lhs_list = []
         end
 
         def add_parameterizing_rule(rule)
@@ -16,6 +19,10 @@ module Lrama
 
         def find(token)
           select_rules(token).last
+        end
+
+        def created_lhs(lhs_s_value)
+          @created_lhs_list.select { |created_lhs| created_lhs.s_value == lhs_s_value }.last
         end
 
         private

--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -110,7 +110,7 @@ module Lrama
               parameterizing_rule = parameterizing_rule_resolver.find(token)
               raise "Unexpected token. #{token}" unless parameterizing_rule
 
-              bindings = Binding.new(parameterizing_rule.parameters, token.args)
+              bindings = Binding.new(parameterizing_rule, token.args)
               actual_args = token.args.map do |arg|
                 resolved = bindings.resolve_symbol(arg)
                 if resolved.is_a?(Lexer::Token::InstantiateRule)
@@ -119,13 +119,13 @@ module Lrama
                   resolved.s_value
                 end
               end
-              new_token = Lrama::Lexer::Token::Ident.new(s_value: "#{token.rule_name}_#{actual_args.join('_')}")
+              new_token = Lrama::Lexer::Token::Ident.new(s_value: "#{token.rule_name}_#{actual_args.join('_')}", location: token.location)
               @replaced_rhs << new_token
 
               parameterizing_rule.rhs_list.each do |r|
                 rule_builder = RuleBuilder.new(@rule_counter, @midrule_action_counter, i, lhs_tag: token.lhs_tag, skip_preprocess_references: true)
                 rule_builder.lhs = new_token
-                r.symbols.each { |sym| rule_builder.add_rhs(bindings.resolve_symbol(sym)) }
+                r.symbols.each { |sym| rule_builder.add_rhs(bindings.resolve_symbol(sym, new_token)) }
                 rule_builder.line = line
                 rule_builder.user_code = r.user_code
                 rule_builder.precedence_sym = r.precedence_sym

--- a/sig/lrama/grammar/binding.rbs
+++ b/sig/lrama/grammar/binding.rbs
@@ -4,11 +4,13 @@ module Lrama
       attr_reader actual_args: Array[Lexer::Token]
       attr_reader count: Integer
 
+      @rule_name: String
+      @required_parameters_count: Integer
       @parameters: Array[Lexer::Token]
       @parameter_to_arg: untyped
 
-      def initialize: (Array[Lexer::Token] parameters, Array[Lexer::Token] actual_args) -> void
-      def resolve_symbol: (Lexer::Token symbol) -> Lexer::Token
+      def initialize: (Grammar::ParameterizingRule::Rule parameterizing_rule, Array[Lexer::Token] actual_args) -> void
+      def resolve_symbol: (Lexer::Token symbol, ?Lexer::Token lhs_token) -> Lexer::Token
     end
   end
 end

--- a/sig/lrama/grammar/binding.rbs
+++ b/sig/lrama/grammar/binding.rbs
@@ -10,7 +10,7 @@ module Lrama
       @parameter_to_arg: untyped
 
       def initialize: (Grammar::ParameterizingRule::Rule parameterizing_rule, Array[Lexer::Token] actual_args) -> void
-      def resolve_symbol: (Lexer::Token symbol, ?Lexer::Token lhs_token) -> Lexer::Token
+      def resolve_symbol: (Lexer::Token symbol) -> Lexer::Token
     end
   end
 end

--- a/sig/lrama/grammar/parameterizing_rule/resolver.rbs
+++ b/sig/lrama/grammar/parameterizing_rule/resolver.rbs
@@ -2,12 +2,15 @@ module Lrama
   class Grammar
     class ParameterizingRule
       class Resolver
+        attr_accessor created_lhs_list: Array[Lexer::Token]
+
         @rules: Array[Grammar::ParameterizingRule::Rule]
 
         def initialize: () -> void
         def add_parameterizing_rule: (Grammar::ParameterizingRule::Rule rule) -> void
         def defined?: (Lexer::Token::InstantiateRule token) -> bool
         def find: (Lexer::Token::InstantiateRule token) -> Grammar::ParameterizingRule::Rule?
+        def created_lhs: (String lhs_s_value) -> Lexer::Token?
 
         private
 

--- a/sig/lrama/grammar/rule_builder.rbs
+++ b/sig/lrama/grammar/rule_builder.rbs
@@ -35,6 +35,7 @@ module Lrama
       def preprocess_references: () -> void
       def build_rules: () -> void
       def process_rhs: (Grammar::ParameterizingRule::Resolver parameterizing_rule_resolver) -> void
+      def lhs_s_value: (Lexer::Token::InstantiateRule token, Grammar::Binding bindings) -> String
       def numberize_references: () -> void
       def flush_user_code: () -> void
     end

--- a/spec/fixtures/parameterizing_rules/user_defined_with_recursive.y
+++ b/spec/fixtures/parameterizing_rules/user_defined_with_recursive.y
@@ -1,0 +1,41 @@
+/*
+ * This is comment for this file.
+ */
+
+%{
+// Prologue
+static int yylex(YYSTYPE *val, YYLTYPE *loc);
+static int yyerror(YYLTYPE *loc, const char *str);
+%}
+
+%union {
+    int i;
+}
+
+%token <i> number
+
+%rule list(X): /* empty */
+             | X
+             | list(X)
+             ;
+
+%%
+
+program         : list(number)
+                ;
+
+%%
+
+static int yylex(YYSTYPE *yylval, YYLTYPE *loc) {
+{
+  return 0;
+}
+
+static int yyerror(YYLTYPE *loc, const char *str) {
+{
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+}

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1669,6 +1669,79 @@ RSpec.describe Lrama::Parser do
         ])
       end
 
+
+      it "user defined with recursive" do
+        path = "parameterizing_rules/user_defined_with_recursive.y"
+        y = File.read(fixture_path(path))
+        grammar = Lrama::Parser.new(y, path).parse
+
+        expect(grammar.nterms.sort_by(&:number)).to match_symbols([
+          Sym.new(id: T::Ident.new(s_value: "$accept"), alias_name: nil, number: 4, tag: nil, term: false, token_id: 0, nullable: false),
+          Sym.new(id: T::Ident.new(s_value: "list_number"), alias_name: nil, number: 5, tag: nil, term: false, token_id: 1, nullable: true),
+          Sym.new(id: T::Ident.new(s_value: "program"), alias_name: nil, number: 6, tag: nil, term: false, token_id: 2, nullable: true),
+        ])
+
+        expect(grammar.rules).to eq([
+          Rule.new(
+            id: 0,
+            lhs: grammar.find_symbol_by_s_value!("$accept"),
+            rhs: [
+              grammar.find_symbol_by_s_value!("program"),
+              grammar.find_symbol_by_s_value!("YYEOF"),
+            ],
+            token_code: nil,
+            nullable: false,
+            precedence_sym: grammar.find_symbol_by_s_value!("YYEOF"),
+            lineno: 24,
+          ),
+          Rule.new(
+            id: 1,
+            lhs: grammar.find_symbol_by_s_value!("list_number"),
+            rhs: [],
+            token_code: nil,
+            nullable: true,
+            precedence_sym: nil,
+            position_in_original_rule_rhs: 0,
+            lineno: 24,
+          ),
+          Rule.new(
+            id: 2,
+            lhs: grammar.find_symbol_by_s_value!("list_number"),
+            rhs: [
+              grammar.find_symbol_by_s_value!("number"),
+            ],
+            token_code: nil,
+            nullable: false,
+            precedence_sym: grammar.find_symbol_by_s_value!("number"),
+            position_in_original_rule_rhs: 0,
+            lineno: 24,
+          ),
+          Rule.new(
+            id: 3,
+            lhs: grammar.find_symbol_by_s_value!("list_number"),
+            rhs: [
+              grammar.find_symbol_by_s_value!("list_number"),
+            ],
+            token_code: nil,
+            nullable: true,
+            precedence_sym: nil,
+            position_in_original_rule_rhs: 0,
+            lineno: 24,
+          ),
+          Rule.new(
+            id: 4,
+            lhs: grammar.find_symbol_by_s_value!("program"),
+            rhs: [
+              grammar.find_symbol_by_s_value!("list_number"),
+            ],
+            token_code: nil,
+            nullable: true,
+            precedence_sym: nil,
+            lineno: 24,
+          ),
+        ])
+      end
+
       context 'when error case' do
         context "when invalid argument number" do
           it "raise an error" do


### PR DESCRIPTION
This PR fixes the issue of an infinite loop when there is a recurrent parameterizing rule call.

For example, the following rule would have resulted in an infinite loop.

```ruby
%rule list(X): /* empty */
             | X
             | list(X)
             ;
```