### PR TITLE
chore: Exclude sample directory from gemspec files

### DIFF
--- a/lrama.gemspec
+++ b/lrama.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features|sample)/}) }
   end
 
   spec.metadata["homepage_uri"]      = spec.homepage


### PR DESCRIPTION
The gemspec files were updated to exclude the `sample` directory from the list of files included in the gem. This ensures that the `sample` directory is not included when building the gem.