### PR TITLE
Use msys2 instead of chocolatey to install flex

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,14 +29,22 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['head']
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: choco install winflexbison || choco install winflexbison
-      - run: win_flex --help
+      - uses: msys2/setup-msys2@v2
+        id: setup-msys2
+        with:
+          update: true
+          install: >-
+            flex
+      - run: flex --help
       - run: bundle install
       - run: bundle exec rspec
   test-memory:

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "integration" do
       lexer_h_path = tmpdir + "/#{parser_name}-lexer.h"
       obj_path = tmpdir + "/#{parser_name}"
 
-      flex = windows? ? "win_flex" : "flex"
+      flex = windows? ? "flex" : "flex"
       command = [obj_path, input]
       if ENV['ENABEL_VALGRIND']
         command = ["valgrind", "--leak-check=full", "--show-leak-kinds=all", "--leak-resolution=high"] + command


### PR DESCRIPTION
CI fails to install winflexbison because of checksum mismatch. Change to use msys2 to fix the issue.

See: https://github.com/ruby/lrama/actions/runs/7429169162/job/20217621117