### PR TITLE
Fix an error for `Lrama::Grammar::ParameterizingRule::Rhs#resolve_user_code` when multiple execute method

### DIFF
--- a/lib/lrama/grammar/parameterizing_rule/rhs.rb
+++ b/lib/lrama/grammar/parameterizing_rule/rhs.rb
@@ -13,6 +13,7 @@ module Lrama
         def resolve_user_code(bindings)
           return unless user_code
 
+          resolved = Lexer::Token::UserCode.new(s_value: user_code.s_value, location: user_code.location)
           var_to_arg = {}
           symbols.each do |sym|
             resolved_sym = bindings.resolve_symbol(sym)
@@ -22,14 +23,14 @@ module Lrama
           end
 
           var_to_arg.each do |var, arg|
-            user_code.references.each do |ref|
+            resolved.references.each do |ref|
               if ref.name == var
                 ref.name = arg
               end
             end
           end
 
-          return user_code
+          return resolved
         end
       end
     end

--- a/spec/fixtures/integration/user_defined_parameterizing_rules.y
+++ b/spec/fixtures/integration/user_defined_parameterizing_rules.y
@@ -25,6 +25,7 @@ static int yyerror(YYLTYPE *loc, const char *str);
                     {
                         $$ = $1 + $2;
                         printf("(%d, %d)\n", $1, $2);
+                        printf("(%d, %d)\n", $X, $2);
                         printf("(%d, %d)\n", $:1, $:2);
                     }
                 ;

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -98,8 +98,10 @@ RSpec.describe "integration" do
     it "prints messages corresponding to rules" do
       expected = <<~STR
         (2, 3)
+        (2, 3)
         (-2, -1)
         pair even odd: 5
+        (1, 0)
         (1, 0)
         (-2, -1)
         pair odd even: 1


### PR DESCRIPTION
```
  1) integration user defined parameterizing rules prints messages corresponding to rules
     Failure/Error: expect(out).to eq(expected)

       expected: "(2, 3)\n(2, 3)\n(-2, -1)\npair even odd: 5\n(1, 0)\n(1, 0)\n(-2, -1)\npair odd even: 1\n"
            got: "(2, 3)\n(3, 3)\n(-2, -1)\npair even odd: 5\n(1, 0)\n(0, 0)\n(-2, -1)\npair odd even: 1\n"

       (compared using ==)

       Diff:

       @@ -1,9 +1,9 @@
        (2, 3)
       -(2, 3)
       +(3, 3)
        (-2, -1)
        pair even odd: 5
        (1, 0)
       -(1, 0)
       +(0, 0)
        (-2, -1)
        pair odd even: 1

     # ./spec/lrama/integration_spec.rb:46:in `test_parser'
     # ./spec/lrama/integration_spec.rb:109:in `block (3 levels) in <top (required)>'
```