### PR TITLE
Add support for aliased Named References for actions of rhs in Parameterizing rules

### DIFF
--- a/lib/lrama/grammar/binding.rb
+++ b/lib/lrama/grammar/binding.rb
@@ -16,8 +16,17 @@ module Lrama
           resolved_args = symbol.args.map { |arg| resolve_symbol(arg) }
           Lrama::Lexer::Token::InstantiateRule.new(s_value: symbol.s_value, location: symbol.location, args: resolved_args, lhs_tag: symbol.lhs_tag)
         else
-          @parameter_to_arg[symbol.s_value] || symbol
+          parameter_to_arg(symbol) || symbol
         end
+      end
+
+      private
+
+      def parameter_to_arg(symbol)
+        if (arg = @parameter_to_arg[symbol.s_value].dup)
+          arg.alias_name = symbol.alias_name
+        end
+        arg
       end
     end
   end

--- a/sig/lrama/grammar/binding.rbs
+++ b/sig/lrama/grammar/binding.rbs
@@ -10,6 +10,10 @@ module Lrama
 
       def initialize: (Grammar::ParameterizingRule::Rule parameterizing_rule, Array[Lexer::Token] actual_args) -> void
       def resolve_symbol: (Lexer::Token symbol) -> Lexer::Token
+
+      private
+
+      def parameter_to_arg: (Lexer::Token symbol) -> Lexer::Token?
     end
   end
 end

--- a/spec/fixtures/parameterizing_rules/user_defined/with_action_and_named_references.y
+++ b/spec/fixtures/parameterizing_rules/user_defined/with_action_and_named_references.y
@@ -16,7 +16,7 @@ static int yyerror(YYLTYPE *loc, const char *str);
 %token <i> number
 %token <s> string
 
-%rule pair(X, Y): X ',' Y { printf("(%d, %d)\n", $X, $3); }
+%rule pair(X, Y): X ',' Y[alias] { printf("(%d, %d)\n", $X, $alias); }
                 ;
 
 %%

--- a/spec/fixtures/parameterizing_rules/user_defined/with_action_and_named_references.y
+++ b/spec/fixtures/parameterizing_rules/user_defined/with_action_and_named_references.y
@@ -10,18 +10,17 @@ static int yyerror(YYLTYPE *loc, const char *str);
 
 %union {
     int i;
-    char *s;
 }
 
 %token <i> number
-%token <s> string
+%token <i> summand
 
-%rule pair(X, Y): X ',' Y[alias] { printf("(%d, %d)\n", $X, $alias); }
-                ;
+%rule plus(X): X '+' number[addend] { $$ = $X + $addend; }
+             ;
 
 %%
 
-program         : pair(number, string) { printf("pair odd even\n"); }
+program         : plus(summand) { printf("plus number\n"); }
                 ;
 
 %%

--- a/spec/fixtures/parameterizing_rules/user_defined/with_action_and_named_references.y
+++ b/spec/fixtures/parameterizing_rules/user_defined/with_action_and_named_references.y
@@ -13,14 +13,13 @@ static int yyerror(YYLTYPE *loc, const char *str);
 }
 
 %token <i> number
-%token <i> summand
 
-%rule plus(X): X '+' number[addend] { $$ = $X + $addend; }
+%rule sum(X, Y) <i>: X[summand] '+' Y[addend] { $$ = $summand + $addend; }
              ;
 
 %%
 
-program         : plus(summand) { printf("plus number\n"); }
+program         : sum(number, number) { printf("sum number\n"); }
                 ;
 
 %%

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1693,7 +1693,7 @@ RSpec.describe Lrama::Parser do
             it "expands parameterizing rules" do
               expect(grammar.nterms.sort_by(&:number)).to match_symbols([
                 Sym.new(id: T::Ident.new(s_value: "$accept"), alias_name: nil, number: 6, tag: nil, term: false, token_id: 0, nullable: false),
-                Sym.new(id: T::Ident.new(s_value: "pair_number_string"), alias_name: nil, number: 7, tag: nil, term: false, token_id: 1, nullable: false),
+                Sym.new(id: T::Ident.new(s_value: "plus_summand"), alias_name: nil, number: 7, tag: nil, term: false, token_id: 1, nullable: false),
                 Sym.new(id: T::Ident.new(s_value: "program"), alias_name: nil, number: 8, tag: nil, term: false, token_id: 2, nullable: false),
               ])
 
@@ -1708,33 +1708,33 @@ RSpec.describe Lrama::Parser do
                   token_code: nil,
                   nullable: false,
                   precedence_sym: grammar.find_symbol_by_s_value!("YYEOF"),
-                  lineno: 24,
+                  lineno: 23,
                 ),
                 Rule.new(
                   id: 1,
-                  lhs: grammar.find_symbol_by_s_value!("pair_number_string"),
+                  lhs: grammar.find_symbol_by_s_value!("plus_summand"),
                   rhs: [
-                    grammar.find_symbol_by_s_value!("number"),
-                    grammar.find_symbol_by_number!(5),
-                    grammar.find_symbol_by_s_value!("string")
+                    grammar.find_symbol_by_s_value!("summand"),
+                    grammar.find_symbol_by_s_value!("'+'"),
+                    grammar.find_symbol_by_s_value!("number")
                   ],
                   lhs_tag: nil,
-                  token_code: T::UserCode.new(s_value: " printf(\"(%d, %d)\\n\", $X, $alias); "),
+                  token_code: T::UserCode.new(s_value: " $$ = $X + $addend; "),
                   nullable: false,
-                  precedence_sym: grammar.find_symbol_by_s_value!("string"),
-                  lineno: 24,
+                  precedence_sym: grammar.find_symbol_by_s_value!("number"),
+                  lineno: 23,
                 ),
                 Rule.new(
                   id: 2,
                   lhs: grammar.find_symbol_by_s_value!("program"),
                   rhs: [
-                    grammar.find_symbol_by_s_value!("pair_number_string"),
+                    grammar.find_symbol_by_s_value!("plus_summand"),
                   ],
                   lhs_tag: nil,
-                  token_code: T::UserCode.new(s_value: " printf(\"pair odd even\\n\"); "),
+                  token_code: T::UserCode.new(s_value: " printf(\"plus number\\n\"); "),
                   nullable: false,
                   precedence_sym: nil,
-                  lineno: 24,
+                  lineno: 23,
                 ),
               ])
             end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1692,9 +1692,9 @@ RSpec.describe Lrama::Parser do
 
             it "expands parameterizing rules" do
               expect(grammar.nterms.sort_by(&:number)).to match_symbols([
-                Sym.new(id: T::Ident.new(s_value: "$accept"), alias_name: nil, number: 6, tag: nil, term: false, token_id: 0, nullable: false),
-                Sym.new(id: T::Ident.new(s_value: "plus_summand"), alias_name: nil, number: 7, tag: nil, term: false, token_id: 1, nullable: false),
-                Sym.new(id: T::Ident.new(s_value: "program"), alias_name: nil, number: 8, tag: nil, term: false, token_id: 2, nullable: false),
+                Sym.new(id: T::Ident.new(s_value: "$accept"), alias_name: nil, number: 5, tag: nil, term: false, token_id: 0, nullable: false),
+                Sym.new(id: T::Ident.new(s_value: "sum_number_number"), alias_name: nil, number: 6, tag: T::Tag.new(s_value: "<i>"), term: false, token_id: 1, nullable: false),
+                Sym.new(id: T::Ident.new(s_value: "program"), alias_name: nil, number: 7, tag: nil, term: false, token_id: 2, nullable: false),
               ])
 
               expect(grammar.rules).to eq([
@@ -1708,33 +1708,33 @@ RSpec.describe Lrama::Parser do
                   token_code: nil,
                   nullable: false,
                   precedence_sym: grammar.find_symbol_by_s_value!("YYEOF"),
-                  lineno: 23,
+                  lineno: 22,
                 ),
                 Rule.new(
                   id: 1,
-                  lhs: grammar.find_symbol_by_s_value!("plus_summand"),
+                  lhs: grammar.find_symbol_by_s_value!("sum_number_number"),
                   rhs: [
-                    grammar.find_symbol_by_s_value!("summand"),
+                    grammar.find_symbol_by_s_value!("number"),
                     grammar.find_symbol_by_s_value!("'+'"),
                     grammar.find_symbol_by_s_value!("number")
                   ],
-                  lhs_tag: nil,
-                  token_code: T::UserCode.new(s_value: " $$ = $X + $addend; "),
+                  lhs_tag: T::Tag.new(s_value: "<i>"),
+                  token_code: T::UserCode.new(s_value: " $$ = $summand + $addend; "),
                   nullable: false,
                   precedence_sym: grammar.find_symbol_by_s_value!("number"),
-                  lineno: 23,
+                  lineno: 22,
                 ),
                 Rule.new(
                   id: 2,
                   lhs: grammar.find_symbol_by_s_value!("program"),
                   rhs: [
-                    grammar.find_symbol_by_s_value!("plus_summand"),
+                    grammar.find_symbol_by_s_value!("sum_number_number"),
                   ],
                   lhs_tag: nil,
-                  token_code: T::UserCode.new(s_value: " printf(\"plus number\\n\"); "),
+                  token_code: T::UserCode.new(s_value: " printf(\"sum number\\n\"); "),
                   nullable: false,
                   precedence_sym: nil,
-                  lineno: 23,
+                  lineno: 22,
                 ),
               ])
             end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1719,7 +1719,7 @@ RSpec.describe Lrama::Parser do
                     grammar.find_symbol_by_s_value!("string")
                   ],
                   lhs_tag: nil,
-                  token_code: T::UserCode.new(s_value: " printf(\"(%d, %d)\\n\", $X, $3); "),
+                  token_code: T::UserCode.new(s_value: " printf(\"(%d, %d)\\n\", $X, $alias); "),
                   nullable: false,
                   precedence_sym: grammar.find_symbol_by_s_value!("string"),
                   lineno: 24,


### PR DESCRIPTION
This PR support for aliased Named References for actions of rhs in Parameterizing rules.

## Motivation

If there is a non-terminal symbol in the RHS of parameterizing rules as shown below, I want to access it in the Named Reference.

```
%rule sum(X, Y): X[summand] '+' Y[addend] { $$ = $summand + $addend }
                ;
```