### PR TITLE
Ignore temporary parse files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /Gemfile.lock
 /coverage/
 /parser.output
+/parse.tmp.*
 /pkg/
 /tmp/
 /vendor/bundle


### PR DESCRIPTION
When measuring by stackprof, I always follow the procedure described in the README.
At that time, parse.tmp.c and parse.tmp.h are created, but I don't want to commit them by mistake.

So, ignore the file created by the following procedure: https://github.com/ruby/lrama/blob/24786d88a35b7f7e7b95963d18d20125b29eb949/README.md?plain=1#L159-L161