### PR TITLE
Remove `,` from Rule print format

### DIFF
--- a/lib/lrama/grammar/rule.rb
+++ b/lib/lrama/grammar/rule.rb
@@ -19,7 +19,7 @@ module Lrama
       # TODO: Change this to display_name
       def to_s
         l = lhs.id.s_value
-        r = empty_rule? ? "ε" : rhs.map {|r| r.id.s_value }.join(", ")
+        r = empty_rule? ? "ε" : rhs.map {|r| r.id.s_value }.join(" ")
 
         "#{l} -> #{r}"
       end

--- a/spec/lrama/command_spec.rb
+++ b/spec/lrama/command_spec.rb
@@ -36,16 +36,16 @@ RSpec.describe Lrama::Command do
         command = Lrama::Command.new
         expect { command.run(o_option + [fixture_path("command/basic.y"), "--trace=rules"]) }.to output(<<~OUTPUT).to_stdout
           Grammar rules:
-          $accept -> list, YYEOF
+          $accept -> list YYEOF
           list -> ε
-          list -> list, LF
-          list -> list, expr, LF
+          list -> list LF
+          list -> list expr LF
           expr -> NUM
-          expr -> expr, '+', expr
-          expr -> expr, '-', expr
-          expr -> expr, '*', expr
-          expr -> expr, '/', expr
-          expr -> '(', expr, ')'
+          expr -> expr '+' expr
+          expr -> expr '-' expr
+          expr -> expr '*' expr
+          expr -> expr '/' expr
+          expr -> '(' expr ')'
         OUTPUT
       end
     end
@@ -55,16 +55,16 @@ RSpec.describe Lrama::Command do
         command = Lrama::Command.new
         expect { command.run(o_option + [fixture_path("command/basic.y"), "--trace=actions"]) }.to output(<<~'OUTPUT').to_stdout
           Grammar rules with actions:
-          $accept -> list, YYEOF {}
+          $accept -> list YYEOF {}
           list -> ε {}
-          list -> list, LF {}
-          list -> list, expr, LF { printf("=> %d\n", $2); }
+          list -> list LF {}
+          list -> list expr LF { printf("=> %d\n", $2); }
           expr -> NUM {}
-          expr -> expr, '+', expr { $$ = $1 + $3; }
-          expr -> expr, '-', expr { $$ = $1 - $3; }
-          expr -> expr, '*', expr { $$ = $1 * $3; }
-          expr -> expr, '/', expr { $$ = $1 / $3; }
-          expr -> '(', expr, ')' { $$ = $2; }
+          expr -> expr '+' expr { $$ = $1 + $3; }
+          expr -> expr '-' expr { $$ = $1 - $3; }
+          expr -> expr '*' expr { $$ = $1 * $3; }
+          expr -> expr '/' expr { $$ = $1 / $3; }
+          expr -> '(' expr ')' { $$ = $2; }
         OUTPUT
       end
     end

--- a/spec/lrama/grammar/code_spec.rb
+++ b/spec/lrama/grammar/code_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe Lrama::Grammar::Code do
           expect { code.translated_code }.to raise_error("Tag is not specified for '$$' in '@2 -> ε'")
 
           code = grammar.rules.find {|r| r.lhs.id.s_value == "rule7" }
-          expect { code.translated_code }.to raise_error("Tag is not specified for '$2' in 'rule7 -> expr, @2, '+', expr'")
+          expect { code.translated_code }.to raise_error("Tag is not specified for '$2' in 'rule7 -> expr @2 '+' expr'")
 
           # midrule action in rule8
           # rule8 has no tag
@@ -305,7 +305,7 @@ RSpec.describe Lrama::Grammar::Code do
           expect { code.translated_code }.to raise_error("Tag is not specified for '$$' in '@3 -> ε'")
 
           code = grammar.rules.find {|r| r.lhs.id.s_value == "rule8" }
-          expect { code.translated_code }.to raise_error("Tag is not specified for '$2' in 'rule8 -> expr, @3, '+', expr'")
+          expect { code.translated_code }.to raise_error("Tag is not specified for '$2' in 'rule8 -> expr @3 '+' expr'")
         end
       end
 

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -598,8 +598,8 @@ RSpec.describe Lrama::States do
           [Includes Relation]
 
           [Lookback Relation]
-            (Rule: A -> B, C, D, A) -> (State 0, A)
-            (Rule: A -> B, C, D, A) -> (State 7, A)
+            (Rule: A -> B C D A) -> (State 0, A)
+            (Rule: A -> B C D A) -> (State 7, A)
 
           [Follow sets]
 
@@ -790,8 +790,8 @@ RSpec.describe Lrama::States do
           [Includes Relation]
 
           [Lookback Relation]
-            (Rule: A -> b, B) -> (State 0, A)
-            (Rule: A -> b, B) -> (State 8, A)
+            (Rule: A -> b B) -> (State 0, A)
+            (Rule: A -> b B) -> (State 8, A)
 
           [Follow sets]
 
@@ -861,7 +861,7 @@ RSpec.describe Lrama::States do
           [Includes Relation]
 
           [Lookback Relation]
-            (Rule: B -> c, C) -> (State 2, B)
+            (Rule: B -> c C) -> (State 2, B)
 
           [Follow sets]
 
@@ -884,7 +884,7 @@ RSpec.describe Lrama::States do
           [Includes Relation]
 
           [Lookback Relation]
-            (Rule: C -> d, A) -> (State 5, C)
+            (Rule: C -> d A) -> (State 5, C)
 
           [Follow sets]
 


### PR DESCRIPTION
It's confusing with `','` terminal symbol.