### PR TITLE
Add support for Parameterizing rules with zero parameters

### DIFF
--- a/lib/lrama/grammar/parameterizing_rule/resolver.rb
+++ b/lib/lrama/grammar/parameterizing_rule/resolver.rb
@@ -14,7 +14,13 @@ module Lrama
         end
 
         def find(token)
-          select_rules(token).last
+          rules = select_rules_by_name(token.rule_name)
+          select_rules_by_parameters_count(rules, token).last
+        end
+
+        def find!(token)
+          rules = select_rules_by_name!(token.rule_name)
+          select_rules_by_parameters_count!(rules, token).last
         end
 
         def created_lhs(lhs_s_value)
@@ -23,20 +29,27 @@ module Lrama
 
         private
 
-        def select_rules(token)
-          rules = select_rules_by_name(token.rule_name)
-          rules = rules.select { |rule| rule.required_parameters_count == token.args_count }
+        def select_rules_by_name(rule_name)
+          @rules.select { |rule| rule.name == rule_name }
+        end
+
+        def select_rules_by_parameters_count(rules, token)
+          rules.select { |rule| rule.required_parameters_count == token.args_count }
+        end
+
+        def select_rules_by_name!(rule_name)
+          rules = select_rules_by_name(rule_name)
           if rules.empty?
-            raise "Invalid number of arguments. `#{token.rule_name}`"
+            raise "Parameterizing rule does not exist. `#{rule_name}`"
           else
             rules
           end
         end
 
-        def select_rules_by_name(rule_name)
-          rules = @rules.select { |rule| rule.name == rule_name }
+        def select_rules_by_parameters_count!(rules, token)
+          rules = select_rules_by_parameters_count(rules, token)
           if rules.empty?
-            raise "Parameterizing rule does not exist. `#{rule_name}`"
+            raise "Invalid number of arguments. `#{token.rule_name}`"
           else
             rules
           end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -658,7 +658,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 529)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 534)
 
 include Lrama::Report::Duration
 
@@ -732,172 +732,176 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    96,    50,    97,   156,   155,    78,    50,    50,   156,   199,
-    78,    78,    50,    50,   199,    49,    78,   158,    69,     6,
-     3,     7,   158,   200,   210,   154,     8,    50,   200,    49,
-    40,   174,   175,   176,    47,    50,    46,    49,    53,    78,
-    74,    50,    53,    49,   159,    53,    81,    98,    56,   159,
-   201,   174,   175,   176,    94,   201,    22,    24,    25,    26,
+    97,    50,    98,   159,   165,    78,    50,    50,   166,   159,
+    78,    78,    50,   181,   166,     3,    78,   160,     8,   182,
+   183,   184,   168,   160,    50,   164,    49,    40,   168,    69,
+    50,     6,    49,     7,    78,    74,    46,    50,    50,    49,
+    49,    47,    81,    81,   161,    53,    50,    99,    49,   169,
+   161,    81,    50,    53,    49,   169,    22,    24,    25,    26,
     27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
-    37,    46,    50,    50,    49,    49,    91,    81,    81,    50,
-    50,    49,    49,    50,    81,    49,    57,    78,   184,    58,
-    59,    22,    24,    25,    26,    27,    28,    29,    30,    31,
-    32,    33,    34,    35,    36,    37,     9,    50,    60,    49,
-    13,    14,    15,    16,    17,    18,    61,    62,    19,    20,
+    37,    46,    50,    50,    49,    49,    92,    81,    50,    50,
+    49,    49,    78,   200,    50,    50,    49,    49,    78,   200,
+    53,    22,    24,    25,    26,    27,    28,    29,    30,    31,
+    32,    33,    34,    35,    36,    37,     9,    50,    56,    49,
+    13,    14,    15,    16,    17,    18,    46,    88,    19,    20,
     21,    22,    24,    25,    26,    27,    28,    29,    30,    31,
     32,    33,    34,    35,    36,    37,    38,    50,    50,    49,
-    49,    78,   184,    50,    50,    49,    49,    78,   184,    50,
-    50,    49,    49,    78,   184,    50,    50,    49,    49,    78,
-   184,    50,    50,    49,    49,    78,   184,    50,    50,    49,
+    49,    78,   200,    50,    50,    49,    49,    78,   200,    50,
+    50,    49,    49,    78,   200,    50,    50,    49,    49,    78,
+   200,    50,    50,    49,    49,    78,    78,    50,    50,    49,
     49,    78,    78,    50,    50,    49,    49,    78,    78,    50,
-    50,    49,    49,    78,    78,    50,    50,   190,    49,    78,
-    78,    50,    50,   190,    49,    78,    78,    50,    50,   190,
-    49,    78,    50,    50,    49,    49,   152,   203,   153,   204,
-   174,   175,   176,   219,   221,   204,   204,    63,    64,    65,
-    66,    87,    88,    92,    94,    99,    99,    99,   101,   107,
-   111,   112,   115,   115,   115,   115,   118,   121,   122,   124,
-   126,   127,   128,   129,   130,   133,   137,   138,   139,   142,
-   143,   144,   146,   161,   163,   164,   165,   166,   167,   168,
-   169,   142,   171,   179,   180,   189,   194,   195,   197,   202,
-   189,    94,   194,   216,   218,    94,   194,   224,    94 ]
+    50,    49,   204,    78,    78,    50,    50,   204,    49,    78,
+    78,    50,    50,   204,    49,    78,   182,   183,   184,    95,
+    50,    57,    49,   182,   183,   184,   162,   163,   213,   214,
+   218,   214,   225,   214,    58,    59,    60,    61,    62,    63,
+    64,    65,    66,    89,    93,    95,   100,   100,   100,   102,
+   108,   112,   113,   116,   116,   116,   116,   119,   120,   123,
+   124,   126,   128,   129,   130,   131,   132,   135,   140,   142,
+   143,   144,   147,   148,   149,   151,   157,   171,   173,   174,
+   175,   176,   177,   140,    95,   187,   188,   147,   190,   195,
+   196,   206,   140,   210,   211,   215,   157,   222,   210,   224,
+    95,    95,   210 ]
 
 racc_action_check = [
-    48,   141,    48,   141,   140,   141,   170,   188,   170,   188,
-   170,   188,   207,    32,   207,    32,   207,   141,    32,     2,
-     1,     2,   170,   188,   199,   140,     3,    14,   207,    14,
-     7,   199,   199,   199,    13,    33,     9,    33,    15,    33,
-    33,    34,    16,    34,   141,    17,    34,    48,    18,   170,
-   188,   157,   157,   157,   157,   207,     9,     9,     9,     9,
+    48,   139,    48,   139,   145,   139,   146,   178,   146,   178,
+   146,   178,   189,   159,   189,     1,   189,   139,     3,   159,
+   159,   159,   146,   178,    32,   145,    32,     7,   189,    32,
+    33,     2,    33,     2,    33,    33,     9,    34,    35,    34,
+    35,    13,    34,    35,   139,    15,    36,    48,    36,   146,
+   178,    36,    14,    16,    14,   189,     9,     9,     9,     9,
      9,     9,     9,     9,     9,     9,     9,     9,     9,     9,
-     9,    41,    35,    36,    35,    36,    41,    35,    36,    37,
-    68,    37,    68,   165,    37,   165,    19,   165,   165,    22,
-    24,    41,    41,    41,    41,    41,    41,    41,    41,    41,
-    41,    41,    41,    41,    41,    41,     4,    69,    25,    69,
-     4,     4,     4,     4,     4,     4,    26,    27,     4,     4,
+     9,    41,    37,    68,    37,    68,    41,    37,   175,    69,
+   175,    69,   175,   175,   176,    80,   176,    80,   176,   176,
+    17,    41,    41,    41,    41,    41,    41,    41,    41,    41,
+    41,    41,    41,    41,    41,    41,     4,    81,    18,    81,
+     4,     4,     4,     4,     4,     4,    38,    38,     4,     4,
      4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-     4,     4,     4,     4,     4,     4,     4,   166,    80,   166,
-    80,   166,   166,   167,    81,   167,    81,   167,   167,   181,
-   107,   181,   107,   181,   181,   185,   109,   185,   109,   185,
-   185,   186,   115,   186,   115,   186,   186,    73,    74,    73,
-    74,    73,    74,   112,   114,   112,   114,   112,   114,   134,
-   159,   134,   159,   134,   159,   171,   201,   171,   201,   171,
-   201,   202,   204,   202,   204,   202,   204,   210,   117,   210,
-   117,   210,   131,   135,   131,   135,   136,   191,   136,   191,
-   192,   192,   192,   213,   217,   213,   217,    28,    29,    30,
-    31,    38,    39,    44,    45,    52,    54,    55,    56,    67,
-    71,    72,    79,    84,    85,    86,    87,    93,    94,   100,
-   102,   103,   104,   105,   106,   110,   118,   119,   120,   121,
-   122,   123,   125,   145,   147,   148,   149,   150,   151,   152,
-   153,   154,   156,   160,   162,   168,   173,   177,   187,   190,
-   197,   198,   203,   206,   211,   216,   220,   222,   224 ]
+     4,     4,     4,     4,     4,     4,     4,   177,   108,   177,
+   108,   177,   177,   197,   110,   197,   110,   197,   197,   201,
+   116,   201,   116,   201,   201,   202,   118,   202,   118,   202,
+   202,    73,    74,    73,    74,    73,    74,   113,   115,   113,
+   115,   113,   115,   136,   161,   136,   161,   136,   161,   169,
+   181,   169,   181,   169,   181,   190,   214,   190,   214,   190,
+   214,   215,   133,   215,   133,   215,   167,   167,   167,   167,
+   137,    19,   137,   205,   205,   205,   141,   141,   203,   203,
+   208,   208,   221,   221,    22,    24,    25,    26,    27,    28,
+    29,    30,    31,    39,    44,    45,    52,    54,    55,    56,
+    67,    71,    72,    79,    84,    85,    86,    87,    88,    94,
+    95,   101,   103,   104,   105,   106,   107,   111,   119,   120,
+   121,   122,   123,   124,   125,   127,   138,   150,   152,   153,
+   154,   155,   156,   157,   158,   162,   163,   164,   166,   170,
+   172,   185,   187,   192,   193,   204,   207,   217,   218,   219,
+   222,   224,   227 ]
 
 racc_action_pointer = [
-   nil,    20,     9,    26,    97,   nil,   nil,    23,   nil,    32,
-   nil,   nil,   nil,    28,    24,    19,    23,    26,    43,    67,
-   nil,   nil,    70,   nil,    71,    89,    97,   112,   212,   213,
-   214,   215,    10,    32,    38,    69,    70,    76,   216,   220,
-   nil,    67,   nil,   nil,   200,   174,   nil,   nil,    -5,   nil,
-   nil,   nil,   206,   nil,   207,   208,   209,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   221,    77,   104,
-   nil,   224,   223,   164,   165,   nil,   nil,   nil,   nil,   224,
-   135,   141,   nil,   nil,   225,   226,   227,   196,   nil,   nil,
-   nil,   nil,   nil,   195,   233,   nil,   nil,   nil,   nil,   nil,
-   237,   nil,   238,   239,   240,   241,   242,   147,   nil,   153,
-   238,   nil,   170,   nil,   171,   159,   nil,   195,   241,   236,
-   246,   204,   199,   249,   nil,   250,   nil,   nil,   nil,   nil,
-   nil,   199,   nil,   nil,   176,   200,   165,   nil,   nil,   nil,
-   -19,    -2,   nil,   nil,   nil,   233,   nil,   234,   235,   236,
-   237,   238,   217,   255,   216,   nil,   222,     4,   nil,   177,
-   243,   nil,   244,   nil,   nil,    80,   134,   140,   220,   nil,
-     3,   182,   nil,   258,   nil,   nil,   nil,   265,   nil,   nil,
-   nil,   146,   nil,   nil,   nil,   152,   158,   224,     4,   nil,
-   229,   166,   163,   nil,   nil,   nil,   nil,   225,   221,   -16,
-   nil,   183,   188,   264,   189,   nil,   253,     9,   nil,   nil,
-   194,   272,   nil,   172,   nil,   nil,   225,   173,   nil,   nil,
-   268,   nil,   257,   nil,   228,   nil ]
+   nil,    15,    21,    18,    97,   nil,   nil,    20,   nil,    32,
+   nil,   nil,   nil,    35,    49,    26,    34,    71,   103,   182,
+   nil,   nil,   195,   nil,   196,   197,   198,   213,   214,   215,
+   216,   217,    21,    27,    34,    35,    43,    69,   112,   221,
+   nil,    67,   nil,   nil,   201,   175,   nil,   nil,    -5,   nil,
+   nil,   nil,   207,   nil,   208,   209,   210,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   222,    70,    76,
+   nil,   225,   224,   158,   159,   nil,   nil,   nil,   nil,   225,
+    82,   104,   nil,   nil,   226,   227,   228,   197,   197,   nil,
+   nil,   nil,   nil,   nil,   199,   235,   nil,   nil,   nil,   nil,
+   nil,   239,   nil,   240,   241,   242,   243,   244,   135,   nil,
+   141,   240,   nil,   164,   nil,   165,   147,   nil,   153,   203,
+   244,   239,   249,   207,   202,   252,   nil,   253,   nil,   nil,
+   nil,   nil,   nil,   189,   nil,   nil,   170,   197,   212,    -2,
+   nil,   164,   nil,   nil,   nil,   -19,     3,   nil,   nil,   nil,
+   237,   nil,   238,   239,   240,   241,   242,   218,   214,   -28,
+   nil,   171,   225,   261,   222,   nil,   227,   149,   nil,   176,
+   249,   nil,   250,   nil,   nil,    75,    81,   134,     4,   nil,
+   nil,   177,   nil,   nil,   nil,   269,   nil,   227,   nil,     9,
+   182,   nil,   265,   272,   nil,   nil,   nil,   140,   nil,   nil,
+   nil,   146,   152,   166,   234,   156,   nil,   232,   168,   nil,
+   nil,   nil,   nil,   nil,   183,   188,   nil,   257,   270,   259,
+   nil,   170,   230,   nil,   231,   nil,   nil,   274,   nil ]
 
 racc_action_default = [
-    -2,  -136,    -8,  -136,  -136,    -3,    -4,  -136,   226,  -136,
-    -9,   -10,   -11,  -136,  -136,  -136,  -136,  -136,  -136,  -136,
-   -23,   -24,  -136,   -28,  -136,  -136,  -136,  -136,  -136,  -136,
-  -136,  -136,  -136,  -136,  -136,  -136,  -136,  -136,  -136,  -136,
-    -7,  -121,   -94,   -96,  -136,  -118,  -120,   -12,  -125,   -92,
-   -93,  -124,   -14,   -83,   -15,   -16,  -136,   -20,   -25,   -29,
-   -32,   -35,   -38,   -39,   -40,   -41,   -42,   -43,   -49,  -136,
-   -52,   -69,   -44,   -73,  -136,   -76,   -78,   -79,  -133,   -45,
-   -86,  -136,   -89,   -91,   -46,   -47,   -48,  -136,    -5,    -1,
-   -95,  -122,   -97,  -136,  -136,   -13,  -126,  -127,  -128,   -80,
-  -136,   -17,  -136,  -136,  -136,  -136,  -136,  -136,   -53,   -50,
-   -71,   -70,  -136,   -77,   -74,  -136,   -90,   -87,  -136,  -136,
-  -136,  -102,  -136,  -136,   -84,  -136,   -21,   -26,   -30,   -33,
-   -36,   -51,   -54,   -72,   -75,   -88,  -136,   -56,    -6,  -123,
-   -98,   -99,  -103,  -119,   -81,  -136,   -18,  -136,  -136,  -136,
-  -136,  -136,  -136,  -136,  -102,  -101,   -92,  -118,  -107,  -136,
-  -136,   -85,  -136,   -22,   -27,  -136,  -136,  -136,   -60,   -57,
-  -100,  -136,  -104,  -134,  -111,  -112,  -113,  -136,  -110,   -82,
-   -19,   -31,  -129,  -131,  -132,   -34,   -37,   -55,   -58,   -61,
-   -92,  -136,  -114,  -105,  -135,  -108,  -130,   -60,  -118,   -92,
-   -65,  -136,  -136,  -134,  -136,  -116,  -136,   -59,   -62,   -63,
-  -136,  -136,   -68,  -136,  -106,  -115,  -118,  -136,   -66,  -117,
-  -134,   -64,  -136,  -109,  -118,   -67 ]
+    -2,  -137,    -8,  -137,  -137,    -3,    -4,  -137,   229,  -137,
+    -9,   -10,   -11,  -137,  -137,  -137,  -137,  -137,  -137,  -137,
+   -23,   -24,  -137,   -28,  -137,  -137,  -137,  -137,  -137,  -137,
+  -137,  -137,  -137,  -137,  -137,  -137,  -137,  -137,  -137,  -137,
+    -7,  -122,   -95,   -97,  -137,  -119,  -121,   -12,  -126,   -93,
+   -94,  -125,   -14,   -84,   -15,   -16,  -137,   -20,   -25,   -29,
+   -32,   -35,   -38,   -39,   -40,   -41,   -42,   -43,   -49,  -137,
+   -52,   -70,   -44,   -74,  -137,   -77,   -79,   -80,  -134,   -45,
+   -87,  -137,   -90,   -92,   -46,   -47,   -48,  -137,  -137,    -5,
+    -1,   -96,  -123,   -98,  -137,  -137,   -13,  -127,  -128,  -129,
+   -81,  -137,   -17,  -137,  -137,  -137,  -137,  -137,  -137,   -53,
+   -50,   -72,   -71,  -137,   -78,   -75,  -137,   -91,   -88,   -61,
+  -137,  -137,  -137,  -103,  -137,  -137,   -85,  -137,   -21,   -26,
+   -30,   -33,   -36,   -51,   -54,   -73,   -76,   -89,   -55,   -59,
+   -62,  -137,   -57,    -6,  -124,   -99,  -100,  -104,  -120,   -82,
+  -137,   -18,  -137,  -137,  -137,  -137,  -137,   -61,  -119,   -93,
+   -66,  -137,  -137,  -137,  -103,  -102,   -93,  -119,  -108,  -137,
+  -137,   -86,  -137,   -22,   -27,  -137,  -137,  -137,   -60,   -63,
+   -64,  -137,  -112,  -113,  -114,  -137,   -69,   -61,   -58,  -101,
+  -137,  -105,  -135,  -137,  -111,   -83,   -19,   -31,  -130,  -132,
+  -133,   -34,   -37,  -137,   -93,  -115,   -67,   -56,  -137,  -106,
+  -136,  -109,  -131,   -65,  -137,  -137,  -117,  -137,  -135,  -137,
+  -116,  -137,  -119,  -107,  -119,  -118,   -68,  -135,  -110 ]
 
 racc_goto_table = [
-    93,    75,    51,    68,    73,   193,   116,   108,   191,   173,
-   196,     1,   117,     2,   196,   196,   141,     4,    42,    41,
-    71,    89,    83,    83,    83,    83,   188,    79,    84,    85,
-    86,    52,    54,    55,     5,   214,   181,   185,   186,   213,
-   109,   113,    75,   116,   205,   114,   135,   217,   108,   170,
-    90,   209,   223,    39,   119,   207,    71,    71,    10,    11,
-    12,   116,    48,    95,   125,   162,   102,   147,    83,    83,
-   108,   103,   148,   104,   149,   105,   150,   106,   131,   151,
-    75,    67,   113,   134,    72,   110,   132,   136,   187,   211,
-   222,   123,   160,   100,   145,    71,   140,    71,   177,   206,
-   120,   nil,   113,    83,   nil,    83,   nil,   nil,   nil,   157,
-   nil,   nil,   172,   nil,   nil,   nil,   nil,   nil,   nil,    71,
-   nil,   nil,   nil,    83,   nil,   nil,   nil,   178,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   157,   192,
+    75,    94,    68,    51,    73,   138,   109,   180,   117,   146,
+   203,    42,   118,   212,     1,   192,   209,   212,   212,   208,
+     2,    71,     4,    83,    83,    83,    83,    79,    84,    85,
+    86,    52,    54,    55,   197,   201,   202,    41,    90,   110,
+   114,    75,   223,    91,   221,   115,   117,   137,   109,     5,
+   189,   228,    39,   216,   121,    10,    11,    71,    71,    12,
+    48,    96,   127,   172,   103,   117,   152,   104,   153,    83,
+    83,   109,   105,   207,   154,   106,   155,   107,   133,   156,
+    75,    67,   114,    72,   136,   111,   134,    87,   141,   178,
+   185,   217,   125,   170,   101,   150,   145,    71,   193,    71,
+   219,   122,   nil,   114,   nil,    83,   158,    83,   nil,   nil,
+   nil,   nil,   nil,   167,   179,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    71,   191,   nil,   nil,    83,   nil,   186,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   194,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   158,   nil,   nil,   205,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   167,   205,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   208,   nil,   nil,   198,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   212,
-   192,   220,   215,   nil,   nil,   198,   nil,   nil,   192,   225 ]
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   226,   nil,
+   227,   220,   205 ]
 
 racc_goto_check = [
-    41,    40,    34,    32,    46,    59,    53,    33,    43,    42,
-    63,     1,    52,     2,    63,    63,    58,     3,    54,     4,
-    34,     5,    34,    34,    34,    34,    39,    31,    31,    31,
-    31,    14,    14,    14,     6,    59,    20,    20,    20,    43,
-    32,    40,    40,    53,    42,    46,    52,    43,    33,    58,
-    54,    42,    59,     7,     8,    39,    34,    34,     9,    10,
-    11,    53,    12,    13,    15,    16,    17,    18,    34,    34,
-    33,    21,    22,    23,    24,    25,    26,    27,    32,    28,
-    40,    29,    40,    46,    30,    35,    36,    37,    38,    44,
-    45,    48,    49,    50,    51,    34,    57,    34,    60,    61,
-    62,   nil,    40,    34,   nil,    34,   nil,   nil,   nil,    40,
-   nil,   nil,    41,   nil,   nil,   nil,   nil,   nil,   nil,    34,
-   nil,   nil,   nil,    34,   nil,   nil,   nil,    40,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    40,    40,
+    41,    42,    32,    34,    47,    38,    33,    43,    54,    58,
+    44,    55,    53,    63,     1,    43,    59,    63,    63,    44,
+     2,    34,     3,    34,    34,    34,    34,    31,    31,    31,
+    31,    14,    14,    14,    20,    20,    20,     4,     5,    32,
+    41,    41,    59,    55,    44,    47,    54,    53,    33,     6,
+    58,    59,     7,    43,     8,     9,    10,    34,    34,    11,
+    12,    13,    15,    16,    17,    54,    18,    21,    22,    34,
+    34,    33,    23,    38,    24,    25,    26,    27,    32,    28,
+    41,    29,    41,    30,    47,    35,    36,    37,    39,    40,
+    45,    46,    49,    50,    51,    52,    57,    34,    60,    34,
+    61,    62,   nil,    41,   nil,    34,    41,    34,   nil,   nil,
+   nil,   nil,   nil,    41,    42,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    34,    42,   nil,   nil,    34,   nil,    41,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    41,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,    41,   nil,   nil,    41,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    41,    41,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,    41,   nil,   nil,    40,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    40,
-    40,    41,    40,   nil,   nil,    40,   nil,   nil,    40,    41 ]
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    42,   nil,
+    42,    41,    41 ]
 
 racc_goto_pointer = [
-   nil,    11,    13,    15,    10,   -20,    32,    47,   -34,    54,
-    55,    56,    48,    15,    16,   -37,   -81,     9,   -59,   nil,
-  -129,    13,   -55,    14,   -54,    15,   -53,    16,   -51,    49,
-    51,    -7,   -29,   -61,   -12,    14,   -24,   -31,   -80,  -142,
-   -32,   -45,  -148,  -163,  -111,  -128,   -29,   nil,    -8,   -52,
-    40,   -30,   -69,   -74,     9,   nil,   nil,   -25,  -105,  -168,
-   -60,   -96,     9,  -171 ]
+   nil,    14,    20,    20,    28,    -3,    47,    46,   -35,    51,
+    52,    55,    46,    13,    16,   -40,   -88,     7,   -62,   nil,
+  -141,     9,   -61,    13,   -56,    15,   -55,    16,   -53,    49,
+    50,    -7,   -30,   -62,   -11,    14,   -25,    49,  -114,   -32,
+   -68,   -33,   -44,  -152,  -171,   -70,  -115,   -29,   nil,    -8,
+   -56,    41,   -31,   -69,   -72,     2,   nil,   -27,  -114,  -176,
+   -70,  -111,     9,  -184 ]
 
 racc_goto_default = [
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
     44,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    23,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,    70,    76,   nil,   nil,   nil,   nil,   nil,
-   183,   nil,   nil,   nil,   nil,   nil,   nil,    77,   nil,   nil,
-   nil,   nil,    80,    82,   nil,    43,    45,   nil,   nil,   nil,
-   nil,   nil,   nil,   182 ]
+   nil,   nil,   nil,    70,    76,   nil,   nil,    45,   nil,   nil,
+   139,   199,   nil,   nil,   nil,   nil,   nil,   nil,    77,   nil,
+   nil,   nil,   nil,    80,    82,   nil,    43,   nil,   nil,   nil,
+   nil,   nil,   nil,   198 ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -955,91 +959,92 @@ racc_reduce_table = [
   1, 85, :_reduce_52,
   2, 85, :_reduce_53,
   3, 86, :_reduce_54,
-  7, 64, :_reduce_55,
-  1, 90, :_reduce_56,
-  3, 90, :_reduce_57,
-  1, 91, :_reduce_58,
-  3, 91, :_reduce_59,
-  0, 92, :_reduce_60,
-  1, 92, :_reduce_61,
-  3, 92, :_reduce_62,
-  3, 92, :_reduce_63,
-  5, 92, :_reduce_64,
-  0, 97, :_reduce_65,
+  4, 64, :_reduce_55,
+  7, 64, :_reduce_56,
+  1, 92, :_reduce_57,
+  3, 92, :_reduce_58,
+  1, 91, :_reduce_59,
+  3, 91, :_reduce_60,
+  0, 93, :_reduce_61,
+  1, 93, :_reduce_62,
+  3, 93, :_reduce_63,
+  3, 93, :_reduce_64,
+  5, 93, :_reduce_65,
   0, 98, :_reduce_66,
-  7, 92, :_reduce_67,
-  3, 92, :_reduce_68,
+  0, 99, :_reduce_67,
+  7, 93, :_reduce_68,
+  3, 93, :_reduce_69,
   0, 88, :_reduce_none,
   1, 88, :_reduce_none,
   0, 89, :_reduce_none,
   1, 89, :_reduce_none,
-  1, 83, :_reduce_73,
-  2, 83, :_reduce_74,
-  3, 83, :_reduce_75,
-  1, 99, :_reduce_76,
-  2, 99, :_reduce_77,
-  1, 93, :_reduce_none,
-  1, 93, :_reduce_none,
-  0, 101, :_reduce_80,
+  1, 83, :_reduce_74,
+  2, 83, :_reduce_75,
+  3, 83, :_reduce_76,
+  1, 100, :_reduce_77,
+  2, 100, :_reduce_78,
+  1, 94, :_reduce_none,
+  1, 94, :_reduce_none,
   0, 102, :_reduce_81,
-  6, 67, :_reduce_82,
-  0, 103, :_reduce_83,
+  0, 103, :_reduce_82,
+  6, 67, :_reduce_83,
   0, 104, :_reduce_84,
-  5, 67, :_reduce_85,
-  1, 84, :_reduce_86,
-  2, 84, :_reduce_87,
-  3, 84, :_reduce_88,
-  1, 105, :_reduce_89,
-  2, 105, :_reduce_90,
-  1, 106, :_reduce_none,
-  1, 87, :_reduce_92,
+  0, 105, :_reduce_85,
+  5, 67, :_reduce_86,
+  1, 84, :_reduce_87,
+  2, 84, :_reduce_88,
+  3, 84, :_reduce_89,
+  1, 106, :_reduce_90,
+  2, 106, :_reduce_91,
+  1, 107, :_reduce_none,
   1, 87, :_reduce_93,
+  1, 87, :_reduce_94,
   1, 57, :_reduce_none,
   2, 57, :_reduce_none,
-  1, 107, :_reduce_none,
-  2, 107, :_reduce_none,
-  4, 108, :_reduce_98,
-  1, 110, :_reduce_99,
-  3, 110, :_reduce_100,
+  1, 108, :_reduce_none,
+  2, 108, :_reduce_none,
+  4, 109, :_reduce_99,
+  1, 110, :_reduce_100,
+  3, 110, :_reduce_101,
   2, 110, :_reduce_none,
-  0, 111, :_reduce_102,
-  1, 111, :_reduce_103,
-  3, 111, :_reduce_104,
-  4, 111, :_reduce_105,
-  6, 111, :_reduce_106,
-  0, 113, :_reduce_107,
-  0, 114, :_reduce_108,
-  8, 111, :_reduce_109,
-  3, 111, :_reduce_110,
-  1, 95, :_reduce_111,
-  1, 95, :_reduce_112,
-  1, 95, :_reduce_113,
+  0, 111, :_reduce_103,
+  1, 111, :_reduce_104,
+  3, 111, :_reduce_105,
+  4, 111, :_reduce_106,
+  6, 111, :_reduce_107,
+  0, 113, :_reduce_108,
+  0, 114, :_reduce_109,
+  8, 111, :_reduce_110,
+  3, 111, :_reduce_111,
+  1, 96, :_reduce_112,
+  1, 96, :_reduce_113,
   1, 96, :_reduce_114,
-  3, 96, :_reduce_115,
-  2, 96, :_reduce_116,
-  4, 96, :_reduce_117,
-  0, 94, :_reduce_none,
-  3, 94, :_reduce_119,
-  1, 109, :_reduce_none,
+  1, 97, :_reduce_115,
+  3, 97, :_reduce_116,
+  2, 97, :_reduce_117,
+  4, 97, :_reduce_118,
+  0, 95, :_reduce_none,
+  3, 95, :_reduce_120,
+  1, 90, :_reduce_none,
   0, 58, :_reduce_none,
-  0, 115, :_reduce_122,
-  3, 58, :_reduce_123,
+  0, 115, :_reduce_123,
+  3, 58, :_reduce_124,
   1, 65, :_reduce_none,
   0, 66, :_reduce_none,
   1, 66, :_reduce_none,
   1, 66, :_reduce_none,
   1, 66, :_reduce_none,
-  1, 73, :_reduce_129,
-  2, 73, :_reduce_130,
+  1, 73, :_reduce_130,
+  2, 73, :_reduce_131,
   1, 116, :_reduce_none,
   1, 116, :_reduce_none,
-  1, 100, :_reduce_133,
+  1, 101, :_reduce_134,
   0, 112, :_reduce_none,
   1, 112, :_reduce_none ]
 
-racc_reduce_n = 136
+racc_reduce_n = 137
 
-racc_shift_n = 226
+racc_shift_n = 229
 
 racc_token_table = {
   false => 0,
@@ -1082,9 +1087,9 @@ racc_token_table = {
   "%precedence" => 37,
   "%nonassoc" => 38,
   "%rule" => 39,
-  "(" => 40,
-  ")" => 41,
-  ":" => 42,
+  ":" => 40,
+  "(" => 41,
+  ")" => 42,
   "," => 43,
   "|" => 44,
   "%empty" => 45,
@@ -1158,9 +1163,9 @@ Racc_token_to_s_table = [
   "\"%precedence\"",
   "\"%nonassoc\"",
   "\"%rule\"",
+  "\":\"",
   "\"(\"",
   "\")\"",
-  "\":\"",
   "\",\"",
   "\"|\"",
   "\"%empty\"",
@@ -1208,8 +1213,9 @@ Racc_token_to_s_table = [
   "id",
   "int_opt",
   "alias",
-  "rule_args",
+  "id_colon",
   "rule_rhs_list",
+  "rule_args",
   "rule_rhs",
   "symbol",
   "named_ref_opt",
@@ -1227,7 +1233,6 @@ Racc_token_to_s_table = [
   "token_declaration_for_precedence",
   "rules_or_grammar_declaration",
   "rules",
-  "id_colon",
   "rhs_list",
   "rhs",
   "tag_opt",
@@ -1653,6 +1658,15 @@ module_eval(<<'.,.,', 'parser.y', 231)
 
 module_eval(<<'.,.,', 'parser.y', 235)
   def _reduce_55(val, _values, result)
+                            rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, [], val[3])
+                        @grammar.add_parameterizing_rule(rule)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 240)
+  def _reduce_56(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[6])
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1660,22 +1674,22 @@ module_eval(<<'.,.,', 'parser.y', 235)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 239)
-  def _reduce_56(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 244)
+  def _reduce_57(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 240)
-  def _reduce_57(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 245)
+  def _reduce_58(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 244)
-  def _reduce_58(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 249)
+  def _reduce_59(val, _values, result)
                       builder = val[0]
                   result = [builder]
 
@@ -1683,19 +1697,10 @@ module_eval(<<'.,.,', 'parser.y', 244)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 249)
-  def _reduce_59(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 254)
+  def _reduce_60(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 255)
-  def _reduce_60(val, _values, result)
-                  reset_precs
-              result = Grammar::ParameterizingRule::Rhs.new
 
     result
   end
@@ -1712,6 +1717,15 @@ module_eval(<<'.,.,', 'parser.y', 260)
 
 module_eval(<<'.,.,', 'parser.y', 265)
   def _reduce_62(val, _values, result)
+                  reset_precs
+              result = Grammar::ParameterizingRule::Rhs.new
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 270)
+  def _reduce_63(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1722,8 +1736,8 @@ module_eval(<<'.,.,', 'parser.y', 265)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 273)
-  def _reduce_63(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 278)
+  def _reduce_64(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1732,8 +1746,8 @@ module_eval(<<'.,.,', 'parser.y', 273)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 279)
-  def _reduce_64(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 284)
+  def _reduce_65(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3])
                 result = builder
@@ -1742,8 +1756,8 @@ module_eval(<<'.,.,', 'parser.y', 279)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 285)
-  def _reduce_65(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 290)
+  def _reduce_66(val, _values, result)
                   if @prec_seen
                 on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                 @code_after_prec = true
@@ -1754,16 +1768,16 @@ module_eval(<<'.,.,', 'parser.y', 285)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 293)
-  def _reduce_66(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 298)
+  def _reduce_67(val, _values, result)
                   end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 297)
-  def _reduce_67(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 302)
+  def _reduce_68(val, _values, result)
                   user_code = val[3]
               user_code.alias_name = val[6]
               builder = val[0]
@@ -1774,8 +1788,8 @@ module_eval(<<'.,.,', 'parser.y', 297)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 305)
-  def _reduce_68(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 310)
+  def _reduce_69(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1786,99 +1800,91 @@ module_eval(<<'.,.,', 'parser.y', 305)
   end
 .,.,
 
-# reduce 69 omitted
-
 # reduce 70 omitted
 
 # reduce 71 omitted
 
 # reduce 72 omitted
 
-module_eval(<<'.,.,', 'parser.y', 320)
-  def _reduce_73(val, _values, result)
+# reduce 73 omitted
+
+module_eval(<<'.,.,', 'parser.y', 325)
+  def _reduce_74(val, _values, result)
                                result = [{tag: nil, tokens: val[0]}]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 324)
-  def _reduce_74(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 329)
+  def _reduce_75(val, _values, result)
                                result = [{tag: val[0], tokens: val[1]}]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 328)
-  def _reduce_75(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 333)
+  def _reduce_76(val, _values, result)
                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 331)
-  def _reduce_76(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 336)
+  def _reduce_77(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 332)
-  def _reduce_77(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 337)
+  def _reduce_78(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 78 omitted
-
 # reduce 79 omitted
 
-module_eval(<<'.,.,', 'parser.y', 339)
-  def _reduce_80(val, _values, result)
+# reduce 80 omitted
+
+module_eval(<<'.,.,', 'parser.y', 344)
+  def _reduce_81(val, _values, result)
                   begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 343)
-  def _reduce_81(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 348)
+  def _reduce_82(val, _values, result)
                   end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 347)
-  def _reduce_82(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 352)
+  def _reduce_83(val, _values, result)
                   result = val[0].append(val[3])
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 351)
-  def _reduce_83(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 356)
+  def _reduce_84(val, _values, result)
                   begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 355)
-  def _reduce_84(val, _values, result)
-                  end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 359)
+module_eval(<<'.,.,', 'parser.y', 360)
   def _reduce_85(val, _values, result)
-                  result = [val[2]]
+                  end_c_declaration
 
     result
   end
@@ -1886,59 +1892,65 @@ module_eval(<<'.,.,', 'parser.y', 359)
 
 module_eval(<<'.,.,', 'parser.y', 364)
   def _reduce_86(val, _values, result)
+                  result = [val[2]]
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 369)
+  def _reduce_87(val, _values, result)
                                              result = [{tag: nil, tokens: val[0]}]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 368)
-  def _reduce_87(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 373)
+  def _reduce_88(val, _values, result)
                                              result = [{tag: val[0], tokens: val[1]}]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 372)
-  def _reduce_88(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 377)
+  def _reduce_89(val, _values, result)
                                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 375)
-  def _reduce_89(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 380)
+  def _reduce_90(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 376)
-  def _reduce_90(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 381)
+  def _reduce_91(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 91 omitted
+# reduce 92 omitted
 
-module_eval(<<'.,.,', 'parser.y', 380)
-  def _reduce_92(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 385)
+  def _reduce_93(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 381)
-  def _reduce_93(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 386)
+  def _reduce_94(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
-
-# reduce 94 omitted
 
 # reduce 95 omitted
 
@@ -1946,8 +1958,10 @@ module_eval(<<'.,.,', 'parser.y', 381)
 
 # reduce 97 omitted
 
-module_eval(<<'.,.,', 'parser.y', 391)
-  def _reduce_98(val, _values, result)
+# reduce 98 omitted
+
+module_eval(<<'.,.,', 'parser.y', 396)
+  def _reduce_99(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -1960,8 +1974,8 @@ module_eval(<<'.,.,', 'parser.y', 391)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 402)
-  def _reduce_99(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 407)
+  def _reduce_100(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -1972,8 +1986,8 @@ module_eval(<<'.,.,', 'parser.y', 402)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 410)
-  def _reduce_100(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 415)
+  def _reduce_101(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -1984,16 +1998,7 @@ module_eval(<<'.,.,', 'parser.y', 410)
   end
 .,.,
 
-# reduce 101 omitted
-
-module_eval(<<'.,.,', 'parser.y', 420)
-  def _reduce_102(val, _values, result)
-               reset_precs
-           result = Grammar::RuleBuilder.new(@rule_counter, @midrule_action_counter)
-
-    result
-  end
-.,.,
+# reduce 102 omitted
 
 module_eval(<<'.,.,', 'parser.y', 425)
   def _reduce_103(val, _values, result)
@@ -2006,6 +2011,15 @@ module_eval(<<'.,.,', 'parser.y', 425)
 
 module_eval(<<'.,.,', 'parser.y', 430)
   def _reduce_104(val, _values, result)
+               reset_precs
+           result = Grammar::RuleBuilder.new(@rule_counter, @midrule_action_counter)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 435)
+  def _reduce_105(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -2016,8 +2030,8 @@ module_eval(<<'.,.,', 'parser.y', 430)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 438)
-  def _reduce_105(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 443)
+  def _reduce_106(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]], lhs_tag: val[3])
            builder = val[0]
            builder.add_rhs(token)
@@ -2028,8 +2042,8 @@ module_eval(<<'.,.,', 'parser.y', 438)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 446)
-  def _reduce_106(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 451)
+  def _reduce_107(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
            builder = val[0]
            builder.add_rhs(token)
@@ -2040,8 +2054,8 @@ module_eval(<<'.,.,', 'parser.y', 446)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 454)
-  def _reduce_107(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 459)
+  def _reduce_108(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
              @code_after_prec = true
@@ -2052,16 +2066,16 @@ module_eval(<<'.,.,', 'parser.y', 454)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 462)
-  def _reduce_108(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 467)
+  def _reduce_109(val, _values, result)
                end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 466)
-  def _reduce_109(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 471)
+  def _reduce_110(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
            user_code.tag = val[7]
@@ -2073,8 +2087,8 @@ module_eval(<<'.,.,', 'parser.y', 466)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 475)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 480)
+  def _reduce_111(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2085,70 +2099,70 @@ module_eval(<<'.,.,', 'parser.y', 475)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 482)
-  def _reduce_111(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 487)
+  def _reduce_112(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 483)
-  def _reduce_112(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 488)
+  def _reduce_113(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 484)
-  def _reduce_113(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 489)
+  def _reduce_114(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 486)
-  def _reduce_114(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 491)
+  def _reduce_115(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 487)
-  def _reduce_115(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 492)
+  def _reduce_116(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 488)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 493)
+  def _reduce_117(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 489)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 494)
+  def _reduce_118(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-# reduce 118 omitted
+# reduce 119 omitted
 
-module_eval(<<'.,.,', 'parser.y', 492)
-  def _reduce_119(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 497)
+  def _reduce_120(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-# reduce 120 omitted
-
 # reduce 121 omitted
 
-module_eval(<<'.,.,', 'parser.y', 499)
-  def _reduce_122(val, _values, result)
+# reduce 122 omitted
+
+module_eval(<<'.,.,', 'parser.y', 504)
+  def _reduce_123(val, _values, result)
                         begin_c_declaration('\Z')
                     @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2156,16 +2170,14 @@ module_eval(<<'.,.,', 'parser.y', 499)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 504)
-  def _reduce_123(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 509)
+  def _reduce_124(val, _values, result)
                         end_c_declaration
                     @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
-
-# reduce 124 omitted
 
 # reduce 125 omitted
 
@@ -2175,34 +2187,36 @@ module_eval(<<'.,.,', 'parser.y', 504)
 
 # reduce 128 omitted
 
-module_eval(<<'.,.,', 'parser.y', 515)
-  def _reduce_129(val, _values, result)
+# reduce 129 omitted
+
+module_eval(<<'.,.,', 'parser.y', 520)
+  def _reduce_130(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 516)
-  def _reduce_130(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 521)
+  def _reduce_131(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 131 omitted
-
 # reduce 132 omitted
 
-module_eval(<<'.,.,', 'parser.y', 521)
-  def _reduce_133(val, _values, result)
+# reduce 133 omitted
+
+module_eval(<<'.,.,', 'parser.y', 526)
+  def _reduce_134(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end
 .,.,
 
-# reduce 134 omitted
-
 # reduce 135 omitted
+
+# reduce 136 omitted
 
 def _reduce_none(val, _values, result)
   val[0]

--- a/parser.y
+++ b/parser.y
@@ -231,7 +231,12 @@ rule
 
   token_declaration: id int_opt alias { result = val }
 
-  rule_declaration: "%rule" IDENTIFIER "(" rule_args ")" ":" rule_rhs_list
+  rule_declaration: "%rule" id_colon ":" rule_rhs_list
+                      {
+                        rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, [], val[3])
+                        @grammar.add_parameterizing_rule(rule)
+                      }
+                  | "%rule" IDENTIFIER "(" rule_args ")" ":" rule_rhs_list
                       {
                         rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[6])
                         @grammar.add_parameterizing_rule(rule)

--- a/sig/lrama/grammar/parameterizing_rule/resolver.rbs
+++ b/sig/lrama/grammar/parameterizing_rule/resolver.rbs
@@ -9,12 +9,15 @@ module Lrama
         def initialize: () -> void
         def add_parameterizing_rule: (Grammar::ParameterizingRule::Rule rule) -> void
         def find: (Lexer::Token::InstantiateRule token) -> Grammar::ParameterizingRule::Rule?
+        def find!: (Lexer::Token::InstantiateRule token) -> Grammar::ParameterizingRule::Rule?
         def created_lhs: (String lhs_s_value) -> Lexer::Token?
 
         private
 
-        def select_rules: (Lexer::Token::InstantiateRule token) -> Array[Grammar::ParameterizingRule::Rule]
         def select_rules_by_name: (String rule_name) -> Array[Grammar::ParameterizingRule::Rule]
+        def select_rules_by_name!: (String rule_name) -> Array[Grammar::ParameterizingRule::Rule]
+        def select_rules_by_parameters_count: (Array[Grammar::ParameterizingRule::Rule] rules, Lexer::Token::InstantiateRule token) -> Array[Grammar::ParameterizingRule::Rule]
+        def select_rules_by_parameters_count!: (Array[Grammar::ParameterizingRule::Rule] rules, Lexer::Token::InstantiateRule token) -> Array[Grammar::ParameterizingRule::Rule]
       end
     end
   end

--- a/sig/lrama/grammar/rule_builder.rbs
+++ b/sig/lrama/grammar/rule_builder.rbs
@@ -35,6 +35,7 @@ module Lrama
       def preprocess_references: () -> void
       def build_rules: () -> void
       def process_rhs: (Grammar::ParameterizingRule::Resolver parameterizing_rule_resolver) -> void
+      def resolve_parameterizing_rule: (Grammar::ParameterizingRule::Resolver parameterizing_rule_resolver, Grammar::ParameterizingRule::Rule parameterizing_rule, Lexer::Token::InstantiateRule parameterizing_rule) -> void
       def lhs_s_value: (Lexer::Token::InstantiateRule token, Grammar::Binding bindings) -> String
       def numberize_references: () -> void
       def flush_user_code: () -> void

--- a/spec/fixtures/parameterizing_rules/user_defined_without_args.y
+++ b/spec/fixtures/parameterizing_rules/user_defined_without_args.y
@@ -1,0 +1,39 @@
+/*
+ * This is comment for this file.
+ */
+
+%{
+// Prologue
+static int yylex(YYSTYPE *val, YYLTYPE *loc);
+static int yyerror(YYLTYPE *loc, const char *str);
+%}
+
+%union {
+    int i;
+}
+
+%token <i> number
+
+%rule foo: /* empty */ { printf("empty\n"); }
+         ;
+
+%%
+
+program         : foo number
+                ;
+
+%%
+
+static int yylex(YYSTYPE *yylval, YYLTYPE *loc)
+{
+  return 0;
+}
+
+static int yyerror(YYLTYPE *loc, const char *str)
+{
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+}

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1882,6 +1882,54 @@ RSpec.describe Lrama::Parser do
         end
       end
 
+      context "when user defined without arguments" do
+        let(:path) { "parameterizing_rules/user_defined_without_args.y" }
+
+        it "expands parameterizing rules" do
+          expect(grammar.nterms.sort_by(&:number)).to match_symbols([
+            Sym.new(id: T::Ident.new(s_value: "$accept"), alias_name: nil, number: 4, tag: nil, term: false, token_id: 0, nullable: false),
+            Sym.new(id: T::Ident.new(s_value: "foo_"), alias_name: nil, number: 5, tag: nil, term: false, token_id: 1, nullable: true),
+            Sym.new(id: T::Ident.new(s_value: "program"), alias_name: nil, number: 6, tag: nil, term: false, token_id: 2, nullable: false)
+          ])
+
+          expect(grammar.rules).to eq([
+            Rule.new(
+              id: 0,
+              lhs: grammar.find_symbol_by_s_value!("$accept"),
+              rhs: [
+                grammar.find_symbol_by_s_value!("program"),
+                grammar.find_symbol_by_s_value!("YYEOF"),
+              ],
+              token_code: nil,
+              nullable: false,
+              precedence_sym: grammar.find_symbol_by_s_value!("YYEOF"),
+              lineno: 22,
+            ),
+            Rule.new(
+              id: 1,
+              lhs: grammar.find_symbol_by_s_value!("foo_"),
+              rhs: [],
+              token_code: T::UserCode.new(s_value: " printf(\"empty\\n\"); "),
+              nullable: true,
+              precedence_sym: nil,
+              lineno: 22,
+            ),
+            Rule.new(
+              id: 2,
+              lhs: grammar.find_symbol_by_s_value!("program"),
+              rhs: [
+                grammar.find_symbol_by_s_value!("foo_"),
+                grammar.find_symbol_by_s_value!("number"),
+              ],
+              token_code: nil,
+              nullable: false,
+              precedence_sym: grammar.find_symbol_by_s_value!("number"),
+              lineno: 22,
+            ),
+          ])
+        end
+      end
+
       context 'when error case' do
         context "when invalid argument number" do
           let(:path) { "parameterizing_rules/invalid_argument_number.y" }


### PR DESCRIPTION
In some cases, Inline does not specify parameters. Inline is implemented as an option to Parameterizing rules. 
Therefore, we added support for Parameterizing rules with zero parameters.