### PR TITLE
Fix some rbs

### DIFF
--- a/sig/lrama/grammar.rbs
+++ b/sig/lrama/grammar.rbs
@@ -71,7 +71,7 @@ module Lrama
     def epilogue_first_lineno=: (Integer epilogue_first_lineno) -> Integer
     def epilogue=: (String epilogue) -> String
     def prepare: () -> void
-    def validate!: () -> (void | bot)
+    def validate!: () -> void
     def find_rules_by_symbol!: (Grammar::Symbol sym) -> Array[Rule]
     def find_rules_by_symbol: (Grammar::Symbol sym) -> Array[Rule]?
 

--- a/sig/lrama/grammar.rbs
+++ b/sig/lrama/grammar.rbs
@@ -88,6 +88,6 @@ module Lrama
     def fill_default_precedence: () -> void
     def fill_symbols: () -> Array[Grammar::Symbol]
     def fill_sym_to_rules: () -> Array[Rule]
-    def validate_rule_lhs_is_nterm!: () -> bot?
+    def validate_rule_lhs_is_nterm!: () -> void
   end
 end

--- a/sig/lrama/options.rbs
+++ b/sig/lrama/options.rbs
@@ -1,5 +1,5 @@
 module Lrama
- class Options
+  class Options
     attr_accessor skeleton: String
     attr_accessor header: bool
     attr_accessor header_file: String?
@@ -13,5 +13,5 @@ module Lrama
     attr_accessor debug: bool
 
     def initialize: () -> void
- end
+  end
 end


### PR DESCRIPTION
- Fix an indentation in sig/lrama/options.rbs
- Fix rbs validate warning
  ```
  ❯ bundle exec rbs -I sig validate
  W, [2024-06-07T16:09:23.137310 #4825]  WARN -- rbs: sig/lrama/grammar.rbs:74:19...74:37: `void` type is only allowed in return type or generics parameter (RBS::WillSyntaxError)
        def validate!: () -> (void | bot)
                       ^^^^^^^^^^^^^^^^^^
  ```
- Use void instead of bot?