### PR TITLE
chore: Change rake command to use bundle exec in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ This also requires Lrama to be able to run with only default gems because BASERU
 ### How to generate parser.rb
 
 ```shell
-$ rake build:parser
+$ bundle exec rake build:parser
 ```
 
 `parser.rb` is generated from `parser.y` by Racc.


### PR DESCRIPTION
The rake command for building the parser was updated to use `bundle exec` to ensure it runs in the correct gem environment.