### PR TITLE
Trivial fixes

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -37,7 +37,6 @@ module Lrama
                                         :find_symbol_by_s_value!, :fill_symbol_number, :fill_nterm_type,
                                         :fill_printer, :fill_destructor, :fill_error_token, :sort_by_number!
 
-
     def initialize(rule_counter)
       @rule_counter = rule_counter
 

--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -175,7 +175,7 @@ module Lrama
 
       def resolve_inline
         rhs.each_with_index do |token, i|
-          if inline_rule = @parameterizing_rule_resolver.find_inline(token)
+          if (inline_rule = @parameterizing_rule_resolver.find_inline(token))
             inline_rule.rhs_list.each_with_index do |inline_rhs|
               rule_builder = RuleBuilder.new(@rule_counter, @midrule_action_counter, @parameterizing_rule_resolver, lhs_tag: lhs_tag, skip_preprocess_references: true)
               resolve_inline_rhs(rule_builder, inline_rhs, i)


### PR DESCRIPTION
- Remove unnecessary empty line
- Enclose in parentheses where you assign in the if condition