### PR TITLE
Add error recovery test case for "(1+2"

### DIFF
--- a/spec/fixtures/integration/error_recovery.l
+++ b/spec/fixtures/integration/error_recovery.l
@@ -18,6 +18,14 @@ NUMBER [0-9]+
     return NUM;
 }
 
+[\(] {
+    return LPAREN;
+}
+
+[\)] {
+    return RPAREN;
+}
+
 [+\-\*\/\(\)] {
     return yytext[0];
 }

--- a/spec/fixtures/integration/error_recovery.y
+++ b/spec/fixtures/integration/error_recovery.y
@@ -13,25 +13,37 @@ static int yyerror(YYLTYPE *loc, const char *str);
 }
 
 %token <val> NUM
+%token <val> LPAREN "("
+%token <val> RPAREN ")"
+%type <val> stmt
 %type <val> expr
 %left '+' '-'
 %left '*' '/'
 
 %error-token {
     $$ = 100;
-} NUM
+} NUM RPAREN
 
 %%
 
 program : /* empty */
-     | expr { printf("=> %d", $1); }
+     | stmt { printf("=> %d", $1); }
+     ;
+stmt : expr { $$ = $1; }
+     | LPAREN expr RPAREN
+        {
+            if ($3 == 100) {
+                $$ = $2 + $3;
+            } else {
+                $$ = $2;
+            }
+        }
      ;
 expr : NUM
      | expr '+' expr { $$ = $1 + $3; }
      | expr '-' expr { $$ = $1 - $3; }
      | expr '*' expr { $$ = $1 * $3; }
      | expr '/' expr { $$ = $1 / $3; }
-     | '(' expr ')'  { $$ = $2; }
      ;
 
 %%

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -246,12 +246,17 @@ RSpec.describe "integration" do
     end
   end
 
-  # TODO: Add test case for "(1+2"
   describe "error_recovery" do
     it "returns 101 for '(1+)'" do
       # (1+) #=> 101
       # '100' is complemented
       test_parser("error_recovery", "(1+)", "=> 101", lrama_command_args: %W[-e])
+    end
+
+    it "returns 103 for '(1+2'" do
+      # (1+2 #=> 103
+      # '100' is complemented
+      test_parser("error_recovery", "(1+2", "=> 103", lrama_command_args: %W[-e])
     end
   end
 


### PR DESCRIPTION
I added a test case for “(1+2)” for error recovery.
However, I am not sure if the test case is what it is supposed to be, so I would appreciate your comments if it is different.