### PR TITLE
Truncate GrammarFile's @text when inspecting

### DIFF
--- a/lib/lrama/lexer/grammar_file.rb
+++ b/lib/lrama/lexer/grammar_file.rb
@@ -1,11 +1,17 @@
 module Lrama
   class Lexer
     class GrammarFile
+      class Text < String
+        def inspect
+          length <= 50 ? super : "#{self[0..47]}...".inspect
+        end
+      end
+
       attr_reader :path, :text
 
       def initialize(path, text)
         @path = path
-        @text = text.freeze
+        @text = Text.new(text).freeze
       end
 
       def ==(other)

--- a/sig/lrama/lexer/grammar_file.rbs
+++ b/sig/lrama/lexer/grammar_file.rbs
@@ -1,6 +1,8 @@
 module Lrama
   class Lexer
     class GrammarFile
+      class Text < String
+      end
       attr_reader path: String
       attr_reader text: String
 


### PR DESCRIPTION
In my environment, inspection of Lrama::State is too slowly.
After a little research, there are many inspections of Lrama::GrammarFile instances in Lrama::Token and I found printing the whole text of grammar file many times.