### PR TITLE
Use ruby/actions workflow for ruby versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,12 +8,19 @@ permissions:
   contents: read
 
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 2.5
+
   test:
+    needs: ruby-versions
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['head', '3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Previously, Ruby versions in `test.yaml` were specified using an array. However, this PR has been changed to use the [ruby/actions](https://github.com/ruby/actions/blob/master/.github/workflows/ruby_versions.yml) workflow for version.