### PR TITLE
Fix an error for initialization within YY_INITIAL_VALUE() with C++

### DIFF
--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -1475,7 +1475,11 @@ int yychar;
 /* The semantic value of the lookahead symbol.  */
 /* Default value used for initialization, for pacifying older GCCs
    or non-GCC compilers.  */
+#ifdef __cplusplus
+static const YYSTYPE yyval_default = YY_INITIAL_VALUE(YYSTYPE());
+#else
 YY_INITIAL_VALUE (static const YYSTYPE yyval_default;)
+#endif
 YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
 /* Location data for the lookahead symbol.  */


### PR DESCRIPTION
Fix: https://github.com/ruby/lrama/issues/442

Before:
```
❯ exe/lrama -d sample/calc.y -o calc.c && cc -Wall calc.c -o calc

❯ exe/lrama -d sample/calc.y -o calc.c && gcc -Wall calc.c -o calc

❯ exe/lrama -d sample/calc.y -o calc.c && c++ -Wall calc.c -o calc
clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
calc.c:1199:40: error: default initialization of an object of const type 'const YYSTYPE' without a user-provided default constructor
YY_INITIAL_VALUE (static const YYSTYPE yyval_default;)
```

After:
```
❯ exe/lrama -d sample/calc.y -o calc.c && cc -Wall calc.c -o calc

❯ exe/lrama -d sample/calc.y -o calc.c && gcc -Wall calc.c -o calc

❯ exe/lrama -d sample/calc.y -o calc.c && c++ -Wall calc.c -o calc
clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
```