### PR TITLE
Add support `-v`, `--verbose` option

### DIFF
--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -90,7 +90,7 @@ module Lrama
         o.on_tail '    time                             display generation time'
         o.on_tail '    all                              include all the above traces'
         o.on_tail '    none                             disable all traces'
-        o.on('-v', 'reserved, do nothing') { }
+        o.on('-v', '--verbose', "same as '--report=state'") {|_v| @report << 'states' }
         o.separator ''
         o.separator 'Diagnostics:'
         o.on('-W', '--warnings', 'report the warnings') {|v| @options.diagnostic = true }

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Lrama::OptionParser do
                   --report-file=FILE           also produce details on the automaton output to a file named FILE
               -o, --output=FILE                leave output to FILE
                   --trace=TRACES               also output trace logs at runtime
-              -v                               reserved, do nothing
+              -v, --verbose                    same as '--report=state'
 
           Diagnostics:
               -W, --warnings                   report the warnings
@@ -141,6 +141,20 @@ RSpec.describe Lrama::OptionParser do
     describe "invalid options are passed" do
       it "returns option hash" do
         expect { option_parser.send(:validate_report, ["invalid"]) }.to raise_error(/Invalid report option/)
+      end
+    end
+
+    context "when -v option is passed" do
+      it "returns option hash states flag enabled" do
+        opts = option_parser.send(:validate_report, ["states"])
+        expect(opts).to eq({grammar: true, states: true})
+      end
+    end
+
+    context "when --verbose option is passed" do
+      it "returns option hash states flag enabled" do
+        opts = option_parser.send(:validate_report, ["states"])
+        expect(opts).to eq({grammar: true, states: true})
       end
     end
   end


### PR DESCRIPTION
Add support for `-v` and `--vervose` options. These options align with Bison behavior.

```
❯ bison --help      
Usage: bison [OPTION]... FILE
Generate a deterministic LR or generalized LR (GLR) parser employing
LALR(1), IELR(1), or canonical LR(1) parser tables.
: (snip)
Output Files:
  -H, --header=[FILE]           also produce a header file
  -d                            likewise but cannot specify FILE (for POSIX Yacc)
  -r, --report=THINGS           also produce details on the automaton
      --report-file=FILE        write report to FILE
  -v, --verbose                 same as '--report=state'
```