### PR TITLE
Add metadata for rubygems.org

### DIFF
--- a/lrama.gemspec
+++ b/lrama.gemspec
@@ -16,6 +16,11 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
   end
+  spec.metadata = {
+    "bug_tracker_uri"   => "https://github.com/ruby/lrama/issues",
+    "changelog_uri"     => "https://github.com/ruby/lrama/releases",
+    "source_code_uri"   => "https://github.com/ruby/lrama"
+  }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This PR added [metadata](https://guides.rubygems.org/specification-reference/#metadata) for [rubygems.org](https://rubygems.org/gems/lrama)