### PR TITLE
Omit too long text when printing module `Lrama::Lexer::GrammarFile` class

### DIFF
--- a/lib/lrama/lexer/grammar_file.rb
+++ b/lib/lrama/lexer/grammar_file.rb
@@ -14,6 +14,10 @@ module Lrama
         @text = Text.new(text).freeze
       end
 
+      def inspect
+        "<#{self.class}: @path=#{path}, @text=#{text.inspect}>"
+      end
+
       def ==(other)
         self.class == other.class &&
         self.path == other.path


### PR DESCRIPTION
It would be great if it could be shortened because it would be very difficult to see when debugging.

before:
```
#<Lrama::Lexer::Token::Ident:0x0000000104fd0fc0
 @alias_name=nil,
 @location=
  #<Lrama::Lexer::Location:0x000000010516e5d0
   @first_column=0,
   @first_line=27,
   @grammar_file=
    #<Lrama::Lexer::GrammarFile:0x0000000104e975a0
     @path="spec/fixtures/inlining/resolve_index.y",
     @text=
      "/*\n" +
      " * This is comment for this file.\n" +
      " */\n" +
      "\n" +
      "%{\n" +
      "// Prologue\n" +
      "static int yylex(YYSTYPE *val, YYLTYPE *loc);\n" +
      "static int yyerror(YYLTYPE *loc, const char *str);\n" +
      "%}\n" +
      "\n" +
      "%union {\n" +
      "    int i;\n" +
      "}\n" +
      "\n" +
      "%token <i> NUM\n" +
      "%type <i> expression\n" +
      "\n" +
      "%rule %inline op  : '+' '=' { += }\n" +
      "                  | '-' '-' '=' { -= }\n" +
      "                  ;\n" +
      "\n" +
      "%rule %inline other_op : '*' '=' { *= }\n" +
      "                       ;\n" +
      "\n" +
      "%%\n" +
      "\n" +
      "expression      : NUM\n" +
      "                | expression op expression other_op { $$ = $1 $2 $3 $4; }\n" +
      "                ;\n" +
      "\n" +
      "\n" +
      "\n" +
      "%%\n" +
      "\n" +
      "static int yylex(YYSTYPE *yylval, YYLTYPE *loc)\n" +
      "{\n" +
      "  return 0;\n" +
      "}\n" +
      "\n" +
      "static int yyerror(YYLTYPE *loc, const char *str)\n" +
      "{\n" +
      "  return 0;\n" +
      "}\n" +
      "\n" +
      "int main(int argc, char *argv[])\n" +
      "{\n" +
      "}\n">,
   @last_column=10,
   @last_line=27>,
 @s_value="expression">
```

after:
```
#<Lrama::Lexer::Token::Ident:0x0000000100f6c4c0 @alias_name=nil, @location=#<Lrama::Lexer::Location:0x0000000100faf518 @first_column=0, @first_line=27, @grammar_file=<Lrama::Lexer::GrammarFile: @path=spec/fixtures/inlining/resolve_index.y, @text="/*\n * This is comment for this file.\n */\n\n%{\n// ...">, @last_column=10, @last_line=27>, @s_value="expression">
```