### PR TITLE
Rename Lrama::Grammar::Rule#to_s to Lrama::Grammar:Rule::display_name

### DIFF
--- a/lib/lrama/command.rb
+++ b/lib/lrama/command.rb
@@ -44,7 +44,7 @@ module Lrama
 
       if options.trace_opts && options.trace_opts[:rules]
         puts "Grammar rules:"
-        puts grammar.rules
+        grammar.rules.each { |rule| puts rule.display_name }
       end
 
       if options.trace_opts && options.trace_opts[:actions]

--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -386,7 +386,7 @@ module Lrama
       rules.each do |rule|
         next if rule.lhs.nterm?
 
-        errors << "[BUG] LHS of #{rule} (line: #{rule.lineno}) is term. It should be nterm."
+        errors << "[BUG] LHS of #{rule.display_name} (line: #{rule.lineno}) is term. It should be nterm."
       end
 
       return if errors.empty?

--- a/lib/lrama/grammar/code/rule_action.rb
+++ b/lib/lrama/grammar/code/rule_action.rb
@@ -82,7 +82,7 @@ module Lrama
         end
 
         def raise_tag_not_found_error(ref)
-          raise "Tag is not specified for '$#{ref.value}' in '#{@rule}'"
+          raise "Tag is not specified for '$#{ref.value}' in '#{@rule.display_name}'"
         end
       end
     end

--- a/lib/lrama/grammar/rule.rb
+++ b/lib/lrama/grammar/rule.rb
@@ -16,8 +16,7 @@ module Lrama
         self.lineno == other.lineno
       end
 
-      # TODO: Change this to display_name
-      def to_s
+      def display_name
         l = lhs.id.s_value
         r = empty_rule? ? "ε" : rhs.map {|r| r.id.s_value }.join(" ")
 
@@ -33,7 +32,7 @@ module Lrama
       end
 
       def with_actions
-        "#{to_s} {#{token_code&.s_value}}"
+        "#{display_name} {#{token_code&.s_value}}"
       end
 
       # opt_nl: ε     <-- empty_rule

--- a/lib/lrama/states_reporter.rb
+++ b/lib/lrama/states_reporter.rb
@@ -275,7 +275,7 @@ module Lrama
 
             a.each do |state_id2, nterm_id2|
               n = @states.nterms.find {|n| n.token_id == nterm_id2 }
-              io << "    (Rule: #{rule}) -> (State #{state_id2}, #{n.id.s_value})\n"
+              io << "    (Rule: #{rule.display_name}) -> (State #{state_id2}, #{n.id.s_value})\n"
             end
           end
           io << "\n"

--- a/sig/lrama/grammar/rule.rbs
+++ b/sig/lrama/grammar/rule.rbs
@@ -20,6 +20,8 @@ module Lrama
         ?precedence_sym: Lexer::Token?, ?lineno: Integer?
       ) -> void
 
+      def display_name: () -> String
+
       def as_comment: -> String
 
       def empty_rule?: -> bool


### PR DESCRIPTION
I saw a TODO in `lib/lrama/grammar/rule.rb` to rename the `to_s` method to the `display_name` method, so I renamed it.