### PR TITLE
Check `grammar` directory and fix some types

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -6,23 +6,7 @@ target :lib do
   repo_path '.gem_rbs_collection/'
   signature "sig"
 
-  check "lib/lrama/grammar/code"
-  check "lib/lrama/grammar/parameterizing_rule"
-  check "lib/lrama/grammar/symbols"
-
-  check "lib/lrama/grammar/binding.rb"
-  check "lib/lrama/grammar/code.rb"
-  check "lib/lrama/grammar/counter.rb"
-  check "lib/lrama/grammar/destructor.rb"
-  check "lib/lrama/grammar/error_token.rb"
-  check "lib/lrama/grammar/percent_code.rb"
-  check "lib/lrama/grammar/precedence.rb"
-  check "lib/lrama/grammar/printer.rb"
-  check "lib/lrama/grammar/reference.rb"
-  check "lib/lrama/grammar/rule_builder.rb"
-  check "lib/lrama/grammar/symbol.rb"
-  check "lib/lrama/grammar/type.rb"
-
+  check "lib/lrama/grammar"
   check "lib/lrama/lexer"
   check "lib/lrama/report"
   check "lib/lrama/bitmap.rb"

--- a/sig/lrama/grammar/parameterizing_rule/rhs.rbs
+++ b/sig/lrama/grammar/parameterizing_rule/rhs.rbs
@@ -4,7 +4,7 @@ module Lrama
       class Rhs
         attr_reader symbols: Array[untyped]
         attr_reader user_code: Lexer::Token::UserCode?
-        attr_reader precedence_sym: Lexer::Token?
+        attr_reader precedence_sym: Grammar::Symbol?
 
         def initialize: () -> void
         def resolve_user_code: (Grammar::Binding bindings) -> Lexer::Token::UserCode?

--- a/sig/lrama/grammar/rule.rbs
+++ b/sig/lrama/grammar/rule.rbs
@@ -4,20 +4,20 @@ module Lrama
       attr_accessor id: Integer
       attr_accessor _lhs: Lexer::Token
       attr_accessor lhs: Grammar::Symbol
-      attr_accessor lhs_tag: untyped
+      attr_accessor lhs_tag: Lexer::Token::Tag?
       attr_accessor _rhs: Array[Lexer::Token]
       attr_accessor rhs: Array[Grammar::Symbol]
-      attr_accessor token_code: Lexer::Token::UserCode?
+      attr_accessor token_code: Grammar::Code?
       attr_accessor position_in_original_rule_rhs: Integer
       attr_accessor nullable: bool
-      attr_accessor precedence_sym: Lexer::Token?
+      attr_accessor precedence_sym: Grammar::Symbol?
       attr_accessor lineno: Integer?
       attr_accessor original_rule: Rule
 
       def initialize: (
-        ?id: Integer, ?_lhs: Lexer::Token, ?lhs: Lexer::Token, ?lhs_tag: untyped, ?_rhs: untyped, ?rhs: untyped,
+        ?id: Integer, ?_lhs: Lexer::Token, ?lhs: Lexer::Token, ?lhs_tag: Lexer::Token::Tag?, ?_rhs: Array[Lexer::Token], ?rhs: Array[Grammar::Symbol],
         ?token_code: Lexer::Token::UserCode?, ?position_in_original_rule_rhs: Integer?, ?nullable: bool,
-        ?precedence_sym: Lexer::Token?, ?lineno: Integer?
+        ?precedence_sym: Grammar::Symbol?, ?lineno: Integer?
       ) -> void
 
       def display_name: () -> String
@@ -27,6 +27,10 @@ module Lrama
       def empty_rule?: -> bool
 
       def initial_rule?: -> bool
+
+      def precedence: -> Precedence?
+
+      def translated_code: -> String?
 
       def with_actions: -> String
 

--- a/sig/lrama/grammar/rule_builder.rbs
+++ b/sig/lrama/grammar/rule_builder.rbs
@@ -6,7 +6,7 @@ module Lrama
       attr_reader lhs_tag: Lexer::Token::Tag?
       attr_reader rhs: Array[Lexer::Token]
       attr_reader user_code: Lexer::Token::UserCode?
-      attr_reader precedence_sym: Lexer::Token?
+      attr_reader precedence_sym: Grammar::Symbol?
 
       @rule_counter: Counter
       @midrule_action_counter: Counter
@@ -26,7 +26,7 @@ module Lrama
       def has_inline_rules?: -> bool
       def resolve_inline_rules: -> Array[RuleBuilder]
       def user_code=: (Lexer::Token::UserCode? user_code) -> void
-      def precedence_sym=: (Lexer::Token? precedence_sym) -> void
+      def precedence_sym=: (Grammar::Symbol? precedence_sym) -> void
       def complete_input: () -> void
       def setup_rules: () -> void
       def rules: () -> Array[Rule]


### PR DESCRIPTION
Type-checked all Ruby files contained in the `grammar` directory. Fixed to pass inspection.