### PR TITLE
Fix an error for using parameterizing rules with own stack in semantic action

### DIFF
--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -130,7 +130,7 @@ module Lrama
               @replaced_rhs << lhs_token
               parameterizing_rule_resolver.created_lhs_list << lhs_token
               parameterizing_rule.rhs_list.each do |r|
-                rule_builder = RuleBuilder.new(@rule_counter, @midrule_action_counter, lhs_tag: token.lhs_tag, skip_preprocess_references: true)
+                rule_builder = RuleBuilder.new(@rule_counter, @midrule_action_counter, lhs_tag: token.lhs_tag)
                 rule_builder.lhs = lhs_token
                 r.symbols.each { |sym| rule_builder.add_rhs(bindings.resolve_symbol(sym)) }
                 rule_builder.line = line

--- a/spec/fixtures/integration/user_defined_parameterizing_rules.y
+++ b/spec/fixtures/integration/user_defined_parameterizing_rules.y
@@ -25,6 +25,7 @@ static int yyerror(YYLTYPE *loc, const char *str);
                     {
                         $$ = $1 + $2;
                         printf("(%d, %d)\n", $1, $2);
+                        printf("(%d, %d)\n", $:1, $:2);
                     }
                 ;
 

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -98,8 +98,10 @@ RSpec.describe "integration" do
     it "prints messages corresponding to rules" do
       expected = <<~STR
         (2, 3)
+        (-2, -1)
         pair even odd: 5
         (1, 0)
+        (-2, -1)
         pair odd even: 1
       STR
       test_parser("user_defined_parameterizing_rules", "2 3 ; 1 0", expected)


### PR DESCRIPTION
This PR fixes error.

```
tool/lrama/lib/lrama/grammar/code/rule_action.rb:58:in 'Integer#+': nil can't be coerced into Integer (TypeError)
```

