### PR TITLE
Apply frozen string literal magic comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 
 namespace "build" do

--- a/Steepfile
+++ b/Steepfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # D = Steep::Diagnostic
 #
 target :lib do

--- a/exe/lrama
+++ b/exe/lrama
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH << File.join(__dir__, "../lib")
 require "lrama"

--- a/lib/lrama.rb
+++ b/lib/lrama.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lrama/bitmap"
 require_relative "lrama/command"
 require_relative "lrama/context"

--- a/lib/lrama/bitmap.rb
+++ b/lib/lrama/bitmap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   module Bitmap
     def self.from_array(ary)

--- a/lib/lrama/command.rb
+++ b/lib/lrama/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Command
     LRAMA_LIB = File.realpath(File.join(File.dirname(__FILE__)))

--- a/lib/lrama/context.rb
+++ b/lib/lrama/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "report/duration"
 
 module Lrama

--- a/lib/lrama/counterexamples.rb
+++ b/lib/lrama/counterexamples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 
 require_relative "counterexamples/derivation"

--- a/lib/lrama/counterexamples/derivation.rb
+++ b/lib/lrama/counterexamples/derivation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Counterexamples
     class Derivation

--- a/lib/lrama/counterexamples/example.rb
+++ b/lib/lrama/counterexamples/example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Counterexamples
     class Example

--- a/lib/lrama/counterexamples/path.rb
+++ b/lib/lrama/counterexamples/path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Counterexamples
     class Path

--- a/lib/lrama/counterexamples/production_path.rb
+++ b/lib/lrama/counterexamples/production_path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Counterexamples
     class ProductionPath < Path

--- a/lib/lrama/counterexamples/start_path.rb
+++ b/lib/lrama/counterexamples/start_path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Counterexamples
     class StartPath < Path

--- a/lib/lrama/counterexamples/state_item.rb
+++ b/lib/lrama/counterexamples/state_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Counterexamples
     class StateItem < Struct.new(:state, :item)

--- a/lib/lrama/counterexamples/transition_path.rb
+++ b/lib/lrama/counterexamples/transition_path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Counterexamples
     class TransitionPath < Path

--- a/lib/lrama/counterexamples/triple.rb
+++ b/lib/lrama/counterexamples/triple.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Counterexamples
     # s: state

--- a/lib/lrama/digraph.rb
+++ b/lib/lrama/digraph.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   # Algorithm Digraph of https://dl.acm.org/doi/pdf/10.1145/69622.357187 (P. 625)
   class Digraph

--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 require_relative "grammar/auxiliary"
 require_relative "grammar/binding"

--- a/lib/lrama/grammar/auxiliary.rb
+++ b/lib/lrama/grammar/auxiliary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     # Grammar file information not used by States but by Output

--- a/lib/lrama/grammar/binding.rb
+++ b/lib/lrama/grammar/binding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Binding

--- a/lib/lrama/grammar/code.rb
+++ b/lib/lrama/grammar/code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 require_relative "code/destructor_code"
 require_relative "code/initial_action_code"

--- a/lib/lrama/grammar/code/destructor_code.rb
+++ b/lib/lrama/grammar/code/destructor_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Code

--- a/lib/lrama/grammar/code/initial_action_code.rb
+++ b/lib/lrama/grammar/code/initial_action_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Code

--- a/lib/lrama/grammar/code/no_reference_code.rb
+++ b/lib/lrama/grammar/code/no_reference_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Code

--- a/lib/lrama/grammar/code/printer_code.rb
+++ b/lib/lrama/grammar/code/printer_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Code

--- a/lib/lrama/grammar/code/rule_action.rb
+++ b/lib/lrama/grammar/code/rule_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Code

--- a/lib/lrama/grammar/counter.rb
+++ b/lib/lrama/grammar/counter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Counter

--- a/lib/lrama/grammar/destructor.rb
+++ b/lib/lrama/grammar/destructor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Destructor < Struct.new(:ident_or_tags, :token_code, :lineno, keyword_init: true)

--- a/lib/lrama/grammar/error_token.rb
+++ b/lib/lrama/grammar/error_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class ErrorToken < Struct.new(:ident_or_tags, :token_code, :lineno, keyword_init: true)

--- a/lib/lrama/grammar/parameterizing_rule.rb
+++ b/lib/lrama/grammar/parameterizing_rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'parameterizing_rule/resolver'
 require_relative 'parameterizing_rule/rhs'
 require_relative 'parameterizing_rule/rule'

--- a/lib/lrama/grammar/parameterizing_rule/resolver.rb
+++ b/lib/lrama/grammar/parameterizing_rule/resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class ParameterizingRule

--- a/lib/lrama/grammar/parameterizing_rule/rhs.rb
+++ b/lib/lrama/grammar/parameterizing_rule/rhs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class ParameterizingRule

--- a/lib/lrama/grammar/parameterizing_rule/rule.rb
+++ b/lib/lrama/grammar/parameterizing_rule/rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class ParameterizingRule

--- a/lib/lrama/grammar/percent_code.rb
+++ b/lib/lrama/grammar/percent_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class PercentCode

--- a/lib/lrama/grammar/precedence.rb
+++ b/lib/lrama/grammar/precedence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Precedence < Struct.new(:type, :precedence, keyword_init: true)

--- a/lib/lrama/grammar/printer.rb
+++ b/lib/lrama/grammar/printer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Printer < Struct.new(:ident_or_tags, :token_code, :lineno, keyword_init: true)

--- a/lib/lrama/grammar/reference.rb
+++ b/lib/lrama/grammar/reference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     # type: :dollar or :at

--- a/lib/lrama/grammar/rule.rb
+++ b/lib/lrama/grammar/rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     # _rhs holds original RHS element. Use rhs to refer to Symbol.

--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class RuleBuilder

--- a/lib/lrama/grammar/symbol.rb
+++ b/lib/lrama/grammar/symbol.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Symbol is both of nterm and term
 # `number` is both for nterm and term
 # `token_id` is tokentype for term, internal sequence number for nterm

--- a/lib/lrama/grammar/symbols.rb
+++ b/lib/lrama/grammar/symbols.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require_relative "symbols/resolver"

--- a/lib/lrama/grammar/symbols/resolver.rb
+++ b/lib/lrama/grammar/symbols/resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Symbols

--- a/lib/lrama/grammar/type.rb
+++ b/lib/lrama/grammar/type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Type

--- a/lib/lrama/grammar/union.rb
+++ b/lib/lrama/grammar/union.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Grammar
     class Union < Struct.new(:code, :lineno, keyword_init: true)

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "strscan"
 
 require_relative "lexer/grammar_file"

--- a/lib/lrama/lexer/grammar_file.rb
+++ b/lib/lrama/lexer/grammar_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Lexer
     class GrammarFile

--- a/lib/lrama/lexer/location.rb
+++ b/lib/lrama/lexer/location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Lexer
     class Location

--- a/lib/lrama/lexer/token.rb
+++ b/lib/lrama/lexer/token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'token/char'
 require_relative 'token/ident'
 require_relative 'token/instantiate_rule'

--- a/lib/lrama/lexer/token/char.rb
+++ b/lib/lrama/lexer/token/char.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Lexer
     class Token

--- a/lib/lrama/lexer/token/ident.rb
+++ b/lib/lrama/lexer/token/ident.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Lexer
     class Token

--- a/lib/lrama/lexer/token/instantiate_rule.rb
+++ b/lib/lrama/lexer/token/instantiate_rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Lexer
     class Token

--- a/lib/lrama/lexer/token/tag.rb
+++ b/lib/lrama/lexer/token/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Lexer
     class Token

--- a/lib/lrama/lexer/token/user_code.rb
+++ b/lib/lrama/lexer/token/user_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "strscan"
 
 module Lrama

--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'optparse'
 
 module Lrama

--- a/lib/lrama/options.rb
+++ b/lib/lrama/options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   # Command line options.
   class Options

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erb"
 require "forwardable"
 require_relative "report/duration"
@@ -63,7 +65,7 @@ module Lrama
 
     # A part of b4_token_enums
     def token_enums
-      str = ""
+      str = "".dup
 
       @context.yytokentype.each do |s_value, token_id, display_name|
         s = sprintf("%s = %d%s", s_value, token_id, token_id == yymaxutok ? "" : ",")
@@ -80,7 +82,7 @@ module Lrama
 
     # b4_symbol_enum
     def symbol_enum
-      str = ""
+      str = "".dup
 
       last_sym_number = @context.yysymbol_kind_t.last[1]
       @context.yysymbol_kind_t.each do |s_value, sym_number, display_name|
@@ -132,7 +134,7 @@ module Lrama
     end
 
     def symbol_actions_for_printer
-      str = ""
+      str = "".dup
 
       @grammar.symbols.each do |sym|
         next unless sym.printer
@@ -151,7 +153,7 @@ module Lrama
     end
 
     def symbol_actions_for_destructor
-      str = ""
+      str = "".dup
 
       @grammar.symbols.each do |sym|
         next unless sym.destructor
@@ -236,7 +238,7 @@ module Lrama
     end
 
     def symbol_actions_for_error_token
-      str = ""
+      str = "".dup
 
       @grammar.symbols.each do |sym|
         next unless sym.error_token
@@ -256,7 +258,7 @@ module Lrama
 
     # b4_user_actions
     def user_actions
-      str = ""
+      str = "".dup
 
       @context.states.rules.each do |rule|
         next unless rule.token_code
@@ -343,7 +345,7 @@ module Lrama
 
     # b4_parse_param_use
     def parse_param_use(val, loc)
-      str = <<-STR
+      str = <<-STR.dup
   YY_USE (#{val});
   YY_USE (#{loc});
       STR
@@ -398,7 +400,7 @@ module Lrama
       last = ary.count - 1
 
       s = ary.each_with_index.each_slice(10).map do |slice|
-        str = "  "
+        str = "  ".dup
 
         slice.each do |e, i|
           str << sprintf("%6d%s", e, (i == last) ? "" : ",")
@@ -461,8 +463,8 @@ module Lrama
     end
 
     def string_array_to_string(ary)
-      str = ""
-      tmp = " "
+      str = "".dup
+      tmp = " ".dup
 
       ary.each do |s|
         s = s.gsub('\\', '\\\\\\\\')
@@ -470,7 +472,7 @@ module Lrama
 
         if (tmp + s + " \"\",").length > 75
           str << tmp << "\n"
-          tmp = "  \"#{s}\","
+          tmp = "  \"#{s}\",".dup
         else
           tmp << " \"#{s}\","
         end

--- a/lib/lrama/report.rb
+++ b/lib/lrama/report.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require_relative 'report/duration'
 require_relative 'report/profile'

--- a/lib/lrama/report/duration.rb
+++ b/lib/lrama/report/duration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Report
     module Duration

--- a/lib/lrama/report/profile.rb
+++ b/lib/lrama/report/profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Report
     module Profile

--- a/lib/lrama/state.rb
+++ b/lib/lrama/state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "state/reduce"
 require_relative "state/reduce_reduce_conflict"
 require_relative "state/resolved_conflict"

--- a/lib/lrama/state/reduce.rb
+++ b/lib/lrama/state/reduce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class State
     class Reduce

--- a/lib/lrama/state/reduce_reduce_conflict.rb
+++ b/lib/lrama/state/reduce_reduce_conflict.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class State
     class ReduceReduceConflict < Struct.new(:symbols, :reduce1, :reduce2, keyword_init: true)

--- a/lib/lrama/state/resolved_conflict.rb
+++ b/lib/lrama/state/resolved_conflict.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class State
     # * symbol: A symbol under discussion

--- a/lib/lrama/state/shift.rb
+++ b/lib/lrama/state/shift.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class State
     class Shift

--- a/lib/lrama/state/shift_reduce_conflict.rb
+++ b/lib/lrama/state/shift_reduce_conflict.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class State
     class ShiftReduceConflict < Struct.new(:symbols, :shift, :reduce, keyword_init: true)

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 require_relative "report/duration"
 require_relative "states/item"

--- a/lib/lrama/states/item.rb
+++ b/lib/lrama/states/item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # TODO: Validate position is not over rule rhs
 
 require "forwardable"

--- a/lib/lrama/states_reporter.rb
+++ b/lib/lrama/states_reporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class StatesReporter
     include Lrama::Report::Duration

--- a/lib/lrama/version.rb
+++ b/lib/lrama/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   VERSION = "0.6.9".freeze
 end

--- a/lib/lrama/warning.rb
+++ b/lib/lrama/warning.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lrama
   class Warning
     attr_reader :errors, :warns

--- a/lrama.gemspec
+++ b/lrama.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/lrama/version.rb"
 
 Gem::Specification.new do |spec|

--- a/spec/lrama/bitmap_spec.rb
+++ b/spec/lrama/bitmap_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Bitmap do
   describe ".from_array" do
     it "converts array of integer into bitmap integer" do

--- a/spec/lrama/command_spec.rb
+++ b/spec/lrama/command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tmpdir"
 
 RSpec.describe Lrama::Command do

--- a/spec/lrama/context_spec.rb
+++ b/spec/lrama/context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Context do
   let(:out) { "" }
   let(:warning) { Lrama::Warning.new(out) }

--- a/spec/lrama/counterexamples_spec.rb
+++ b/spec/lrama/counterexamples_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Counterexamples do
-  let(:out) { "" }
+  let(:out) { "".dup }
   let(:warning) { Lrama::Warning.new(out) }
 
   describe "#compute" do

--- a/spec/lrama/grammar/code_spec.rb
+++ b/spec/lrama/grammar/code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Grammar::Code do
   let(:token_class) { Lrama::Lexer::Token }
   let(:user_code_dollar_dollar) { token_class::UserCode.new(s_value: 'print($$);') }

--- a/spec/lrama/grammar/rule_builder_spec.rb
+++ b/spec/lrama/grammar/rule_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Grammar::RuleBuilder do
   let(:rule_counter) { Lrama::Grammar::Counter.new(1) }
   let(:midrule_action_counter) { Lrama::Grammar::Counter.new(1) }

--- a/spec/lrama/grammar/symbol_spec.rb
+++ b/spec/lrama/grammar/symbol_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Grammar::Symbol do
   let(:token_class) { Lrama::Lexer::Token }
 

--- a/spec/lrama/grammar/symbols/resolver_spec.rb
+++ b/spec/lrama/grammar/symbols/resolver_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Grammar::Symbols::Resolver do
   let(:resolver) { Lrama::Grammar::Symbols::Resolver.new }
 

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "open3"
 require "tempfile"
 require "tmpdir"

--- a/spec/lrama/lexer/location_spec.rb
+++ b/spec/lrama/lexer/location_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Lexer::Location do
   describe "#to_s" do
     it "returns location information" do

--- a/spec/lrama/lexer/token/user_code_spec.rb
+++ b/spec/lrama/lexer/token/user_code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Lexer::Token::UserCode do
   describe "#references" do
     let(:grammar_file) { Lrama::Lexer::GrammarFile.new("test.y", "") }

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::Lexer do
   let(:token_class) { Lrama::Lexer::Token }
 

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "open3"
 
 RSpec.describe Lrama::OptionParser do

--- a/spec/lrama/output_spec.rb
+++ b/spec/lrama/output_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 
 RSpec.describe Lrama::Output do

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tempfile"
 
 RSpec.describe Lrama::Parser do

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe Lrama::States do
-  let(:out) { "" }
+  let(:out) { "".dup }
   let(:warning) { Lrama::Warning.new(out) }
 
   describe '#compute' do
@@ -12,7 +14,7 @@ RSpec.describe Lrama::States do
       states = Lrama::States.new(grammar, warning)
       states.compute
 
-      str = ""
+      str = "".dup
       states.reporter.report(str, grammar: true, states: true, itemsets: true, lookaheads: true)
 
       expect(str).to eq(<<~STR)
@@ -351,7 +353,7 @@ RSpec.describe Lrama::States do
       states = Lrama::States.new(grammar, warning)
       states.compute
 
-      str = ""
+      str = "".dup
       states.reporter.report(str, states: true, itemsets: true, verbose: true)
 
       expect(str).to eq(<<~STR)
@@ -621,7 +623,7 @@ RSpec.describe Lrama::States do
       states = Lrama::States.new(grammar, warning)
       states.compute
 
-      str = ""
+      str = "".dup
       states.reporter.report(str, states: true, itemsets: true, verbose: true)
 
       expect(str).to eq(<<~STR)
@@ -922,7 +924,7 @@ RSpec.describe Lrama::States do
         states = Lrama::States.new(grammar, warning)
         states.compute
 
-        str = ""
+        str = "".dup
         states.reporter.report(str, states: true, lookaheads: true)
 
         expect(str).to eq(<<~STR)
@@ -993,7 +995,7 @@ RSpec.describe Lrama::States do
         states = Lrama::States.new(grammar, warning)
         states.compute
 
-        str = ""
+        str = "".dup
         states.reporter.report(str, states: true, lookaheads: true, itemsets: true)
 
         expect(str).to eq(<<~STR)
@@ -1085,7 +1087,7 @@ RSpec.describe Lrama::States do
         states = Lrama::States.new(grammar, warning)
         states.compute
 
-        str = ""
+        str = "".dup
         states.reporter.report(str, states: true, solved: true)
 
         expect(str).to eq(<<~STR)
@@ -1204,7 +1206,7 @@ RSpec.describe Lrama::States do
         states = Lrama::States.new(grammar, warning)
         states.compute
 
-        str = ""
+        str = "".dup
         states.reporter.report(str, states: true, solved: true)
 
         expect(str).to eq(<<~STR)
@@ -1303,7 +1305,7 @@ RSpec.describe Lrama::States do
         states = Lrama::States.new(grammar, warning)
         states.compute
 
-        str = ""
+        str = "".dup
         states.reporter.report(str, states: true, solved: true)
 
         expect(str).to eq(<<~STR)
@@ -1454,7 +1456,7 @@ RSpec.describe Lrama::States do
       states = Lrama::States.new(grammar, warning)
       states.compute
 
-      str = ""
+      str = "".dup
       states.reporter.report(str, states: true)
 
       expect(str).to eq(<<~STR)
@@ -1628,7 +1630,7 @@ RSpec.describe Lrama::States do
       states = Lrama::States.new(grammar, warning)
       states.compute
 
-      str = ""
+      str = "".dup
       states.reporter.report(str, states: true)
 
       expect(str).to eq(<<~STR)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "simplecov"
 
 SimpleCov.start do


### PR DESCRIPTION
Starting with Ruby 3.4, there is a gradual plan to freeze strings: https://bugs.ruby-lang.org/issues/20205#note-35

Using Ruby 3.4dev with code prior to this PR results in the following warning:

```console
$ cd path/to/ruby/lrama
$ ruby -v
ruby 3.4.0dev (2024-05-27T01:45:38Z master 5853a38043) [x86_64-darwin23]
$ RUBYOPT=-W:deprecated bundle exec rake
(snip)

/Users/koic/src/github.com/ruby/lrama/lib/lrama/output.rb:74: warning: literal string will be frozen in the future
```

This warning suggests that applying the frozen string magic comment will lead to `FrozenError`. So, this indicates that the future behavior of (default frozen) string will produce `FrozenError`.

This PR applies the frozen string magic comment to detect `FrozenError` and uses `String#dup` to prevent it: https://gist.github.com/fxn/bf4eed2505c76f4fca03ab48c43adc72#ruby-34

This ensures compatibility for the future.

NOTE: From Ruby 3.3+, there is no speed difference between `String#+@` and `String#dup`. For readability, `String#dup` has been chosen: https://github.com/ruby/ruby/pull/8952