### PR TITLE
Fix an issue in a user-defined parameterizing rule where the caller cannot access `$$` in the rule

### DIFF
--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -115,12 +115,12 @@ module Lrama
               @replaced_rhs << lhs_token
               parameterizing_rule_resolver.created_lhs_list << lhs_token
               parameterizing_rule.rhs_list.each do |r|
-                rule_builder = RuleBuilder.new(@rule_counter, @midrule_action_counter, i, lhs_tag: token.lhs_tag, skip_preprocess_references: true)
+                rule_builder = RuleBuilder.new(@rule_counter, @midrule_action_counter, lhs_tag: token.lhs_tag, skip_preprocess_references: true)
                 rule_builder.lhs = lhs_token
                 r.symbols.each { |sym| rule_builder.add_rhs(bindings.resolve_symbol(sym)) }
                 rule_builder.line = line
-                rule_builder.user_code = r.user_code
                 rule_builder.precedence_sym = r.precedence_sym
+                rule_builder.user_code = r.user_code
                 rule_builder.complete_input
                 rule_builder.setup_rules(parameterizing_rule_resolver)
                 @rule_builders_for_parameterizing_rules << rule_builder

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "integration" do
     it "prints messages corresponding to rules" do
       expected = <<~STR
         (2, 3)
-        pair even odd: 2
+        pair even odd: 5
         (1, 0)
         pair odd even: 1
       STR

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -606,7 +606,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -618,7 +617,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -638,7 +636,6 @@ RSpec.describe Lrama::Parser do
               rhs: [],
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -649,7 +646,6 @@ RSpec.describe Lrama::Parser do
               ],
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number_alias"),
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -702,7 +698,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -714,7 +709,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -734,7 +728,6 @@ RSpec.describe Lrama::Parser do
               rhs: [],
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -745,7 +738,6 @@ RSpec.describe Lrama::Parser do
               ],
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number_alias"),
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -792,7 +784,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 1,
               lineno: 21,
             ),
             Rule.new(
@@ -804,7 +795,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("bar"),
-              position_in_original_rule_rhs: 1,
               lineno: 21,
             ),
             Rule.new(
@@ -857,7 +847,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -870,7 +859,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -891,7 +879,6 @@ RSpec.describe Lrama::Parser do
               lhs_tag: T::Tag.new(s_value: "<i>"),
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -903,7 +890,6 @@ RSpec.describe Lrama::Parser do
               lhs_tag: T::Tag.new(s_value: "<i>"),
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number_alias"),
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -954,7 +940,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -967,7 +952,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -989,7 +973,6 @@ RSpec.describe Lrama::Parser do
               ],
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number_alias"),
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -1001,7 +984,6 @@ RSpec.describe Lrama::Parser do
               ],
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number_alias"),
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -1050,7 +1032,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -1063,7 +1044,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 20,
             ),
             Rule.new(
@@ -1083,7 +1063,6 @@ RSpec.describe Lrama::Parser do
               rhs: [],
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -1095,7 +1074,6 @@ RSpec.describe Lrama::Parser do
               ],
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number_alias"),
-              position_in_original_rule_rhs: 0,
               lineno: 23,
             ),
             Rule.new(
@@ -1144,7 +1122,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 19,
             ),
             Rule.new(
@@ -1158,7 +1135,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 19,
             ),
             Rule.new(
@@ -1208,7 +1184,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 19,
             ),
             Rule.new(
@@ -1220,7 +1195,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 19,
             ),
             Rule.new(
@@ -1234,7 +1208,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 19,
             ),
             Rule.new(
@@ -1246,7 +1219,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 19,
             ),
             Rule.new(
@@ -1258,7 +1230,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 19,
             ),
             Rule.new(
@@ -1307,7 +1278,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 25,
             ),
             Rule.new(
@@ -1317,7 +1287,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 25,
             ),
             Rule.new(
@@ -1329,7 +1298,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 25,
             ),
             Rule.new(
@@ -1357,8 +1325,7 @@ RSpec.describe Lrama::Parser do
             Sym.new(id: T::Ident.new(s_value: "program"), alias_name: nil, number: 8, tag: nil, term: false, token_id: 2, nullable: true),
             Sym.new(id: T::Ident.new(s_value: "multi_args_number_string"), alias_name: nil, number: 9, tag: nil, term: false, token_id: 3, nullable: false),
             Sym.new(id: T::Ident.new(s_value: "multi_args_number_number"), alias_name: nil, number: 10, tag: nil, term: false, token_id: 4, nullable: false),
-            Sym.new(id: T::Ident.new(s_value: "$@1"), alias_name: nil, number: 11, tag: nil, term: false, token_id: 5, nullable: true),
-            Sym.new(id: T::Ident.new(s_value: "pair_number_string"), alias_name: nil, number: 12, tag: nil, term: false, token_id: 6, nullable: false),
+            Sym.new(id: T::Ident.new(s_value: "pair_number_string"), alias_name: nil, number: 11, tag: nil, term: false, token_id: 5, nullable: false),
           ])
 
           expect(grammar.rules).to eq([
@@ -1382,7 +1349,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 36,
             ),
             Rule.new(
@@ -1395,7 +1361,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 36,
             ),
             Rule.new(
@@ -1419,7 +1384,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 37,
             ),
             Rule.new(
@@ -1432,7 +1396,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("string"),
-              position_in_original_rule_rhs: 0,
               lineno: 37,
             ),
             Rule.new(
@@ -1457,7 +1420,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 38,
             ),
             Rule.new(
@@ -1470,7 +1432,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 38,
             ),
             Rule.new(
@@ -1487,33 +1448,20 @@ RSpec.describe Lrama::Parser do
             ),
             Rule.new(
               id: 10,
-              lhs: grammar.find_symbol_by_s_value!("$@1"),
-              rhs: [],
-              lhs_tag: nil,
-              token_code: T::UserCode.new(s_value: " printf(\"(%d, %d)\\n\", $1, $2); "),
-              nullable: true,
-              precedence_sym: nil,
-              position_in_original_rule_rhs: 3,
-              lineno: 31,
-            ),
-            Rule.new(
-              id: 11,
               lhs: grammar.find_symbol_by_s_value!("pair_number_string"),
               rhs: [
                 grammar.find_symbol_by_s_value!("number"),
                 grammar.find_symbol_by_number!(5),
-                grammar.find_symbol_by_s_value!("string"),
-                grammar.find_symbol_by_s_value!("$@1")
+                grammar.find_symbol_by_s_value!("string")
               ],
               lhs_tag: nil,
-              token_code: nil,
+              token_code: T::UserCode.new(s_value: " printf(\"(%d, %d)\\n\", $1, $2); "),
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("string"),
-              position_in_original_rule_rhs: 0,
               lineno: 39,
             ),
             Rule.new(
-              id: 12,
+              id: 11,
               lhs: grammar.find_symbol_by_s_value!("program"),
               rhs: [
                 grammar.find_symbol_by_s_value!("pair_number_string"),
@@ -1563,7 +1511,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 42,
             ),
             Rule.new(
@@ -1573,7 +1520,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 42,
             ),
             Rule.new(
@@ -1583,7 +1529,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 42,
             ),
             Rule.new(
@@ -1595,7 +1540,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 42,
             ),
             Rule.new(
@@ -1607,7 +1551,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 42,
             ),
             Rule.new(
@@ -1619,7 +1562,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 42,
             ),
             Rule.new(
@@ -1640,7 +1582,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 43,
             ),
             Rule.new(
@@ -1650,7 +1591,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 43,
             ),
             Rule.new(
@@ -1662,7 +1602,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 43,
             ),
             Rule.new(
@@ -1674,7 +1613,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 43,
             ),
             Rule.new(
@@ -1684,7 +1622,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 43,
             ),
             Rule.new(
@@ -1696,7 +1633,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("string"),
-              position_in_original_rule_rhs: 0,
               lineno: 43,
             ),
             Rule.new(
@@ -1709,7 +1645,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 43,
             ),
             Rule.new(
@@ -1757,7 +1692,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 24,
             ),
             Rule.new(
@@ -1769,7 +1703,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: false,
               precedence_sym: grammar.find_symbol_by_s_value!("number"),
-              position_in_original_rule_rhs: 0,
               lineno: 24,
             ),
             Rule.new(
@@ -1781,7 +1714,6 @@ RSpec.describe Lrama::Parser do
               token_code: nil,
               nullable: true,
               precedence_sym: nil,
-              position_in_original_rule_rhs: 0,
               lineno: 24,
             ),
             Rule.new(


### PR DESCRIPTION
For example, if `printf("pair odd even:% d\n," $1); `was unable to access the pair side of` $$`with` $1`, fix this:
```
%rule pair(X, Y): X Y
  {
    $$ = $1 + $2;
    printf("(%d, %d)\n", $1, $2);
  }
  ;

stmt: pair(ODD, EVEN) <num> { printf("pair odd even: %d\n", $1); }
```