### PR TITLE
Add support `--report=terms` option

### DIFF
--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -92,7 +92,7 @@ module Lrama
     end
 
     BISON_REPORTS = %w[states itemsets lookaheads solved counterexamples cex all none]
-    OTHER_REPORTS = %w[verbose]
+    OTHER_REPORTS = %w[terms verbose]
     NOT_SUPPORTED_REPORTS = %w[cex none]
     VALID_REPORTS = BISON_REPORTS + OTHER_REPORTS - NOT_SUPPORTED_REPORTS
 

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Lrama::OptionParser do
               -h, --help                       display this help and exit
 
           Valid Reports:
-              states itemsets lookaheads solved counterexamples all verbose
+              states itemsets lookaheads solved counterexamples all terms verbose
 
           Valid Traces:
               none locations scan parse automaton bitsets closure grammar rules actions resource sets muscles tools m4-early m4 skeleton time ielr cex all

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -15,9 +15,24 @@ RSpec.describe Lrama::States do
       states.compute
 
       io = StringIO.new
-      states.reporter.report(io, grammar: true, states: true, itemsets: true, lookaheads: true)
+      states.reporter.report(io, grammar: true, terms: true, states: true, itemsets: true, lookaheads: true)
 
       expect(io.string).to eq(<<~STR)
+        Unused Terms
+
+            0 YYerror
+            1 YYUNDEF
+            2 '\\\\'
+            3 '\\13'
+            4 keyword_class2
+            5 tNUMBER
+            6 tPLUS
+            7 tMINUS
+            8 tEQ
+            9 tEQEQ
+           10 '>'
+
+
         State 1 conflicts: 2 shift/reduce, 1 reduce/reduce
 
 


### PR DESCRIPTION
Add report_unused_terms private method to Lrama::StatesReporter for `TODO Unused terms` in `lib/lrama/states_report.rb`
However, I am not sure if the output format is what it is supposed to be, so I would appreciate your comments if it is different.