### PR TITLE
Improve `--report=terms` command

### DIFF
--- a/lib/lrama/states_reporter.rb
+++ b/lib/lrama/states_reporter.rb
@@ -26,8 +26,6 @@ module Lrama
     end
 
     def report_unused_terms(io)
-      io << "Unused Terms\n\n"
-
       results = []
       terms = []
       used_symbols = []
@@ -52,6 +50,10 @@ module Lrama
 
       results = terms.select do |term|
         !used_symbols.include?(term)
+      end
+
+      if !results.empty?
+        io << "#{results.count} Unused Terms\n\n"
       end
 
       results.each_with_index do |term, index|

--- a/lib/lrama/states_reporter.rb
+++ b/lib/lrama/states_reporter.rb
@@ -32,10 +32,6 @@ module Lrama
 
       terms = @states.symbols.select(&:term?)
 
-      @states.states.select do |state|
-        state.shifts.map(&:next_sym)
-      end
-
       @states.states.each do |state|
         state.reduces.select do |reduce|
           used_symbols << reduce.look_ahead.flatten if !reduce.look_ahead.nil?

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Lrama::States do
       states.reporter.report(io, grammar: true, terms: true, states: true, itemsets: true, lookaheads: true)
 
       expect(io.string).to eq(<<~STR)
-        Unused Terms
+        11 Unused Terms
 
             0 YYerror
             1 YYUNDEF


### PR DESCRIPTION
This PR improve `--report=terms` command.

Output `Unused Terms` only when there are unused terms.
Also, output the number of terms as follows:

Before:
```
 Unused Terms
     0 YYerror
     2 YYUNDEF
     3 '\\\\'
     3 '\\13'
     4 keyword_class2
     5 tNUMBER
     6 tPLUS
     7 tMINUS
     8 tEQ
     9 tEQEQ
    10 '>'
```

After:
```
 11 Unused Terms
     0 YYerror
     1 YYUNDEF
     2 '\\\\'
     3 '\\13'
     4 keyword_class2
     5 tNUMBER
     6 tPLUS
     7 tMINUS
     8 tEQ
     9 tEQEQ
    10 '>'
```