### PR TITLE
Introduce the `--trace=actions` option

### DIFF
--- a/lib/lrama/command.rb
+++ b/lib/lrama/command.rb
@@ -47,6 +47,11 @@ module Lrama
         puts grammar.rules
       end
 
+      if options.trace_opts && options.trace_opts[:actions]
+        puts "Grammar rules with actions:"
+        grammar.rules.each { |rule| puts rule.with_actions }
+      end
+
       File.open(options.outfile, "w+") do |f|
         Lrama::Output.new(
           out: f,

--- a/lib/lrama/grammar/rule.rb
+++ b/lib/lrama/grammar/rule.rb
@@ -32,6 +32,10 @@ module Lrama
         "#{l}: #{r}"
       end
 
+      def with_actions
+        "#{to_s} {#{token_code&.s_value}}"
+      end
+
       # opt_nl: ε     <-- empty_rule
       #       | '\n'  <-- not empty_rule
       def empty_rule?

--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -119,8 +119,9 @@ module Lrama
 
     VALID_TRACES = %w[
       none locations scan parse automaton bitsets
-      closure grammar rules resource sets muscles tools
-      m4-early m4 skeleton time ielr cex all
+      closure grammar rules actions resource
+      sets muscles tools m4-early m4 skeleton time
+      ielr cex all
     ]
 
     def validate_trace(trace)

--- a/spec/lrama/command_spec.rb
+++ b/spec/lrama/command_spec.rb
@@ -50,6 +50,25 @@ RSpec.describe Lrama::Command do
       end
     end
 
+    context "when `--trace=actions` option specified" do
+      it "print grammar rules with actions" do
+        command = Lrama::Command.new
+        expect { command.run(o_option + [fixture_path("command/basic.y"), "--trace=actions"]) }.to output(<<~'OUTPUT').to_stdout
+          Grammar rules with actions:
+          $accept -> list, YYEOF {}
+          list -> ε {}
+          list -> list, LF {}
+          list -> list, expr, LF { printf("=> %d\n", $2); }
+          expr -> NUM {}
+          expr -> expr, '+', expr { $$ = $1 + $3; }
+          expr -> expr, '-', expr { $$ = $1 - $3; }
+          expr -> expr, '*', expr { $$ = $1 * $3; }
+          expr -> expr, '/', expr { $$ = $1 / $3; }
+          expr -> '(', expr, ')' { $$ = $2; }
+        OUTPUT
+      end
+    end
+
     context "when `--report-file` option specified" do
       it "create report file" do
         allow(File).to receive(:open).and_call_original

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Lrama::OptionParser do
               states itemsets lookaheads solved counterexamples all verbose
 
           Valid Traces:
-              none locations scan parse automaton bitsets closure grammar rules resource sets muscles tools m4-early m4 skeleton time ielr cex all
+              none locations scan parse automaton bitsets closure grammar rules actions resource sets muscles tools m4-early m4 skeleton time ielr cex all
 
         HELP
       end


### PR DESCRIPTION
The concept of merging actions was born in Inline. I think it would be useful to have an option to print the resolved action. However, we don't know what it is when I just display the action, so I've decided to print the rule and its corresponding action like this:. What do you think?

```
❯ exe/lrama --trace=actions sample/calc.y
Grammar rules with actions:
$accept -> list, YYEOF {}
list -> ε {}
list -> list, LF {}
list -> list, expr, LF { printf("=> %d\n", $2); }
expr -> NUM {}
expr -> expr, '+', expr { $$ = $1  +  $3; }
expr -> expr, '-', expr { $$ = $1  -  $3; }
expr -> expr, '*', expr { $$ = $1  *  $3; }
expr -> expr, '/', expr { $$ = $1  /  $3; }
expr -> '(', expr, ')' { $$ = $2; }
```