### PR TITLE
Use only US-ASCII

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,6 +87,11 @@ jobs:
           bundler-cache: true
       - run: bundle install
 
+      # Copy from https://github.com/ruby/ruby/blob/cb9a47f2acd6e373ef868b890a9d07da6f565dd4/.github/workflows/check_misc.yml#L31
+      - name: Check if C-sources are US-ASCII
+        run: |
+          grep -r -n --include='*.[chyS]' --include='*.asm' $'[^\t-~]' -- . && exit 1 || :
+
       # Copy from https://github.com/ruby/ruby/blob/089227e94823542acfdafa68541d330eee42ffea/.github/workflows/check_misc.yml#L27
       - name: Check for trailing spaces
         run: |

--- a/lib/lrama/grammar/stdlib.y
+++ b/lib/lrama/grammar/stdlib.y
@@ -14,7 +14,7 @@
  * =>
  *
  * program: option_number
- * option_number: ε
+ * option_number: %empty
  * option_number: number
  */
 %rule option(X): /* empty */
@@ -27,7 +27,7 @@
  * =>
  *
  * program: list_number
- * list_number: ε
+ * list_number: %empty
  * list_number: list_number number
  */
 %rule list(X): /* empty */
@@ -67,7 +67,7 @@
  *
  * program: separated_list_comma_number
  * separated_list_comma_number: option_separated_nonempty_list_comma_number
- * option_separated_nonempty_list_comma_number: ε
+ * option_separated_nonempty_list_comma_number: %empty
  * option_separated_nonempty_list_comma_number: separated_nonempty_list_comma_number
  * separated_nonempty_list_comma_number: number
  * separated_nonempty_list_comma_number: comma separated_nonempty_list_comma_number number

--- a/spec/fixtures/command/basic.y
+++ b/spec/fixtures/command/basic.y
@@ -1,5 +1,5 @@
 /*
- * This is a valid　sample grammar file.
+ * This is a valid sample grammar file.
  * It works as simple calculator.
  */
 

--- a/spec/fixtures/lexer/location.y
+++ b/spec/fixtures/lexer/location.y
@@ -1,5 +1,5 @@
 /*
- * This is a valid　sample grammar file.
+ * This is a valid sample grammar file.
  * It works as simple calculator.
  */
 


### PR DESCRIPTION
ruby/ruby checks if C-sources are US-ASCII.
And Compilations failed with "invalid byte sequence in US-ASCII"
if Lrama codes include Non US-ASCII.

See:
* https://github.com/yui-knk/ruby/actions/runs/7675060037/job/20920736805
* https://github.com/yui-knk/ruby/actions/runs/7675060017/job/20920738516