### PR TITLE
Improve `--report` option

### DIFF
--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -91,29 +91,25 @@ module Lrama
       end
     end
 
-    BISON_REPORTS = %w[states itemsets lookaheads solved counterexamples cex all none]
-    OTHER_REPORTS = %w[rules terms verbose]
-    NOT_SUPPORTED_REPORTS = %w[none]
     ALIASED_REPORTS = { cex: :counterexamples }
-    VALID_REPORTS = BISON_REPORTS + OTHER_REPORTS - NOT_SUPPORTED_REPORTS
+    VALID_REPORTS = %i[states itemsets lookaheads solved counterexamples rules terms verbose]
 
     def validate_report(report)
       h = { grammar: true }
+      return h if report.empty?
+      return {} if report == ['none']
+      if report == ['all']
+        VALID_REPORTS.each { |r| h[r] = true }
+        return h
+      end
 
       report.each do |r|
-        if VALID_REPORTS.include?(r)
-          h[aliased_report_option(r)] = true
+        aliased = aliased_report_option(r)
+        if VALID_REPORTS.include?(aliased)
+          h[aliased] = true
         else
           raise "Invalid report option \"#{r}\"."
         end
-      end
-
-      if h[:all]
-        (BISON_REPORTS - NOT_SUPPORTED_REPORTS).each do |r|
-          h[r.to_sym] = true
-        end
-
-        h.delete(:all)
       end
 
       return h

--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -65,11 +65,19 @@ module Lrama
         o.separator 'Output:'
         o.on('-H', '--header=[FILE]', 'also produce a header file named FILE') {|v| @options.header = true; @options.header_file = v }
         o.on('-d', 'also produce a header file') { @options.header = true }
-        o.on('-r', '--report=THINGS', Array, 'also produce details on the automaton') {|v| @report = v }
+        o.on('-r', '--report=REPORTS', Array, 'also produce details on the automaton') {|v| @report = v }
         o.on_tail ''
-        o.on_tail 'Valid Reports:'
-        o.on_tail "    #{VALID_REPORTS.join(' ')}"
-
+        o.on_tail 'REPORTS is a list of comma-separated words that can include:'
+        o.on_tail '    states                           describe the states'
+        o.on_tail '    itemsets                         complete the core item sets with their closure'
+        o.on_tail '    lookaheads                       explicitly associate lookahead tokens to items'
+        o.on_tail '    solved                           describe shift/reduce conflicts solving'
+        o.on_tail '    counterexamples, cex             generate conflict counterexamples'
+        o.on_tail '    rules                            list unused rules'
+        o.on_tail '    terms                            list unused terminals'
+        o.on_tail '    verbose                          report detailed internal state and analysis results'
+        o.on_tail '    all                              include all the above reports'
+        o.on_tail '    none                             disable all reports'
         o.on('--report-file=FILE', 'also produce details on the automaton output to a file named FILE') {|v| @options.report_file = v }
         o.on('-o', '--output=FILE', 'leave output to FILE') {|v| @options.outfile = v }
 

--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -93,16 +93,16 @@ module Lrama
 
     BISON_REPORTS = %w[states itemsets lookaheads solved counterexamples cex all none]
     OTHER_REPORTS = %w[rules terms verbose]
-    NOT_SUPPORTED_REPORTS = %w[cex none]
+    NOT_SUPPORTED_REPORTS = %w[none]
+    ALIASED_REPORTS = { cex: :counterexamples }
     VALID_REPORTS = BISON_REPORTS + OTHER_REPORTS - NOT_SUPPORTED_REPORTS
 
     def validate_report(report)
-      list = VALID_REPORTS
       h = { grammar: true }
 
       report.each do |r|
-        if list.include?(r)
-          h[r.to_sym] = true
+        if VALID_REPORTS.include?(r)
+          h[aliased_report_option(r)] = true
         else
           raise "Invalid report option \"#{r}\"."
         end
@@ -117,6 +117,10 @@ module Lrama
       end
 
       return h
+    end
+
+    def aliased_report_option(opt)
+      (ALIASED_REPORTS[opt.to_sym] || opt).to_sym
     end
 
     VALID_TRACES = %w[

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe Lrama::OptionParser do
   describe "#validate_report" do
     let(:option_parser) { Lrama::OptionParser.new }
 
+    context "when no options are passed" do
+      it "returns option hash with grammar flag enabled" do
+        opts = option_parser.send(:validate_report, [])
+        expect(opts).to eq({grammar: true})
+      end
+    end
+
     context "when valid options are passed" do
       it "returns option hash" do
         opts = option_parser.send(:validate_report, ["states", "itemsets"])
@@ -99,8 +106,16 @@ RSpec.describe Lrama::OptionParser do
           opts = option_parser.send(:validate_report, ["all"])
           expect(opts).to eq({
             grammar: true, states: true, itemsets: true,
-            lookaheads: true, solved: true, counterexamples: true, cex: true,
+            lookaheads: true, solved: true, counterexamples: true,
+            rules: true, terms: true, verbose: true
           })
+        end
+      end
+
+      context "when none is passed" do
+        it "returns empty option hash" do
+          opts = option_parser.send(:validate_report, ["none"])
+          expect(opts).to eq({})
         end
       end
     end

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Lrama::OptionParser do
               -h, --help                       display this help and exit
 
           Valid Reports:
-              states itemsets lookaheads solved counterexamples all rules terms verbose
+              states itemsets lookaheads solved counterexamples cex all rules terms verbose
 
           Valid Traces:
               none locations scan parse automaton bitsets closure grammar rules actions resource sets muscles tools m4-early m4 skeleton time ielr cex all
@@ -81,18 +81,25 @@ RSpec.describe Lrama::OptionParser do
   describe "#validate_report" do
     let(:option_parser) { Lrama::OptionParser.new }
 
-    describe "valid options are passed" do
+    context "when valid options are passed" do
       it "returns option hash" do
         opts = option_parser.send(:validate_report, ["states", "itemsets"])
         expect(opts).to eq({grammar: true, states: true, itemsets: true})
       end
 
-      describe "all is passed" do
+      context "when cex is passed" do
+        it "returns option hash counterexamples flag enabled" do
+          opts = option_parser.send(:validate_report, ["cex"])
+          expect(opts).to eq({grammar: true, counterexamples: true})
+        end
+      end
+
+      context "when all is passed" do
         it "returns option hash all flags enabled" do
           opts = option_parser.send(:validate_report, ["all"])
           expect(opts).to eq({
             grammar: true, states: true, itemsets: true,
-            lookaheads: true, solved: true, counterexamples: true,
+            lookaheads: true, solved: true, counterexamples: true, cex: true,
           })
         end
       end

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Lrama::OptionParser do
           Output:
               -H, --header=[FILE]              also produce a header file named FILE
               -d                               also produce a header file
-              -r, --report=THINGS              also produce details on the automaton
+              -r, --report=REPORTS             also produce details on the automaton
                   --report-file=FILE           also produce details on the automaton output to a file named FILE
               -o, --output=FILE                leave output to FILE
                   --trace=THINGS               also output trace logs at runtime
@@ -67,8 +67,17 @@ RSpec.describe Lrama::OptionParser do
               -V, --version                    output version information and exit
               -h, --help                       display this help and exit
 
-          Valid Reports:
-              states itemsets lookaheads solved counterexamples cex all rules terms verbose
+          REPORTS is a list of comma-separated words that can include:
+              states                           describe the states
+              itemsets                         complete the core item sets with their closure
+              lookaheads                       explicitly associate lookahead tokens to items
+              solved                           describe shift/reduce conflicts solving
+              counterexamples, cex             generate conflict counterexamples
+              rules                            list unused rules
+              terms                            list unused terminals
+              verbose                          report detailed internal state and analysis results
+              all                              include all the above reports
+              none                             disable all reports
 
           Valid Traces:
               none locations scan parse automaton bitsets closure grammar rules actions resource sets muscles tools m4-early m4 skeleton time ielr cex all


### PR DESCRIPTION
This PR will improve the `--report` option as follows:
- Add support `cex` and `none` option in report
- Improve help text for report

Before:
```
Output:
    -H, --header=[FILE]              also produce a header file named FILE
    -d                               also produce a header file
    -r, --report=THINGS              also produce details on the automaton
        --report-file=FILE           also produce details on the automaton output to a file named FILE
: (snip)
Valid Reports:
    states itemsets lookaheads solved counterexamples all rules terms verbose
```

After:
```
Output:
    -H, --header=[FILE]              also produce a header file named FILE
    -d                               also produce a header file
    -r, --report=REPO_THINGS         also produce details on the automaton
        --report-file=FILE           also produce details on the automaton output to a file named FILE
: (snip)
REPO_THINGS is a list of comma-separated words that can include:
    states                           describe the states
    itemsets                         complete the core item sets with their closure
    lookaheads                       explicitly associate lookahead tokens to items
    solved                           describe shift/reduce conflicts solving
    counterexamples, cex             generate conflict counterexamples
    rules                            list unused rules
    terms                            list unused terminals
    verbose                          report detailed internal state and analysis results
    all                              include all the above reports
    none                             disable all reports
```