### PR TITLE
Fix warning when execute rspec

### DIFF
--- a/spec/lrama/grammar/symbols/resolver_spec.rb
+++ b/spec/lrama/grammar/symbols/resolver_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe Lrama::Grammar::Symbols::Resolver do
     end
 
     it "returns nil if nterm exists" do
-      nterm1 = resolver.add_nterm(id: Lrama::Lexer::Token::Ident.new(s_value: "nterm"))
-      nterm2 = resolver.add_nterm(id: Lrama::Lexer::Token::Ident.new(s_value: "nterm"))
-      expect(nterm2).to eq(nil)
+      resolver.add_nterm(id: Lrama::Lexer::Token::Ident.new(s_value: "nterm"))
+      nterm = resolver.add_nterm(id: Lrama::Lexer::Token::Ident.new(s_value: "nterm"))
+      expect(nterm).to eq(nil)
     end
   end
 


### PR DESCRIPTION
```
❯ bundle exec rspec --warning
/ydah/lrama/spec/lrama/grammar/symbols/resolver_spec.rb:83: warning: assigned but unused variable - nterm1
................................................................................................................................................................................................................................

Finished in 8.23 seconds (files took 0.18522 seconds to load)
224 examples, 0 failures
```