### PR TITLE
Organize parser.y

### DIFF
--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 473)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 425)
 
 include Lrama::Report::Duration
 
@@ -728,170 +728,164 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    94,    48,    95,   181,    85,    77,    48,    48,   187,   181,
-    77,    77,    48,    48,   187,    47,    77,   184,    69,    48,
-     6,    47,   184,   184,    81,    48,    40,    47,   184,    77,
-    74,    48,   158,    47,    41,   159,    81,    92,    44,    48,
-    48,    47,    47,    86,    81,    81,   183,   185,    45,    96,
-   159,   190,   183,    92,     4,    52,     5,   190,    20,    24,
-    25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
-    35,    36,    37,    38,    20,    24,    25,    26,    27,    28,
-    29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-    11,    12,    13,    14,    15,    16,   118,   119,    17,    18,
-    19,    52,    20,    24,    25,    26,    27,    28,    29,    30,
-    31,    32,    33,    34,    35,    36,    37,    38,    11,    12,
-    13,    14,    15,    16,    52,    55,    17,    18,    19,    43,
+    94,    48,    95,   165,    48,    77,   171,    48,    77,   165,
+    48,    77,   171,     6,    77,    85,    48,     4,    47,     5,
+    48,    69,    47,    40,    77,    74,    48,    48,    47,    47,
+    41,    81,    81,    48,    44,    47,    92,    48,    81,    47,
+    45,    48,    81,    47,   167,   168,   116,   174,   168,    96,
+   167,   168,    86,   174,   168,    20,    24,    25,    26,    27,
+    28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
+    38,    92,    48,     4,    47,     5,    77,   103,    48,    48,
+    47,    47,    77,   103,    48,    48,    47,    47,    77,   103,
     20,    24,    25,    26,    27,    28,    29,    30,    31,    32,
-    33,    34,    35,    36,    37,    38,    48,     4,    47,     5,
-    48,   115,    47,    56,    77,   195,    48,    48,    47,    47,
-    77,   195,    48,    48,    47,    47,    77,   195,    48,    48,
-    47,    47,    77,   195,    48,    48,    47,    47,    77,    77,
-    48,    48,    47,    47,    77,    77,    48,    48,    47,   219,
-    77,    77,    48,    48,   219,    47,    77,    77,    48,    48,
-   219,    47,    77,   202,   203,   204,   130,   202,   203,   204,
-   130,   226,   231,   238,   227,   227,   227,    48,    48,    47,
-    47,    48,    57,    47,   202,   203,   204,    58,    59,    60,
-    61,    62,    63,    64,    65,    87,    52,    99,   105,   108,
-   110,   117,   124,   125,   127,   130,   131,   133,   134,   135,
-   136,   137,    77,   144,   145,   146,   147,   149,   150,   152,
-   162,   144,   164,   167,   168,   169,   171,   172,   173,   174,
-   175,   176,   178,   179,   186,   191,   198,   162,   205,   130,
-   209,   167,   211,   130,   162,   221,   162,   130,   176,   179,
-   228,   179,   176,   176,   236,   130,   176 ]
+    33,    34,    35,    36,    37,    38,    11,    12,    13,    14,
+    15,    16,    17,    18,    19,    52,    20,    24,    25,    26,
+    27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
+    37,    38,    11,    12,    13,    14,    15,    16,    17,    18,
+    19,    43,    20,    24,    25,    26,    27,    28,    29,    30,
+    31,    32,    33,    34,    35,    36,    37,    38,    48,    48,
+    47,    47,    77,   103,    48,    48,    47,    47,    77,    77,
+    48,    48,    47,    47,    77,    77,    48,    48,    47,   195,
+    77,    77,    48,    48,   195,    47,    77,    77,    48,    52,
+   195,   148,    77,   169,   149,    52,   149,   179,   180,   181,
+   131,   179,   180,   181,   131,   202,   207,   214,   203,   203,
+   203,    48,    48,    47,    47,    48,    48,    47,    47,   179,
+   180,   181,   119,   120,    55,    52,    52,    52,    52,    52,
+    61,    62,    63,    64,    65,    87,    52,    52,   106,   109,
+   111,   118,   125,   126,   128,   131,   132,    77,   140,   141,
+   142,   143,   145,   146,   152,   140,   154,   157,   158,   159,
+   160,   162,   163,   170,   175,   152,   182,   131,   186,   157,
+   188,   131,   152,   197,   152,   131,   160,   163,   204,   163,
+   160,   160,   212,   131,   160 ]
 
 racc_action_check = [
-    46,   161,    46,   161,    38,   161,   166,   199,   166,   199,
-   166,   199,   210,    32,   210,    32,   210,   161,    32,    34,
-     1,    34,   166,   199,    34,    33,     5,    33,   210,    33,
-    33,    35,   143,    35,     6,   143,    35,    44,     9,    36,
-    37,    36,    37,    38,    36,    37,   161,   163,    11,    46,
-   163,   166,   199,    88,     0,    13,     0,   210,    44,    44,
+    46,   151,    46,   151,   156,   151,   156,   176,   156,   176,
+   187,   176,   187,     1,   187,    38,    32,     0,    32,     0,
+    33,    32,    33,     5,    33,    33,    34,    35,    34,    35,
+     6,    34,    35,    36,     9,    36,    44,    37,    36,    37,
+    11,    79,    37,    79,   151,   151,    79,   156,   156,    46,
+   176,   176,    38,   187,   187,    44,    44,    44,    44,    44,
     44,    44,    44,    44,    44,    44,    44,    44,    44,    44,
-    44,    44,    44,    44,    88,    88,    88,    88,    88,    88,
+    44,    88,    58,     2,    58,     2,    58,    58,    59,    12,
+    59,    12,    59,    59,    60,    67,    60,    67,    60,    60,
     88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
-     3,     3,     3,     3,     3,     3,    86,    86,     3,     3,
-     3,    14,     3,     3,     3,     3,     3,     3,     3,     3,
-     3,     3,     3,     3,     3,     3,     3,     3,     8,     8,
-     8,     8,     8,     8,    15,    16,     8,     8,     8,     8,
+    88,    88,    88,    88,    88,    88,     3,     3,     3,     3,
+     3,     3,     3,     3,     3,    13,     3,     3,     3,     3,
+     3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+     3,     3,     8,     8,     8,     8,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
-     8,     8,     8,     8,     8,     8,    79,     2,    79,     2,
-   173,    79,   173,    17,   173,   173,   174,    12,   174,    12,
-   174,   174,   175,    67,   175,    67,   175,   175,   192,    69,
-   192,    69,   192,   192,    72,    74,    72,    74,    72,    74,
-   110,   183,   110,   183,   110,   183,   190,   205,   190,   205,
-   190,   205,   211,   227,   211,   227,   211,   227,   228,    81,
-   228,    81,   228,   180,   180,   180,   180,   188,   188,   188,
-   188,   218,   223,   235,   218,   223,   235,   105,   113,   105,
-   113,   115,    20,   115,   220,   220,   220,    24,    25,    26,
+     8,     8,     8,     8,     8,     8,     8,     8,   100,    69,
+   100,    69,   100,   100,    72,    74,    72,    74,    72,    74,
+   111,   167,   111,   167,   111,   167,   174,   182,   174,   182,
+   174,   182,   188,   203,   188,   203,   188,   203,   204,    14,
+   204,   139,   204,   153,   139,    15,   153,   164,   164,   164,
+   164,   172,   172,   172,   172,   194,   199,   211,   194,   199,
+   211,    81,   106,    81,   106,   114,   116,   114,   116,   196,
+   196,   196,    86,    86,    16,    17,    20,    24,    25,    26,
     27,    28,    29,    30,    31,    39,    50,    55,    66,    70,
-    71,    85,    89,    90,    91,    92,    98,   100,   101,   102,
-   103,   104,   109,   117,   118,   119,   120,   129,   130,   132,
-   145,   146,   148,   149,   150,   151,   153,   154,   155,   156,
-   157,   158,   159,   160,   165,   170,   177,   179,   181,   182,
-   185,   186,   187,   189,   198,   208,   209,   213,   214,   217,
-   219,   222,   224,   226,   230,   231,   237 ]
+    71,    85,    89,    90,    91,    92,    98,   110,   118,   119,
+   120,   121,   130,   131,   141,   142,   144,   145,   146,   147,
+   148,   149,   150,   155,   161,   163,   165,   166,   169,   170,
+   171,   173,   175,   185,   186,   190,   191,   193,   195,   198,
+   200,   202,   206,   207,   213 ]
 
 racc_action_pointer = [
-    44,    20,   137,    77,   nil,    19,    34,   nil,   105,    29,
-   nil,    42,   154,    36,    82,   105,   120,   134,   nil,   nil,
-   203,   nil,   nil,   nil,   208,   209,   210,   225,   226,   227,
-   228,   229,    10,    22,    16,    28,    36,    37,    -1,   233,
-   nil,   nil,   nil,   nil,    33,   nil,    -5,   nil,   nil,   nil,
-   217,   nil,   nil,   nil,   nil,   218,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   230,   160,   nil,   166,
-   233,   232,   171,   nil,   172,   nil,   nil,   nil,   nil,   143,
-   nil,   196,   nil,   nil,   nil,   200,    92,   nil,    49,   233,
-   219,   220,   193,   nil,   nil,   nil,   nil,   nil,   244,   nil,
-   245,   246,   247,   248,   249,   214,   nil,   nil,   nil,   245,
-   177,   nil,   nil,   215,   nil,   218,   nil,   248,   211,   214,
-   245,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   214,
-   253,   nil,   257,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   -10,   nil,   213,   256,   nil,   260,   216,
-   211,   245,   nil,   246,   247,   248,   249,   250,   263,   267,
-   227,    -2,   nil,     5,   nil,   228,     3,   nil,   nil,   nil,
-   255,   nil,   nil,   147,   153,   159,   nil,   233,   nil,   230,
-   154,   237,   227,   178,   nil,   237,   234,   241,   158,   231,
-   183,   nil,   165,   nil,   nil,   nil,   nil,   nil,   237,     4,
-   nil,   nil,   nil,   nil,   nil,   184,   nil,   nil,   283,   239,
-     9,   189,   nil,   235,   280,   nil,   nil,   243,   169,   249,
-   175,   nil,   245,   170,   284,   nil,   285,   190,   195,   nil,
-   274,   243,   nil,   nil,   nil,   171,   nil,   288,   nil,   nil ]
+     7,    13,    63,    93,   nil,    16,    30,   nil,   119,    25,
+   nil,    34,    76,    68,   142,   148,   219,   178,   nil,   nil,
+   179,   nil,   nil,   nil,   180,   181,   182,   225,   226,   227,
+   228,   229,    13,    17,    23,    24,    30,    34,    10,   233,
+   nil,   nil,   nil,   nil,    32,   nil,    -5,   nil,   nil,   nil,
+   189,   nil,   nil,   nil,   nil,   190,   nil,   nil,    69,    75,
+    81,   nil,   nil,   nil,   nil,   nil,   230,    82,   nil,   156,
+   233,   232,   161,   nil,   162,   nil,   nil,   nil,   nil,    38,
+   nil,   208,   nil,   nil,   nil,   202,   218,   nil,    67,   233,
+   221,   222,   193,   nil,   nil,   nil,   nil,   nil,   244,   nil,
+   155,   nil,   nil,   nil,   nil,   nil,   209,   nil,   nil,   nil,
+   240,   167,   nil,   nil,   212,   nil,   213,   nil,   243,   208,
+   211,   240,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   211,   248,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   151,
+   nil,   209,   250,   nil,   254,   212,   205,   211,   252,   256,
+   218,    -2,   nil,   153,   nil,   219,     1,   nil,   nil,   nil,
+   nil,   223,   nil,   220,   148,   227,   215,   168,   nil,   227,
+   224,   231,   152,   219,   173,   227,     4,   nil,   nil,   nil,
+   nil,   nil,   174,   nil,   nil,   271,   229,     7,   179,   nil,
+   223,   268,   nil,   233,   165,   239,   170,   nil,   235,   166,
+   272,   nil,   273,   180,   185,   nil,   234,   231,   nil,   nil,
+   nil,   167,   nil,   276,   nil,   nil ]
 
 racc_action_default = [
-    -1,  -139,    -1,    -3,   -10,  -139,  -139,    -2,    -3,  -139,
-   -16,  -139,  -139,  -139,  -139,  -139,  -139,  -139,   -28,   -29,
-  -139,   -36,   -37,   -38,  -139,  -139,  -139,  -139,  -139,  -139,
-  -139,  -139,  -139,  -139,  -139,  -139,  -139,  -139,  -139,  -139,
-   -13,   240,    -4,   -30,  -139,   -17,  -132,  -102,  -103,  -131,
-   -14,   -19,   -94,   -20,   -21,  -139,   -25,   -33,   -39,   -42,
-   -45,   -48,   -49,   -50,   -51,   -52,   -53,   -59,   -61,  -139,
-   -64,   -54,   -87,   -89,  -139,   -92,   -93,  -138,   -55,   -97,
-   -99,  -139,   -56,   -57,   -58,  -139,  -139,   -11,    -5,    -7,
-  -104,  -139,   -76,   -18,  -133,  -134,  -135,   -15,  -139,   -22,
-  -139,  -139,  -139,  -139,  -139,  -139,   -60,   -62,   -65,   -85,
-  -139,   -88,   -90,   -97,   -98,  -139,  -100,  -139,  -139,  -139,
-  -139,    -6,    -8,    -9,  -129,  -105,  -106,  -107,   -77,  -139,
-  -139,   -95,  -139,   -26,   -34,   -40,   -43,   -46,   -63,   -66,
-   -86,   -91,  -101,  -139,   -72,   -78,  -139,   -12,  -139,  -111,
-  -139,  -139,   -23,  -139,  -139,  -139,  -139,  -139,   -67,  -139,
-   -70,   -74,   -79,  -139,  -130,  -108,  -109,  -112,  -128,   -96,
-  -139,   -27,   -35,  -139,  -139,  -139,   -68,  -139,   -73,   -78,
-   -76,  -102,   -76,  -139,  -125,  -139,  -111,  -102,   -76,   -76,
-  -139,   -24,   -31,   -41,  -136,  -137,   -44,   -47,   -78,   -75,
-   -80,   -81,  -118,  -119,  -120,  -139,   -83,   -84,  -139,   -78,
-  -110,  -139,  -113,   -76,   -67,  -117,   -32,   -69,  -139,  -102,
-  -121,  -126,   -71,  -139,   -67,  -116,   -67,  -139,  -139,  -123,
-  -139,   -76,  -114,   -82,  -122,  -139,  -127,   -67,  -124,  -115 ]
+    -1,  -127,    -1,    -3,   -10,  -127,  -127,    -2,    -3,  -127,
+   -16,  -127,  -127,  -127,  -127,  -127,  -127,  -127,   -24,   -25,
+  -127,   -30,   -31,   -32,  -127,  -127,  -127,  -127,  -127,  -127,
+  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
+   -13,   216,    -4,   -26,  -127,   -17,  -120,   -90,   -91,  -119,
+   -14,   -19,   -82,   -20,   -21,  -127,   -23,   -29,  -127,  -127,
+  -127,   -36,   -37,   -38,   -39,   -40,   -41,   -47,   -49,  -127,
+   -52,   -42,   -75,   -77,  -127,   -80,   -81,  -126,   -43,   -85,
+   -87,  -127,   -44,   -45,   -46,  -127,  -127,   -11,    -5,    -7,
+   -92,  -127,   -64,   -18,  -121,  -122,  -123,   -15,  -127,   -22,
+   -27,   -33,  -124,  -125,   -34,   -35,  -127,   -48,   -50,   -53,
+   -73,  -127,   -76,   -78,   -85,   -86,  -127,   -88,  -127,  -127,
+  -127,  -127,    -6,    -8,    -9,  -117,   -93,   -94,   -95,   -65,
+  -127,  -127,   -83,   -28,   -51,   -54,   -74,   -79,   -89,  -127,
+   -60,   -66,  -127,   -12,  -127,   -99,  -127,  -127,   -55,  -127,
+   -58,   -62,   -67,  -127,  -118,   -96,   -97,  -100,  -116,   -84,
+   -56,  -127,   -61,   -66,   -64,   -90,   -64,  -127,  -113,  -127,
+   -99,   -90,   -64,   -64,  -127,   -66,   -63,   -68,   -69,  -106,
+  -107,  -108,  -127,   -71,   -72,  -127,   -66,   -98,  -127,  -101,
+   -64,   -55,  -105,   -57,  -127,   -90,  -109,  -114,   -59,  -127,
+   -55,  -104,   -55,  -127,  -127,  -111,  -127,   -64,  -102,   -70,
+  -110,  -127,  -115,   -55,  -112,  -103 ]
 
 racc_goto_table = [
-   129,    49,    73,   177,   201,    68,    89,    91,   189,   160,
-   166,     1,   213,   193,   196,   197,   143,   180,     3,   122,
-     7,    70,   188,    79,    79,    79,    79,   123,     9,   194,
-   194,   194,   216,    42,    39,    51,    53,    54,   120,   207,
-   106,   111,   107,   112,   229,   163,   215,   210,   194,    46,
-   121,    91,   189,    93,   218,   180,    70,   132,    70,   225,
-   223,   220,   217,   170,   100,   153,   188,   220,   113,   232,
-   113,   233,    97,   222,   114,   101,   116,   235,   138,   141,
-   154,   102,   239,   234,   220,   155,   103,   156,   200,   104,
-   206,   157,    66,    71,    70,   139,   212,   214,    78,    82,
-    83,    84,   113,   109,   113,   199,   140,    98,   114,   151,
-   142,   126,   165,   208,   230,   148,   nil,   nil,   nil,   nil,
-   nil,   224,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   237 ]
+   102,   102,   102,    49,   130,    73,    68,    89,   156,   161,
+    91,   150,     1,   101,   104,   105,    51,    53,    54,   173,
+   123,   124,   115,    70,   117,    79,    79,    79,    79,    56,
+     9,    39,    57,   187,   121,    42,    58,    59,    60,   178,
+   139,   107,   102,   108,   112,   193,   113,   190,    46,    93,
+   173,   122,   201,    97,    91,   133,   198,   115,    70,   138,
+    70,   208,    66,   209,   153,    71,     3,    99,     7,   194,
+   114,   205,   114,   135,   215,   199,   177,   110,   183,   176,
+   134,   136,    98,   137,   189,   191,    78,    82,    83,    84,
+   147,   211,   127,   164,   155,   185,   206,    70,   172,   144,
+   nil,   nil,   200,   nil,   nil,   114,   nil,   114,   nil,   184,
+   nil,   nil,   nil,   nil,   nil,   nil,   192,   nil,   164,   213,
+   nil,   nil,   nil,   nil,   196,   nil,   nil,   nil,   nil,   172,
+   196,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   210,   196 ]
 
 racc_goto_check = [
-    51,    39,    53,    44,    48,    38,     8,    12,    50,    43,
-    60,     1,    48,    25,    25,    25,    42,    46,     6,     5,
-     6,    39,    46,    39,    39,    39,    39,     9,     7,    46,
-    46,    46,    25,     7,    10,    16,    16,    16,    11,    46,
-    38,    53,    38,    53,    48,    42,    46,    60,    46,    13,
-     8,    12,    50,    14,    49,    46,    39,    17,    39,    44,
-    49,    46,    43,    18,    19,    20,    46,    46,    39,    44,
-    39,    44,    16,    43,    56,    26,    56,    49,    38,    53,
-    27,    28,    44,    46,    46,    29,    30,    31,    51,    32,
-    51,    33,    34,    35,    39,    40,    51,    51,    36,    36,
-    36,    36,    39,    41,    39,    45,    52,    54,    56,    55,
-    56,    58,    59,    61,    62,    63,   nil,   nil,   nil,   nil,
-   nil,    51,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    51 ]
+    34,    34,    34,    27,    39,    41,    26,     8,    48,    32,
+    12,    31,     1,    21,    21,    21,    16,    16,    16,    38,
+     5,     9,    44,    27,    44,    27,    27,    27,    27,    15,
+     7,    10,    15,    48,    11,     7,    15,    15,    15,    36,
+    30,    26,    34,    26,    41,    31,    41,    36,    13,    14,
+    38,     8,    32,    16,    12,    21,    31,    44,    27,    44,
+    27,    32,    22,    32,    30,    23,     6,    15,     6,    37,
+    27,    36,    27,    28,    32,    37,    39,    29,    39,    33,
+    26,    40,    42,    41,    39,    39,    24,    24,    24,    24,
+    43,    37,    46,    34,    47,    49,    50,    27,    34,    51,
+   nil,   nil,    39,   nil,   nil,    27,   nil,    27,   nil,    34,
+   nil,   nil,   nil,   nil,   nil,   nil,    34,   nil,    34,    39,
+   nil,   nil,   nil,   nil,    34,   nil,   nil,   nil,   nil,    34,
+    34,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,    34,    34 ]
 
 racc_goto_pointer = [
-   nil,    11,   nil,   nil,   nil,   -70,    18,    25,   -38,   -62,
-    30,   -49,   -37,    37,     7,   nil,    22,   -42,   -89,     8,
-   -68,   nil,   nil,   nil,   nil,  -160,    18,   -54,    23,   -50,
-    27,   -49,    29,   -46,    60,    60,    64,   nil,   -27,   -11,
-   -14,    33,  -101,  -136,  -155,   -74,  -144,   nil,  -176,  -151,
-  -158,   -92,    -3,   -31,    55,   -22,    -5,   nil,    21,   -37,
-  -139,   -71,  -107,    -9 ]
+   nil,    12,   nil,   nil,   nil,   -69,    66,    27,   -37,   -68,
+    27,   -53,   -34,    36,     3,    12,     3,   nil,   nil,   nil,
+   nil,   -45,    30,    32,    52,   nil,   -26,    -9,   -37,     7,
+   -78,  -130,  -139,   -84,   -58,   nil,  -125,  -113,  -137,   -88,
+   -29,   -28,    30,   -42,   -57,   nil,     2,   -51,  -137,   -73,
+  -101,   -26 ]
 
 racc_goto_default = [
    nil,   nil,     2,     8,    88,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    10,   nil,   nil,    50,   nil,   nil,   nil,   nil,
-   nil,    21,    22,    23,   192,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,    67,   nil,    75,
-   nil,   nil,   nil,   nil,   nil,   161,    72,   128,   nil,   nil,
-   182,   nil,    76,   nil,   nil,   nil,    80,    90,   nil,   nil,
-   nil,   nil,   nil,   nil ]
+   nil,   nil,    10,   nil,   nil,    50,   nil,    21,    22,    23,
+   100,   nil,   nil,   nil,   nil,    67,   nil,    75,   nil,   nil,
+   nil,   nil,   nil,   151,    72,   129,   nil,   nil,   166,   nil,
+    76,   nil,   nil,   nil,    80,    90,   nil,   nil,   nil,   nil,
+   nil,   nil ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -916,127 +910,115 @@ racc_reduce_table = [
   2, 58, :_reduce_none,
   2, 58, :_reduce_20,
   2, 58, :_reduce_21,
-  0, 72, :_reduce_22,
-  0, 73, :_reduce_23,
-  7, 58, :_reduce_24,
-  0, 74, :_reduce_25,
-  0, 75, :_reduce_26,
-  6, 58, :_reduce_27,
-  1, 58, :_reduce_28,
-  1, 58, :_reduce_29,
+  3, 58, :_reduce_22,
+  2, 58, :_reduce_23,
+  1, 58, :_reduce_24,
+  1, 58, :_reduce_25,
   2, 58, :_reduce_none,
-  1, 80, :_reduce_31,
-  2, 80, :_reduce_32,
-  0, 81, :_reduce_33,
-  0, 82, :_reduce_34,
-  6, 67, :_reduce_35,
+  1, 76, :_reduce_27,
+  2, 76, :_reduce_28,
+  2, 67, :_reduce_29,
   1, 67, :_reduce_none,
   1, 67, :_reduce_none,
   1, 67, :_reduce_none,
-  0, 83, :_reduce_39,
-  0, 84, :_reduce_40,
-  7, 67, :_reduce_41,
-  0, 85, :_reduce_42,
-  0, 86, :_reduce_43,
-  7, 67, :_reduce_44,
-  0, 87, :_reduce_45,
-  0, 88, :_reduce_46,
-  7, 67, :_reduce_47,
-  2, 67, :_reduce_48,
-  2, 67, :_reduce_49,
-  2, 67, :_reduce_50,
-  2, 67, :_reduce_51,
-  2, 67, :_reduce_52,
-  2, 76, :_reduce_none,
-  2, 76, :_reduce_54,
-  2, 76, :_reduce_55,
-  2, 76, :_reduce_56,
-  2, 76, :_reduce_57,
-  2, 76, :_reduce_58,
-  1, 93, :_reduce_59,
-  2, 93, :_reduce_60,
-  1, 89, :_reduce_61,
-  2, 89, :_reduce_62,
-  3, 89, :_reduce_63,
-  0, 96, :_reduce_none,
-  1, 96, :_reduce_none,
-  3, 92, :_reduce_66,
-  0, 99, :_reduce_none,
-  1, 99, :_reduce_none,
-  8, 77, :_reduce_69,
-  5, 78, :_reduce_70,
-  8, 78, :_reduce_71,
-  1, 97, :_reduce_72,
-  3, 97, :_reduce_73,
-  1, 98, :_reduce_74,
-  3, 98, :_reduce_75,
-  0, 106, :_reduce_none,
-  1, 106, :_reduce_none,
-  0, 100, :_reduce_78,
-  1, 100, :_reduce_79,
-  3, 100, :_reduce_80,
-  3, 100, :_reduce_81,
-  6, 100, :_reduce_82,
-  3, 100, :_reduce_83,
-  3, 100, :_reduce_84,
-  0, 95, :_reduce_none,
-  1, 95, :_reduce_86,
-  1, 108, :_reduce_87,
-  2, 108, :_reduce_88,
-  1, 90, :_reduce_89,
-  2, 90, :_reduce_90,
-  3, 90, :_reduce_91,
+  3, 67, :_reduce_33,
+  3, 67, :_reduce_34,
+  3, 67, :_reduce_35,
+  2, 67, :_reduce_36,
+  2, 67, :_reduce_37,
+  2, 67, :_reduce_38,
+  2, 67, :_reduce_39,
+  2, 67, :_reduce_40,
+  2, 72, :_reduce_none,
+  2, 72, :_reduce_42,
+  2, 72, :_reduce_43,
+  2, 72, :_reduce_44,
+  2, 72, :_reduce_45,
+  2, 72, :_reduce_46,
+  1, 81, :_reduce_47,
+  2, 81, :_reduce_48,
+  1, 77, :_reduce_49,
+  2, 77, :_reduce_50,
+  3, 77, :_reduce_51,
+  0, 84, :_reduce_none,
+  1, 84, :_reduce_none,
+  3, 80, :_reduce_54,
+  0, 87, :_reduce_none,
+  1, 87, :_reduce_none,
+  8, 73, :_reduce_57,
+  5, 74, :_reduce_58,
+  8, 74, :_reduce_59,
+  1, 85, :_reduce_60,
+  3, 85, :_reduce_61,
+  1, 86, :_reduce_62,
+  3, 86, :_reduce_63,
+  0, 94, :_reduce_none,
+  1, 94, :_reduce_none,
+  0, 88, :_reduce_66,
+  1, 88, :_reduce_67,
+  3, 88, :_reduce_68,
+  3, 88, :_reduce_69,
+  6, 88, :_reduce_70,
+  3, 88, :_reduce_71,
+  3, 88, :_reduce_72,
+  0, 83, :_reduce_none,
+  1, 83, :_reduce_74,
+  1, 96, :_reduce_75,
+  2, 96, :_reduce_76,
+  1, 78, :_reduce_77,
+  2, 78, :_reduce_78,
+  3, 78, :_reduce_79,
+  1, 89, :_reduce_none,
+  1, 89, :_reduce_none,
+  0, 97, :_reduce_82,
+  0, 98, :_reduce_83,
+  5, 70, :_reduce_84,
+  1, 99, :_reduce_85,
+  2, 99, :_reduce_86,
+  1, 79, :_reduce_87,
+  2, 79, :_reduce_88,
+  3, 79, :_reduce_89,
+  1, 82, :_reduce_90,
+  1, 82, :_reduce_91,
+  0, 101, :_reduce_none,
   1, 101, :_reduce_none,
-  1, 101, :_reduce_none,
-  0, 109, :_reduce_94,
-  0, 110, :_reduce_95,
-  5, 70, :_reduce_96,
-  1, 111, :_reduce_97,
-  2, 111, :_reduce_98,
-  1, 91, :_reduce_99,
-  2, 91, :_reduce_100,
-  3, 91, :_reduce_101,
-  1, 94, :_reduce_102,
-  1, 94, :_reduce_103,
-  0, 113, :_reduce_none,
-  1, 113, :_reduce_none,
   2, 59, :_reduce_none,
   2, 59, :_reduce_none,
-  4, 112, :_reduce_108,
-  1, 114, :_reduce_109,
-  3, 114, :_reduce_110,
-  0, 115, :_reduce_111,
-  1, 115, :_reduce_112,
-  3, 115, :_reduce_113,
-  5, 115, :_reduce_114,
-  7, 115, :_reduce_115,
-  4, 115, :_reduce_116,
-  3, 115, :_reduce_117,
-  1, 103, :_reduce_118,
-  1, 103, :_reduce_119,
-  1, 103, :_reduce_120,
-  1, 104, :_reduce_121,
-  3, 104, :_reduce_122,
-  2, 104, :_reduce_123,
-  4, 104, :_reduce_124,
-  0, 116, :_reduce_125,
-  0, 117, :_reduce_126,
-  5, 105, :_reduce_127,
-  3, 102, :_reduce_128,
-  0, 118, :_reduce_129,
-  3, 60, :_reduce_130,
+  4, 100, :_reduce_96,
+  1, 102, :_reduce_97,
+  3, 102, :_reduce_98,
+  0, 103, :_reduce_99,
+  1, 103, :_reduce_100,
+  3, 103, :_reduce_101,
+  5, 103, :_reduce_102,
+  7, 103, :_reduce_103,
+  4, 103, :_reduce_104,
+  3, 103, :_reduce_105,
+  1, 91, :_reduce_106,
+  1, 91, :_reduce_107,
+  1, 91, :_reduce_108,
+  1, 92, :_reduce_109,
+  3, 92, :_reduce_110,
+  2, 92, :_reduce_111,
+  4, 92, :_reduce_112,
+  0, 104, :_reduce_113,
+  0, 105, :_reduce_114,
+  5, 93, :_reduce_115,
+  3, 90, :_reduce_116,
+  0, 106, :_reduce_117,
+  3, 60, :_reduce_118,
   1, 68, :_reduce_none,
   0, 69, :_reduce_none,
   1, 69, :_reduce_none,
   1, 69, :_reduce_none,
   1, 69, :_reduce_none,
-  1, 79, :_reduce_none,
-  1, 79, :_reduce_none,
-  1, 107, :_reduce_138 ]
+  1, 75, :_reduce_none,
+  1, 75, :_reduce_none,
+  1, 95, :_reduce_126 ]
 
-racc_reduce_n = 139
+racc_reduce_n = 127
 
-racc_shift_n = 240
+racc_shift_n = 216
 
 racc_token_table = {
   false => 0,
@@ -1058,36 +1040,36 @@ racc_token_table = {
   "%lex-param" => 16,
   "%parse-param" => 17,
   "%code" => 18,
-  "{" => 19,
-  "}" => 20,
-  "%initial-action" => 21,
-  "%no-stdlib" => 22,
-  "%locations" => 23,
-  ";" => 24,
-  "%union" => 25,
-  "%destructor" => 26,
-  "%printer" => 27,
-  "%error-token" => 28,
-  "%after-shift" => 29,
-  "%before-reduce" => 30,
-  "%after-reduce" => 31,
-  "%after-shift-error-token" => 32,
-  "%after-pop-stack" => 33,
-  "%token" => 34,
-  "%type" => 35,
-  "%left" => 36,
-  "%right" => 37,
-  "%precedence" => 38,
-  "%nonassoc" => 39,
-  "%rule" => 40,
-  "(" => 41,
-  ")" => 42,
-  ":" => 43,
-  "%inline" => 44,
-  "," => 45,
-  "|" => 46,
-  "%empty" => 47,
-  "%prec" => 48,
+  "%initial-action" => 19,
+  "%no-stdlib" => 20,
+  "%locations" => 21,
+  ";" => 22,
+  "%union" => 23,
+  "%destructor" => 24,
+  "%printer" => 25,
+  "%error-token" => 26,
+  "%after-shift" => 27,
+  "%before-reduce" => 28,
+  "%after-reduce" => 29,
+  "%after-shift-error-token" => 30,
+  "%after-pop-stack" => 31,
+  "%token" => 32,
+  "%type" => 33,
+  "%left" => 34,
+  "%right" => 35,
+  "%precedence" => 36,
+  "%nonassoc" => 37,
+  "%rule" => 38,
+  "(" => 39,
+  ")" => 40,
+  ":" => 41,
+  "%inline" => 42,
+  "," => 43,
+  "|" => 44,
+  "%empty" => 45,
+  "%prec" => 46,
+  "{" => 47,
+  "}" => 48,
   "?" => 49,
   "+" => 50,
   "*" => 51,
@@ -1136,8 +1118,6 @@ Racc_token_to_s_table = [
   "\"%lex-param\"",
   "\"%parse-param\"",
   "\"%code\"",
-  "\"{\"",
-  "\"}\"",
   "\"%initial-action\"",
   "\"%no-stdlib\"",
   "\"%locations\"",
@@ -1166,6 +1146,8 @@ Racc_token_to_s_table = [
   "\"|\"",
   "\"%empty\"",
   "\"%prec\"",
+  "\"{\"",
+  "\"}\"",
   "\"?\"",
   "\"+\"",
   "\"*\"",
@@ -1189,23 +1171,11 @@ Racc_token_to_s_table = [
   "value",
   "param",
   "\"-many1@param\"",
-  "@3",
-  "@4",
-  "@5",
-  "@6",
   "symbol_declaration",
   "rule_declaration",
   "inline_declaration",
   "generic_symbol",
   "\"-many1@generic_symbol\"",
-  "@7",
-  "@8",
-  "@9",
-  "@10",
-  "@11",
-  "@12",
-  "@13",
-  "@14",
   "token_declarations",
   "symbol_declarations",
   "token_declarations_for_precedence",
@@ -1226,16 +1196,16 @@ Racc_token_to_s_table = [
   "\"-option@named_ref\"",
   "string_as_id",
   "\"-many1@symbol\"",
-  "@15",
-  "@16",
+  "@3",
+  "@4",
   "\"-many1@id\"",
   "rules",
   "\"-option@;\"",
   "rhs_list",
   "rhs",
-  "@17",
-  "@18",
-  "@19" ]
+  "@5",
+  "@6",
+  "@7" ]
 Ractor.make_shareable(Racc_token_to_s_table) if defined?(Ractor)
 
 Racc_debug_parser = true
@@ -1319,14 +1289,14 @@ module_eval(<<'.,.,', 'parser.y', 21)
 
 # reduce 13 omitted
 
-module_eval(<<'.,.,', 'parser.y', 71)
+module_eval(<<'.,.,', 'parser.y', 55)
   def _reduce_14(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 71)
+module_eval(<<'.,.,', 'parser.y', 55)
   def _reduce_15(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
@@ -1368,7 +1338,7 @@ module_eval(<<'.,.,', 'parser.y', 38)
 
 module_eval(<<'.,.,', 'parser.y', 44)
   def _reduce_22(val, _values, result)
-                             begin_c_declaration("}")
+                             @grammar.add_percent_code(id: val[1], code: val[2])
 
     result
   end
@@ -1376,235 +1346,139 @@ module_eval(<<'.,.,', 'parser.y', 44)
 
 module_eval(<<'.,.,', 'parser.y', 48)
   def _reduce_23(val, _values, result)
-                             end_c_declaration
+                             @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[1])
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 52)
+module_eval(<<'.,.,', 'parser.y', 50)
   def _reduce_24(val, _values, result)
-                             @grammar.add_percent_code(id: val[1], code: val[4])
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 56)
-  def _reduce_25(val, _values, result)
-                             begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 60)
-  def _reduce_26(val, _values, result)
-                             end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 64)
-  def _reduce_27(val, _values, result)
-                             @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[3])
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 66)
-  def _reduce_28(val, _values, result)
      @grammar.no_stdlib = true
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 67)
-  def _reduce_29(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 51)
+  def _reduce_25(val, _values, result)
      @grammar.locations = true
+    result
+  end
+.,.,
+
+# reduce 26 omitted
+
+module_eval(<<'.,.,', 'parser.y', 110)
+  def _reduce_27(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 110)
+  def _reduce_28(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 56)
+  def _reduce_29(val, _values, result)
+                               @grammar.set_union(
+                             Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[1]),
+                             val[1].line
+                           )
+
     result
   end
 .,.,
 
 # reduce 30 omitted
 
-module_eval(<<'.,.,', 'parser.y', 158)
-  def _reduce_31(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
+# reduce 31 omitted
 
-module_eval(<<'.,.,', 'parser.y', 158)
-  def _reduce_32(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
+# reduce 32 omitted
 
-module_eval(<<'.,.,', 'parser.y', 72)
+module_eval(<<'.,.,', 'parser.y', 66)
   def _reduce_33(val, _values, result)
-                               begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 76)
-  def _reduce_34(val, _values, result)
-                               end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 80)
-  def _reduce_35(val, _values, result)
-                               @grammar.set_union(
-                             Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[3]),
-                             val[3].line
+                               @grammar.add_destructor(
+                             ident_or_tags: val[2],
+                             token_code: val[1],
+                             lineno: val[1].line
                            )
 
     result
   end
 .,.,
 
-# reduce 36 omitted
+module_eval(<<'.,.,', 'parser.y', 74)
+  def _reduce_34(val, _values, result)
+                               @grammar.add_printer(
+                             ident_or_tags: val[2],
+                             token_code: val[1],
+                             lineno: val[1].line
+                           )
 
-# reduce 37 omitted
+    result
+  end
+.,.,
 
-# reduce 38 omitted
+module_eval(<<'.,.,', 'parser.y', 82)
+  def _reduce_35(val, _values, result)
+                               @grammar.add_error_token(
+                             ident_or_tags: val[2],
+                             token_code: val[1],
+                             lineno: val[1].line
+                           )
+
+    result
+  end
+.,.,
 
 module_eval(<<'.,.,', 'parser.y', 90)
-  def _reduce_39(val, _values, result)
-                               begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 94)
-  def _reduce_40(val, _values, result)
-                               end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 98)
-  def _reduce_41(val, _values, result)
-                               @grammar.add_destructor(
-                             ident_or_tags: val[6],
-                             token_code: val[3],
-                             lineno: val[3].line
-                           )
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 106)
-  def _reduce_42(val, _values, result)
-                               begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 110)
-  def _reduce_43(val, _values, result)
-                               end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 114)
-  def _reduce_44(val, _values, result)
-                               @grammar.add_printer(
-                             ident_or_tags: val[6],
-                             token_code: val[3],
-                             lineno: val[3].line
-                           )
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 122)
-  def _reduce_45(val, _values, result)
-                               begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 126)
-  def _reduce_46(val, _values, result)
-                               end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 130)
-  def _reduce_47(val, _values, result)
-                               @grammar.add_error_token(
-                             ident_or_tags: val[6],
-                             token_code: val[3],
-                             lineno: val[3].line
-                           )
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 138)
-  def _reduce_48(val, _values, result)
+  def _reduce_36(val, _values, result)
                                @grammar.after_shift = val[1]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 142)
-  def _reduce_49(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 94)
+  def _reduce_37(val, _values, result)
                                @grammar.before_reduce = val[1]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 146)
-  def _reduce_50(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 98)
+  def _reduce_38(val, _values, result)
                                @grammar.after_reduce = val[1]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 150)
-  def _reduce_51(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 102)
+  def _reduce_39(val, _values, result)
                                @grammar.after_shift_error_token = val[1]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 154)
-  def _reduce_52(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 106)
+  def _reduce_40(val, _values, result)
                                @grammar.after_pop_stack = val[1]
 
     result
   end
 .,.,
 
-# reduce 53 omitted
+# reduce 41 omitted
 
-module_eval(<<'.,.,', 'parser.y', 160)
-  def _reduce_54(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 112)
+  def _reduce_42(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               @grammar.add_type(id: id, tag: hash[:tag])
@@ -1615,8 +1489,8 @@ module_eval(<<'.,.,', 'parser.y', 160)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 168)
-  def _reduce_55(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 120)
+  def _reduce_43(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1629,8 +1503,8 @@ module_eval(<<'.,.,', 'parser.y', 168)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 178)
-  def _reduce_56(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 130)
+  def _reduce_44(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1643,8 +1517,8 @@ module_eval(<<'.,.,', 'parser.y', 178)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 188)
-  def _reduce_57(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 140)
+  def _reduce_45(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1657,8 +1531,8 @@ module_eval(<<'.,.,', 'parser.y', 188)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 198)
-  def _reduce_58(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 150)
+  def _reduce_46(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1671,22 +1545,22 @@ module_eval(<<'.,.,', 'parser.y', 198)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 227)
-  def _reduce_59(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 179)
+  def _reduce_47(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 227)
-  def _reduce_60(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 179)
+  def _reduce_48(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 209)
-  def _reduce_61(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 161)
+  def _reduce_49(val, _values, result)
                               val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
                           }
@@ -1695,8 +1569,8 @@ module_eval(<<'.,.,', 'parser.y', 209)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 215)
-  def _reduce_62(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 167)
+  def _reduce_50(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
@@ -1705,11 +1579,85 @@ module_eval(<<'.,.,', 'parser.y', 215)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 221)
-  def _reduce_63(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 173)
+  def _reduce_51(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
+
+    result
+  end
+.,.,
+
+# reduce 52 omitted
+
+# reduce 53 omitted
+
+module_eval(<<'.,.,', 'parser.y', 178)
+  def _reduce_54(val, _values, result)
+     result = val
+    result
+  end
+.,.,
+
+# reduce 55 omitted
+
+# reduce 56 omitted
+
+module_eval(<<'.,.,', 'parser.y', 182)
+  def _reduce_57(val, _values, result)
+                            rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
+                        @grammar.add_parameterizing_rule(rule)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 188)
+  def _reduce_58(val, _values, result)
+                            rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
+                        @grammar.add_parameterizing_rule(rule)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 193)
+  def _reduce_59(val, _values, result)
+                            rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
+                        @grammar.add_parameterizing_rule(rule)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 197)
+  def _reduce_60(val, _values, result)
+     result = [val[0]]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 198)
+  def _reduce_61(val, _values, result)
+     result = val[0].append(val[2])
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 202)
+  def _reduce_62(val, _values, result)
+                      builder = val[0]
+                  result = [builder]
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 207)
+  def _reduce_63(val, _values, result)
+                      builder = val[2]
+                  result = val[0].append(builder)
 
     result
   end
@@ -1719,82 +1667,8 @@ module_eval(<<'.,.,', 'parser.y', 221)
 
 # reduce 65 omitted
 
-module_eval(<<'.,.,', 'parser.y', 226)
+module_eval(<<'.,.,', 'parser.y', 213)
   def _reduce_66(val, _values, result)
-     result = val
-    result
-  end
-.,.,
-
-# reduce 67 omitted
-
-# reduce 68 omitted
-
-module_eval(<<'.,.,', 'parser.y', 230)
-  def _reduce_69(val, _values, result)
-                            rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
-                        @grammar.add_parameterizing_rule(rule)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 236)
-  def _reduce_70(val, _values, result)
-                            rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
-                        @grammar.add_parameterizing_rule(rule)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 241)
-  def _reduce_71(val, _values, result)
-                            rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
-                        @grammar.add_parameterizing_rule(rule)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 245)
-  def _reduce_72(val, _values, result)
-     result = [val[0]]
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 246)
-  def _reduce_73(val, _values, result)
-     result = val[0].append(val[2])
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 250)
-  def _reduce_74(val, _values, result)
-                      builder = val[0]
-                  result = [builder]
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 255)
-  def _reduce_75(val, _values, result)
-                      builder = val[2]
-                  result = val[0].append(builder)
-
-    result
-  end
-.,.,
-
-# reduce 76 omitted
-
-# reduce 77 omitted
-
-module_eval(<<'.,.,', 'parser.y', 261)
-  def _reduce_78(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1802,8 +1676,8 @@ module_eval(<<'.,.,', 'parser.y', 261)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 266)
-  def _reduce_79(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 218)
+  def _reduce_67(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1811,8 +1685,8 @@ module_eval(<<'.,.,', 'parser.y', 266)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 271)
-  def _reduce_80(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 223)
+  def _reduce_68(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1823,8 +1697,8 @@ module_eval(<<'.,.,', 'parser.y', 271)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 279)
-  def _reduce_81(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 231)
+  def _reduce_69(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1833,8 +1707,8 @@ module_eval(<<'.,.,', 'parser.y', 279)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 285)
-  def _reduce_82(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 237)
+  def _reduce_70(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1843,8 +1717,8 @@ module_eval(<<'.,.,', 'parser.y', 285)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 291)
-  def _reduce_83(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 243)
+  def _reduce_71(val, _values, result)
                   user_code = val[1]
               user_code.alias_name = val[2]
               builder = val[0]
@@ -1855,8 +1729,8 @@ module_eval(<<'.,.,', 'parser.y', 291)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 299)
-  def _reduce_84(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 251)
+  def _reduce_72(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1867,46 +1741,123 @@ module_eval(<<'.,.,', 'parser.y', 299)
   end
 .,.,
 
-# reduce 85 omitted
+# reduce 73 omitted
 
-module_eval(<<'.,.,', 'parser.y', 307)
-  def _reduce_86(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 259)
+  def _reduce_74(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 314)
-  def _reduce_87(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 266)
+  def _reduce_75(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 314)
-  def _reduce_88(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 266)
+  def _reduce_76(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 309)
-  def _reduce_89(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 261)
+  def _reduce_77(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 310)
-  def _reduce_90(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 262)
+  def _reduce_78(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 311)
-  def _reduce_91(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 263)
+  def _reduce_79(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
+    result
+  end
+.,.,
+
+# reduce 80 omitted
+
+# reduce 81 omitted
+
+module_eval(<<'.,.,', 'parser.y', 269)
+  def _reduce_82(val, _values, result)
+                   begin_c_declaration("}")
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 273)
+  def _reduce_83(val, _values, result)
+                   end_c_declaration
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 277)
+  def _reduce_84(val, _values, result)
+                   result = val[2]
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 285)
+  def _reduce_85(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 285)
+  def _reduce_86(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 280)
+  def _reduce_87(val, _values, result)
+     result = [{tag: nil, tokens: val[0]}]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 281)
+  def _reduce_88(val, _values, result)
+     result = [{tag: val[0], tokens: val[1]}]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 282)
+  def _reduce_89(val, _values, result)
+     result = val[0].append({tag: val[1], tokens: val[2]})
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 284)
+  def _reduce_90(val, _values, result)
+     on_action_error("ident after %prec", val[0]) if @prec_seen
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 285)
+  def _reduce_91(val, _values, result)
+     on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
@@ -1915,89 +1866,12 @@ module_eval(<<'.,.,', 'parser.y', 311)
 
 # reduce 93 omitted
 
-module_eval(<<'.,.,', 'parser.y', 317)
-  def _reduce_94(val, _values, result)
-                   begin_c_declaration("}")
+# reduce 94 omitted
 
-    result
-  end
-.,.,
+# reduce 95 omitted
 
-module_eval(<<'.,.,', 'parser.y', 321)
-  def _reduce_95(val, _values, result)
-                   end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 325)
+module_eval(<<'.,.,', 'parser.y', 293)
   def _reduce_96(val, _values, result)
-                   result = val[2]
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 333)
-  def _reduce_97(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 333)
-  def _reduce_98(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 328)
-  def _reduce_99(val, _values, result)
-     result = [{tag: nil, tokens: val[0]}]
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 329)
-  def _reduce_100(val, _values, result)
-     result = [{tag: val[0], tokens: val[1]}]
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 330)
-  def _reduce_101(val, _values, result)
-     result = val[0].append({tag: val[1], tokens: val[2]})
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 332)
-  def _reduce_102(val, _values, result)
-     on_action_error("ident after %prec", val[0]) if @prec_seen
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 333)
-  def _reduce_103(val, _values, result)
-     on_action_error("char after %prec", val[0]) if @prec_seen
-    result
-  end
-.,.,
-
-# reduce 104 omitted
-
-# reduce 105 omitted
-
-# reduce 106 omitted
-
-# reduce 107 omitted
-
-module_eval(<<'.,.,', 'parser.y', 341)
-  def _reduce_108(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -2010,8 +1884,8 @@ module_eval(<<'.,.,', 'parser.y', 341)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 352)
-  def _reduce_109(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 304)
+  def _reduce_97(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2022,8 +1896,8 @@ module_eval(<<'.,.,', 'parser.y', 352)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 360)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 312)
+  def _reduce_98(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2034,8 +1908,8 @@ module_eval(<<'.,.,', 'parser.y', 360)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 369)
-  def _reduce_111(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 321)
+  def _reduce_99(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -2043,8 +1917,8 @@ module_eval(<<'.,.,', 'parser.y', 369)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 374)
-  def _reduce_112(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 326)
+  def _reduce_100(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -2052,8 +1926,8 @@ module_eval(<<'.,.,', 'parser.y', 374)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 379)
-  def _reduce_113(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 331)
+  def _reduce_101(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -2064,8 +1938,8 @@ module_eval(<<'.,.,', 'parser.y', 379)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 387)
-  def _reduce_114(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 339)
+  def _reduce_102(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -2076,8 +1950,8 @@ module_eval(<<'.,.,', 'parser.y', 387)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 395)
-  def _reduce_115(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 347)
+  def _reduce_103(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -2088,8 +1962,8 @@ module_eval(<<'.,.,', 'parser.y', 395)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 403)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 355)
+  def _reduce_104(val, _values, result)
                user_code = val[1]
            user_code.alias_name = val[2]
            user_code.tag = val[3]
@@ -2101,8 +1975,8 @@ module_eval(<<'.,.,', 'parser.y', 403)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 412)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 364)
+  def _reduce_105(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2113,57 +1987,57 @@ module_eval(<<'.,.,', 'parser.y', 412)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 419)
-  def _reduce_118(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 371)
+  def _reduce_106(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 420)
-  def _reduce_119(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 372)
+  def _reduce_107(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 421)
-  def _reduce_120(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 373)
+  def _reduce_108(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 423)
-  def _reduce_121(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 375)
+  def _reduce_109(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 424)
-  def _reduce_122(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 376)
+  def _reduce_110(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 425)
-  def _reduce_123(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 377)
+  def _reduce_111(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 426)
-  def _reduce_124(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 378)
+  def _reduce_112(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 430)
-  def _reduce_125(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 382)
+  def _reduce_113(val, _values, result)
                           if @prec_seen
                         on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                         @code_after_prec = true
@@ -2174,31 +2048,31 @@ module_eval(<<'.,.,', 'parser.y', 430)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 438)
-  def _reduce_126(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 390)
+  def _reduce_114(val, _values, result)
                           end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 442)
-  def _reduce_127(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 394)
+  def _reduce_115(val, _values, result)
                           result = val[2]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 445)
-  def _reduce_128(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 397)
+  def _reduce_116(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 449)
-  def _reduce_129(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 401)
+  def _reduce_117(val, _values, result)
                     begin_c_declaration('\Z')
                 @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2206,8 +2080,8 @@ module_eval(<<'.,.,', 'parser.y', 449)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 454)
-  def _reduce_130(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 406)
+  def _reduce_118(val, _values, result)
                     end_c_declaration
                 @grammar.epilogue = val[2].s_value
 
@@ -2215,22 +2089,22 @@ module_eval(<<'.,.,', 'parser.y', 454)
   end
 .,.,
 
-# reduce 131 omitted
+# reduce 119 omitted
 
-# reduce 132 omitted
+# reduce 120 omitted
 
-# reduce 133 omitted
+# reduce 121 omitted
 
-# reduce 134 omitted
+# reduce 122 omitted
 
-# reduce 135 omitted
+# reduce 123 omitted
 
-# reduce 136 omitted
+# reduce 124 omitted
 
-# reduce 137 omitted
+# reduce 125 omitted
 
-module_eval(<<'.,.,', 'parser.y', 468)
-  def _reduce_138(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 420)
+  def _reduce_126(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 534)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 533)
 
 include Lrama::Report::Duration
 
@@ -728,68 +728,68 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-   102,    53,   103,   169,    90,    81,    53,    53,   186,   169,
-    81,    81,    53,     3,   186,    53,    81,    52,   171,   162,
-    72,     8,   163,   187,   171,     6,    53,     7,    52,   187,
+   103,    53,   104,   170,    90,    81,    53,    53,   187,   170,
+    81,    81,    53,     3,   187,    53,    81,    52,   172,   163,
+    72,     8,   164,   188,   172,     6,    53,     7,    52,   188,
     81,    77,    41,    53,    53,    52,    52,    47,    84,    84,
-    53,   189,    52,    91,   163,    84,   172,    48,    53,   104,
-    52,   188,   172,    84,    53,    50,    52,   188,    21,    25,
+    53,   190,    52,    91,   164,    84,   173,    48,    53,   105,
+    52,   189,   173,    84,    53,    50,    52,   189,    21,    25,
     26,    27,    28,    29,    30,    31,    32,    33,    34,    35,
-    36,    37,    38,    39,    47,    53,    53,    52,    52,    95,
-    81,   204,    53,    53,    52,    52,    81,   204,    53,    56,
-    52,   226,    81,   204,   227,    21,    25,    26,    27,    28,
+    36,    37,    38,    39,    47,    53,    53,    52,    52,    96,
+    81,   205,    53,    53,    52,    52,    81,   205,    53,    56,
+    52,   227,    81,   205,   228,    21,    25,    26,    27,    28,
     29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-    39,     9,   194,   195,   196,   100,    12,    13,    14,    15,
-    16,    17,    47,   126,    18,    19,    20,    21,    25,    26,
+    39,     9,   195,   196,   197,   101,    12,    13,    14,    15,
+    16,    17,    47,   127,    18,    19,    20,    21,    25,    26,
     27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
-    37,    38,    39,    53,    53,    52,    52,    81,   204,    53,
-    53,    52,    52,    81,   204,    53,    53,    52,    52,    81,
-   204,    53,    53,    52,    52,    81,    81,    53,    53,    52,
+    37,    38,    39,    53,    53,    52,    52,    81,   205,    53,
+    53,    52,    52,    81,   205,    53,    53,    52,    52,    81,
+   205,    53,    53,    52,    52,    81,    81,    53,    53,    52,
     52,    81,    81,    53,    53,    52,    52,    81,    81,    53,
-    53,    52,   215,    81,    81,    53,    53,   215,   215,    81,
-    81,    53,    53,    52,    52,    81,   194,   195,   196,   100,
-   231,   239,    56,   227,   227,    53,    53,    52,    52,    53,
-    53,    52,    52,   194,   195,   196,    56,    59,    60,    61,
+    53,    52,   216,    81,    81,    53,    53,   216,   216,    81,
+    81,    53,    53,    52,    52,    81,   195,   196,   197,   101,
+   232,   240,    56,   228,   228,    53,    53,    52,    52,    53,
+    53,    52,    52,   195,   196,   197,    56,    59,    60,    61,
     62,    63,    64,    65,    66,    67,    68,    69,    92,    48,
-    97,   100,   105,   105,   105,   107,   113,   116,   118,   121,
-   121,   121,   121,   124,   129,   130,   132,   134,   135,   136,
-   137,   138,    81,   145,   146,   147,   148,   149,   152,   153,
-   154,   156,   166,   145,   168,   174,   176,   177,   178,   179,
-   180,   181,   183,   184,   152,   191,   199,   200,   207,   166,
-   211,   214,   100,   219,   166,   223,   166,   225,   181,   184,
-   184,   100,   236,   181,   238,   181,   100,   100,   181 ]
+    98,   101,   106,   106,   106,   108,   114,   117,   119,   122,
+   122,   122,   122,   125,   130,   131,   133,   135,   136,   137,
+   138,   139,    81,   146,   147,   148,   149,   150,   153,   154,
+   155,   157,   167,   146,   169,   175,   177,   178,   179,   180,
+   181,   182,   184,   185,   153,   192,   200,   201,   208,   167,
+   212,   215,   101,   220,   167,   224,   167,   226,   182,   185,
+   185,   101,   237,   182,   239,   182,   101,   101,   182 ]
 
 racc_action_check = [
-    51,   151,    51,   151,    39,   151,   165,   190,   165,   190,
-   165,   190,   208,     1,   208,    33,   208,    33,   151,   144,
-    33,     3,   144,   165,   190,     2,    34,     2,    34,   208,
+    51,   152,    51,   152,    39,   152,   166,   191,   166,   191,
+   166,   191,   209,     1,   209,    33,   209,    33,   152,   145,
+    33,     3,   145,   166,   191,     2,    34,     2,    34,   209,
     34,    34,     7,    35,    36,    35,    36,     9,    35,    36,
-    37,   167,    37,    39,   167,    37,   151,    10,    38,    51,
-    38,   165,   190,    38,    13,    12,    13,   208,     9,     9,
+    37,   168,    37,    39,   168,    37,   152,    10,    38,    51,
+    38,   166,   191,    38,    13,    12,    13,   209,     9,     9,
      9,     9,     9,     9,     9,     9,     9,     9,     9,     9,
-     9,     9,     9,     9,    42,    71,   178,    71,   178,    42,
-   178,   178,   179,    72,   179,    72,   179,   179,   180,    14,
-   180,   216,   180,   180,   216,    42,    42,    42,    42,    42,
+     9,     9,     9,     9,    42,    71,   179,    71,   179,    42,
+   179,   179,   180,    72,   180,    72,   180,   180,   181,    14,
+   181,   217,   181,   181,   217,    42,    42,    42,    42,    42,
     42,    42,    42,    42,    42,    42,    42,    42,    42,    42,
-    42,     4,   170,   170,   170,   170,     4,     4,     4,     4,
+    42,     4,   171,   171,   171,   171,     4,     4,     4,     4,
      4,     4,    91,    91,     4,     4,     4,     4,     4,     4,
      4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-     4,     4,     4,   201,    83,   201,    83,   201,   201,   205,
-    84,   205,    84,   205,   205,   206,   113,   206,   113,   206,
-   206,    76,    77,    76,    77,    76,    77,   118,   120,   118,
-   120,   118,   120,   142,   172,   142,   172,   142,   172,   188,
-   191,   188,   191,   188,   191,   211,   225,   211,   225,   211,
-   225,   227,   115,   227,   115,   227,   185,   185,   185,   185,
-   222,   233,    15,   222,   233,   121,   123,   121,   123,   139,
-   143,   139,   143,   217,   217,   217,    16,    17,    18,    21,
+     4,     4,     4,   202,    83,   202,    83,   202,   202,   206,
+    84,   206,    84,   206,   206,   207,   114,   207,   114,   207,
+   207,    76,    77,    76,    77,    76,    77,   119,   121,   119,
+   121,   119,   121,   143,   173,   143,   173,   143,   173,   189,
+   192,   189,   192,   189,   192,   212,   226,   212,   226,   212,
+   226,   228,   116,   228,   116,   228,   186,   186,   186,   186,
+   223,   234,    15,   223,   234,   122,   124,   122,   124,   140,
+   144,   140,   144,   218,   218,   218,    16,    17,    18,    21,
     25,    26,    27,    28,    29,    30,    31,    32,    40,    44,
     45,    46,    55,    57,    58,    59,    70,    74,    75,    82,
-    87,    88,    89,    90,    99,   100,   106,   108,   109,   110,
-   111,   112,   117,   124,   125,   126,   127,   128,   129,   130,
-   131,   133,   146,   147,   150,   155,   157,   158,   159,   160,
-   161,   162,   163,   164,   168,   169,   173,   175,   182,   184,
-   186,   189,   193,   197,   207,   212,   214,   215,   218,   221,
-   224,   226,   230,   231,   232,   234,   236,   238,   241 ]
+    87,    88,    89,    90,   100,   101,   107,   109,   110,   111,
+   112,   113,   118,   125,   126,   127,   128,   129,   130,   131,
+   132,   134,   147,   148,   151,   156,   158,   159,   160,   161,
+   162,   163,   164,   165,   169,   170,   174,   176,   183,   185,
+   187,   190,   194,   198,   208,   213,   215,   216,   219,   222,
+   225,   227,   231,   232,   233,   235,   237,   239,   242 ]
 
 racc_action_pointer = [
    nil,    13,    15,    21,   102,   nil,   nil,    25,   nil,    33,
@@ -801,258 +801,259 @@ racc_action_pointer = [
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
    228,    72,    80,   nil,   231,   230,   158,   159,   nil,   nil,
    nil,   nil,   231,   141,   147,   nil,   nil,   232,   233,   234,
-   202,   118,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   201,
-   240,   nil,   nil,   nil,   nil,   nil,   244,   nil,   245,   246,
-   247,   248,   249,   153,   nil,   189,   nil,   245,   164,   nil,
-   165,   202,   nil,   203,   248,   211,   214,   245,   255,   211,
-   206,   258,   nil,   259,   nil,   nil,   nil,   nil,   nil,   206,
-   nil,   nil,   170,   207,   -23,   nil,   215,   258,   nil,   nil,
-   218,    -2,   nil,   nil,   nil,   244,   nil,   245,   246,   247,
-   248,   249,   263,   267,   227,     3,   nil,    -1,   227,   234,
-    63,   nil,   171,   255,   nil,   256,   nil,   nil,    73,    79,
-    85,   nil,   235,   nil,   232,   147,   239,   nil,   176,   238,
-     4,   177,   nil,   230,   nil,   nil,   nil,   281,   nil,   nil,
-   nil,   140,   nil,   nil,   nil,   146,   152,   237,     9,   nil,
-   nil,   182,   283,   nil,   239,   246,    49,   164,   280,   nil,
-   nil,   243,   158,   nil,   244,   183,   239,   188,   nil,   nil,
-   271,   285,   273,   159,   287,   nil,   244,   nil,   245,   nil,
-   nil,   290,   nil,   nil ]
+   202,   118,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   201,   240,   nil,   nil,   nil,   nil,   nil,   244,   nil,   245,
+   246,   247,   248,   249,   153,   nil,   189,   nil,   245,   164,
+   nil,   165,   202,   nil,   203,   248,   211,   214,   245,   255,
+   211,   206,   258,   nil,   259,   nil,   nil,   nil,   nil,   nil,
+   206,   nil,   nil,   170,   207,   -23,   nil,   215,   258,   nil,
+   nil,   218,    -2,   nil,   nil,   nil,   244,   nil,   245,   246,
+   247,   248,   249,   263,   267,   227,     3,   nil,    -1,   227,
+   234,    63,   nil,   171,   255,   nil,   256,   nil,   nil,    73,
+    79,    85,   nil,   235,   nil,   232,   147,   239,   nil,   176,
+   238,     4,   177,   nil,   230,   nil,   nil,   nil,   281,   nil,
+   nil,   nil,   140,   nil,   nil,   nil,   146,   152,   237,     9,
+   nil,   nil,   182,   283,   nil,   239,   246,    49,   164,   280,
+   nil,   nil,   243,   158,   nil,   244,   183,   239,   188,   nil,
+   nil,   271,   285,   273,   159,   287,   nil,   244,   nil,   245,
+   nil,   nil,   290,   nil,   nil ]
 
 racc_action_default = [
-    -2,  -141,   -10,  -141,  -141,    -3,    -4,  -141,   244,  -141,
-    -8,   -12,  -141,  -141,  -141,  -141,  -141,  -141,  -141,   -24,
-   -25,  -141,   -29,   -30,   -31,  -141,  -141,  -141,  -141,  -141,
-  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,
-  -141,    -7,  -128,  -103,    -8,  -141,   -69,  -127,    -9,   -11,
-   -13,  -132,  -101,  -102,  -131,   -15,   -92,   -16,   -17,  -141,
-   -21,   -26,   -32,   -35,   -38,   -41,   -42,   -43,   -44,   -45,
-   -46,   -52,  -141,   -55,   -57,   -47,   -82,  -141,   -85,   -87,
-   -88,  -140,   -48,   -95,  -141,   -98,  -100,   -49,   -50,   -51,
-  -141,  -141,    -5,    -1,  -104,  -129,  -105,  -106,   -70,  -141,
-  -141,   -14,  -133,  -134,  -135,   -89,  -141,   -18,  -141,  -141,
-  -141,  -141,  -141,  -141,   -56,   -53,   -58,   -80,  -141,   -86,
-   -83,  -141,   -99,   -96,  -141,  -141,  -141,  -141,  -141,  -110,
-  -141,  -141,   -93,  -141,   -22,   -27,   -33,   -36,   -39,   -54,
-   -59,   -81,   -84,   -97,  -141,   -65,   -71,  -141,    -6,  -130,
-  -107,  -108,  -111,  -126,   -90,  -141,   -19,  -141,  -141,  -141,
-  -141,  -141,   -60,  -141,   -63,   -67,   -72,  -141,  -110,  -101,
-   -69,  -115,  -141,  -141,   -94,  -141,   -23,   -28,  -141,  -141,
-  -141,   -61,  -141,   -66,   -71,   -69,  -101,   -76,  -141,  -141,
-  -109,  -141,  -112,   -69,  -119,  -120,  -121,  -141,  -118,   -91,
-   -20,   -34,  -136,  -138,  -139,   -37,   -40,   -71,   -68,   -73,
-   -74,  -141,  -141,   -79,   -71,  -101,  -141,  -122,   -60,  -116,
-  -137,   -62,  -141,   -77,   -64,  -141,   -69,  -141,  -124,  -113,
-  -141,   -60,  -141,  -141,   -60,  -123,   -69,   -75,   -69,  -125,
-  -114,   -60,   -78,  -117 ]
+    -4,  -142,   -12,  -142,  -142,    -5,    -6,  -142,   245,  -142,
+   -10,   -14,  -142,  -142,  -142,  -142,  -142,  -142,  -142,   -26,
+   -27,  -142,   -31,   -32,   -33,  -142,  -142,  -142,  -142,  -142,
+  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,
+  -142,    -9,    -1,  -105,   -10,  -142,   -71,  -129,   -11,   -13,
+   -15,  -133,  -103,  -104,  -132,   -17,   -94,   -18,   -19,  -142,
+   -23,   -28,   -34,   -37,   -40,   -43,   -44,   -45,   -46,   -47,
+   -48,   -54,  -142,   -57,   -59,   -49,   -84,  -142,   -87,   -89,
+   -90,  -141,   -50,   -97,  -142,  -100,  -102,   -51,   -52,   -53,
+  -142,  -142,    -7,    -2,    -3,  -106,  -130,  -107,  -108,   -72,
+  -142,  -142,   -16,  -134,  -135,  -136,   -91,  -142,   -20,  -142,
+  -142,  -142,  -142,  -142,  -142,   -58,   -55,   -60,   -82,  -142,
+   -88,   -85,  -142,  -101,   -98,  -142,  -142,  -142,  -142,  -142,
+  -112,  -142,  -142,   -95,  -142,   -24,   -29,   -35,   -38,   -41,
+   -56,   -61,   -83,   -86,   -99,  -142,   -67,   -73,  -142,    -8,
+  -131,  -109,  -110,  -113,  -128,   -92,  -142,   -21,  -142,  -142,
+  -142,  -142,  -142,   -62,  -142,   -65,   -69,   -74,  -142,  -112,
+  -103,   -71,  -117,  -142,  -142,   -96,  -142,   -25,   -30,  -142,
+  -142,  -142,   -63,  -142,   -68,   -73,   -71,  -103,   -78,  -142,
+  -142,  -111,  -142,  -114,   -71,  -121,  -122,  -123,  -142,  -120,
+   -93,   -22,   -36,  -137,  -139,  -140,   -39,   -42,   -73,   -70,
+   -75,   -76,  -142,  -142,   -81,   -73,  -103,  -142,  -124,   -62,
+  -118,  -138,   -64,  -142,   -79,   -66,  -142,   -71,  -142,  -126,
+  -115,  -142,   -62,  -142,  -142,   -62,  -125,   -71,   -77,   -71,
+  -127,  -116,   -62,   -80,  -119 ]
 
 racc_goto_table = [
-    78,    76,    99,    54,   114,   193,   151,    71,   164,   182,
-   122,   144,   123,    49,   220,     1,     2,   216,   220,   220,
-   210,    43,     4,    74,    42,    86,    86,    86,    86,    82,
-    87,    88,    89,    93,   167,     5,    40,   222,    55,    57,
-    58,   127,   119,    78,   120,   190,   115,    96,   114,   143,
-   122,   233,   228,    10,    94,   201,   205,   206,    11,    51,
-   101,    74,    74,   133,   175,   229,   108,   157,   109,   221,
-   122,   158,   114,    86,    86,   110,   224,   159,   237,   111,
-   160,   240,   112,   161,    78,   142,   119,   139,   243,    70,
-    75,   140,   117,   125,   208,   212,   232,   141,   131,   173,
-   106,   155,   150,    74,   197,    74,   230,   128,   119,   nil,
-   nil,    86,   nil,    86,   nil,   nil,   nil,   170,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   192,   nil,   nil,    74,
-   nil,   185,   nil,    86,   nil,   nil,   nil,   nil,   198,   nil,
-   nil,   209,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   218,
-   nil,   nil,   nil,   nil,   213,   nil,   170,   217,   nil,   nil,
+    78,    76,   100,    54,   165,   194,   115,    71,   123,   152,
+   183,    49,   124,   217,   145,    82,    87,    88,    89,     1,
+   211,    43,     2,    74,     4,    86,    86,    86,    86,    42,
+   221,    93,    94,   223,   221,   221,     5,   168,    55,    57,
+    58,    40,   120,    78,   121,    97,   116,   234,   191,   123,
+   144,   115,   229,   128,    95,   202,   206,   207,    10,    11,
+    51,    74,    74,   102,   134,   222,   230,   176,   109,   123,
+   158,   110,   225,    86,    86,   115,   159,   111,   160,   238,
+   112,   161,   241,   113,   162,    78,   143,   120,   140,   244,
+    70,    75,   141,   118,   126,   209,   213,   233,   142,   132,
+   174,   107,   156,   151,    74,   198,    74,   231,   129,   120,
+   nil,   nil,    86,   nil,    86,   nil,   nil,   nil,   171,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   193,   nil,   nil,
+    74,   nil,   186,   nil,    86,   nil,   nil,   nil,   nil,   199,
+   nil,   nil,   210,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   219,   nil,   nil,   nil,   nil,   214,   nil,   171,   218,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   185,   nil,   nil,   217,   nil,   nil,
-   nil,   nil,   234,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   217,   241,   235,   242 ]
+   nil,   nil,   nil,   nil,   nil,   186,   nil,   nil,   218,   nil,
+   nil,   nil,   nil,   235,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   218,   242,   236,   243 ]
 
 racc_goto_check = [
-    44,    52,    48,    36,    35,    46,    62,    34,    40,    41,
-    58,    39,    57,    10,    66,     1,     2,    47,    66,    66,
-    46,    59,     3,    36,     4,    36,    36,    36,    36,    33,
-    33,    33,    33,     5,    39,     6,     7,    47,    14,    14,
-    14,     8,    44,    44,    52,    62,    34,    10,    35,    57,
-    58,    47,    46,     9,    59,    22,    22,    22,    11,    12,
-    13,    36,    36,    15,    16,    41,    17,    18,    23,    40,
-    58,    24,    35,    36,    36,    25,    40,    26,    41,    27,
-    28,    41,    29,    30,    44,    52,    44,    34,    41,    31,
-    32,    37,    38,    42,    43,    49,    50,    51,    53,    54,
-    55,    56,    61,    36,    63,    36,    64,    65,    44,   nil,
-   nil,    36,   nil,    36,   nil,   nil,   nil,    44,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,    48,   nil,   nil,    36,
-   nil,    44,   nil,    36,   nil,   nil,   nil,   nil,    44,   nil,
-   nil,    48,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    48,
-   nil,   nil,   nil,   nil,    44,   nil,    44,    44,   nil,   nil,
+    45,    53,    49,    37,    41,    47,    36,    35,    59,    63,
+    42,    11,    58,    48,    40,    34,    34,    34,    34,     1,
+    47,    60,     2,    37,     3,    37,    37,    37,    37,     4,
+    67,     5,     6,    48,    67,    67,     7,    40,    15,    15,
+    15,     8,    45,    45,    53,    11,    35,    48,    63,    59,
+    58,    36,    47,     9,    60,    23,    23,    23,    10,    12,
+    13,    37,    37,    14,    16,    41,    42,    17,    18,    59,
+    19,    24,    41,    37,    37,    36,    25,    26,    27,    42,
+    28,    29,    42,    30,    31,    45,    53,    45,    35,    42,
+    32,    33,    38,    39,    43,    44,    50,    51,    52,    54,
+    55,    56,    57,    62,    37,    64,    37,    65,    66,    45,
+   nil,   nil,    37,   nil,    37,   nil,   nil,   nil,    45,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,    49,   nil,   nil,
+    37,   nil,    45,   nil,    37,   nil,   nil,   nil,   nil,    45,
+   nil,   nil,    49,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+    49,   nil,   nil,   nil,   nil,    45,   nil,    45,    45,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,    44,   nil,   nil,    44,   nil,   nil,
-   nil,   nil,    48,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,    44,    48,    44,    48 ]
+   nil,   nil,   nil,   nil,   nil,    45,   nil,   nil,    45,   nil,
+   nil,   nil,   nil,    49,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    45,    49,    45,    49 ]
 
 racc_goto_pointer = [
-   nil,    15,    16,    20,    15,    -9,    33,    30,   -51,    49,
-     3,    54,    46,     9,    24,   -44,   -92,     6,   -67,   nil,
-   nil,   nil,  -123,     7,   -64,    13,   -59,    16,   -57,    18,
-   -55,    56,    56,    -6,   -26,   -67,   -10,   -26,    18,  -113,
-  -138,  -153,     2,   -90,   -34,   nil,  -165,  -174,   -44,   -92,
-  -127,   -20,   -33,    -7,   -55,    44,   -31,   -72,   -73,    12,
-   nil,   -27,  -123,   -67,  -113,    12,  -187 ]
+   nil,    19,    22,    22,    20,   -11,   -10,    34,    35,   -39,
+    54,     1,    55,    47,    12,    24,   -44,   -90,     8,   -65,
+   nil,   nil,   nil,  -124,    10,   -60,    15,   -59,    17,   -57,
+    19,   -55,    57,    57,   -20,   -26,   -65,   -10,   -26,    19,
+  -111,  -143,  -153,     3,   -90,   -34,   nil,  -166,  -179,   -44,
+   -92,  -127,   -20,   -33,    -7,   -55,    45,   -31,   -72,   -75,
+    12,   nil,   -27,  -121,   -67,  -113,    12,  -172 ]
 
 racc_goto_default = [
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,    45,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    22,
-    23,    24,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    73,    79,   nil,   nil,   nil,
-   nil,   nil,    46,   165,   203,    98,   nil,   nil,   nil,   nil,
-   nil,    80,   nil,   nil,   nil,   nil,   nil,    83,    85,   nil,
-    44,   nil,   nil,   nil,   nil,   nil,   202 ]
+   nil,   nil,    45,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+    22,    23,    24,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    73,    79,   nil,   nil,
+   nil,   nil,   nil,    46,   166,   204,    99,   nil,   nil,   nil,
+   nil,   nil,    80,   nil,   nil,   nil,   nil,   nil,    83,    85,
+   nil,    44,   nil,   nil,   nil,   nil,   nil,   203 ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
+  0, 61, :_reduce_none,
+  1, 61, :_reduce_none,
   5, 56, :_reduce_none,
   0, 57, :_reduce_none,
   2, 57, :_reduce_none,
-  0, 62, :_reduce_4,
-  0, 63, :_reduce_5,
-  5, 61, :_reduce_6,
-  2, 61, :_reduce_none,
-  0, 65, :_reduce_none,
-  1, 65, :_reduce_none,
-  0, 58, :_reduce_10,
+  0, 63, :_reduce_6,
+  0, 64, :_reduce_7,
+  5, 62, :_reduce_8,
+  2, 62, :_reduce_none,
+  0, 66, :_reduce_none,
+  1, 66, :_reduce_none,
+  0, 58, :_reduce_12,
   3, 58, :_reduce_none,
-  1, 64, :_reduce_none,
-  2, 64, :_reduce_13,
-  3, 64, :_reduce_none,
-  2, 64, :_reduce_none,
-  2, 64, :_reduce_16,
-  2, 64, :_reduce_17,
-  0, 70, :_reduce_18,
-  0, 71, :_reduce_19,
-  7, 64, :_reduce_20,
+  1, 65, :_reduce_none,
+  2, 65, :_reduce_15,
+  3, 65, :_reduce_none,
+  2, 65, :_reduce_none,
+  2, 65, :_reduce_18,
+  2, 65, :_reduce_19,
+  0, 71, :_reduce_20,
   0, 72, :_reduce_21,
-  0, 73, :_reduce_22,
-  6, 64, :_reduce_23,
-  1, 64, :_reduce_24,
-  1, 64, :_reduce_25,
-  0, 78, :_reduce_26,
-  0, 79, :_reduce_27,
-  6, 66, :_reduce_28,
-  1, 66, :_reduce_none,
-  1, 66, :_reduce_none,
-  1, 66, :_reduce_none,
-  0, 80, :_reduce_32,
-  0, 81, :_reduce_33,
-  7, 66, :_reduce_34,
+  7, 65, :_reduce_22,
+  0, 73, :_reduce_23,
+  0, 74, :_reduce_24,
+  6, 65, :_reduce_25,
+  1, 65, :_reduce_26,
+  1, 65, :_reduce_27,
+  0, 79, :_reduce_28,
+  0, 80, :_reduce_29,
+  6, 67, :_reduce_30,
+  1, 67, :_reduce_none,
+  1, 67, :_reduce_none,
+  1, 67, :_reduce_none,
+  0, 81, :_reduce_34,
   0, 82, :_reduce_35,
-  0, 83, :_reduce_36,
-  7, 66, :_reduce_37,
+  7, 67, :_reduce_36,
+  0, 83, :_reduce_37,
   0, 84, :_reduce_38,
-  0, 85, :_reduce_39,
-  7, 66, :_reduce_40,
-  2, 66, :_reduce_41,
-  2, 66, :_reduce_42,
-  2, 66, :_reduce_43,
-  2, 66, :_reduce_44,
-  2, 66, :_reduce_45,
-  2, 74, :_reduce_none,
-  2, 74, :_reduce_47,
-  2, 74, :_reduce_48,
-  2, 74, :_reduce_49,
-  2, 74, :_reduce_50,
-  2, 74, :_reduce_51,
-  1, 86, :_reduce_52,
-  2, 86, :_reduce_53,
-  3, 86, :_reduce_54,
-  1, 89, :_reduce_55,
-  2, 89, :_reduce_56,
-  0, 93, :_reduce_none,
-  1, 93, :_reduce_none,
-  3, 90, :_reduce_59,
-  0, 96, :_reduce_none,
-  1, 96, :_reduce_none,
-  8, 75, :_reduce_62,
-  5, 76, :_reduce_63,
+  7, 67, :_reduce_39,
+  0, 85, :_reduce_40,
+  0, 86, :_reduce_41,
+  7, 67, :_reduce_42,
+  2, 67, :_reduce_43,
+  2, 67, :_reduce_44,
+  2, 67, :_reduce_45,
+  2, 67, :_reduce_46,
+  2, 67, :_reduce_47,
+  2, 75, :_reduce_none,
+  2, 75, :_reduce_49,
+  2, 75, :_reduce_50,
+  2, 75, :_reduce_51,
+  2, 75, :_reduce_52,
+  2, 75, :_reduce_53,
+  1, 87, :_reduce_54,
+  2, 87, :_reduce_55,
+  3, 87, :_reduce_56,
+  1, 90, :_reduce_57,
+  2, 90, :_reduce_58,
+  0, 94, :_reduce_none,
+  1, 94, :_reduce_none,
+  3, 91, :_reduce_61,
+  0, 97, :_reduce_none,
+  1, 97, :_reduce_none,
   8, 76, :_reduce_64,
-  1, 94, :_reduce_65,
-  3, 94, :_reduce_66,
+  5, 77, :_reduce_65,
+  8, 77, :_reduce_66,
   1, 95, :_reduce_67,
   3, 95, :_reduce_68,
-  0, 103, :_reduce_none,
-  1, 103, :_reduce_none,
-  0, 98, :_reduce_71,
-  1, 98, :_reduce_72,
-  3, 98, :_reduce_73,
-  3, 98, :_reduce_74,
-  6, 98, :_reduce_75,
-  0, 104, :_reduce_76,
-  0, 105, :_reduce_77,
-  7, 98, :_reduce_78,
-  3, 98, :_reduce_79,
-  0, 92, :_reduce_none,
-  1, 92, :_reduce_81,
-  1, 87, :_reduce_82,
-  2, 87, :_reduce_83,
-  3, 87, :_reduce_84,
-  1, 107, :_reduce_85,
-  2, 107, :_reduce_86,
-  1, 99, :_reduce_none,
-  1, 99, :_reduce_none,
-  0, 108, :_reduce_89,
-  0, 109, :_reduce_90,
-  6, 69, :_reduce_91,
+  1, 96, :_reduce_69,
+  3, 96, :_reduce_70,
+  0, 104, :_reduce_none,
+  1, 104, :_reduce_none,
+  0, 99, :_reduce_73,
+  1, 99, :_reduce_74,
+  3, 99, :_reduce_75,
+  3, 99, :_reduce_76,
+  6, 99, :_reduce_77,
+  0, 105, :_reduce_78,
+  0, 106, :_reduce_79,
+  7, 99, :_reduce_80,
+  3, 99, :_reduce_81,
+  0, 93, :_reduce_none,
+  1, 93, :_reduce_83,
+  1, 88, :_reduce_84,
+  2, 88, :_reduce_85,
+  3, 88, :_reduce_86,
+  1, 108, :_reduce_87,
+  2, 108, :_reduce_88,
+  1, 100, :_reduce_none,
+  1, 100, :_reduce_none,
+  0, 109, :_reduce_91,
   0, 110, :_reduce_92,
-  0, 111, :_reduce_93,
-  5, 69, :_reduce_94,
-  1, 88, :_reduce_95,
-  2, 88, :_reduce_96,
-  3, 88, :_reduce_97,
-  1, 112, :_reduce_98,
-  2, 112, :_reduce_99,
-  1, 113, :_reduce_none,
-  1, 91, :_reduce_101,
-  1, 91, :_reduce_102,
+  6, 70, :_reduce_93,
+  0, 111, :_reduce_94,
+  0, 112, :_reduce_95,
+  5, 70, :_reduce_96,
+  1, 89, :_reduce_97,
+  2, 89, :_reduce_98,
+  3, 89, :_reduce_99,
+  1, 113, :_reduce_100,
+  2, 113, :_reduce_101,
+  1, 114, :_reduce_none,
+  1, 92, :_reduce_103,
+  1, 92, :_reduce_104,
   1, 59, :_reduce_none,
   2, 59, :_reduce_none,
-  2, 114, :_reduce_none,
-  2, 114, :_reduce_none,
-  4, 115, :_reduce_107,
-  1, 116, :_reduce_108,
-  3, 116, :_reduce_109,
-  0, 117, :_reduce_110,
-  1, 117, :_reduce_111,
-  3, 117, :_reduce_112,
-  5, 117, :_reduce_113,
-  7, 117, :_reduce_114,
-  0, 118, :_reduce_115,
-  0, 119, :_reduce_116,
-  8, 117, :_reduce_117,
-  3, 117, :_reduce_118,
-  1, 101, :_reduce_119,
-  1, 101, :_reduce_120,
-  1, 101, :_reduce_121,
+  2, 115, :_reduce_none,
+  2, 115, :_reduce_none,
+  4, 116, :_reduce_109,
+  1, 117, :_reduce_110,
+  3, 117, :_reduce_111,
+  0, 118, :_reduce_112,
+  1, 118, :_reduce_113,
+  3, 118, :_reduce_114,
+  5, 118, :_reduce_115,
+  7, 118, :_reduce_116,
+  0, 119, :_reduce_117,
+  0, 120, :_reduce_118,
+  8, 118, :_reduce_119,
+  3, 118, :_reduce_120,
+  1, 102, :_reduce_121,
   1, 102, :_reduce_122,
-  3, 102, :_reduce_123,
-  2, 102, :_reduce_124,
-  4, 102, :_reduce_125,
-  3, 100, :_reduce_126,
-  1, 97, :_reduce_none,
-  0, 60, :_reduce_none,
-  0, 120, :_reduce_129,
-  3, 60, :_reduce_130,
-  1, 67, :_reduce_none,
-  0, 68, :_reduce_none,
+  1, 102, :_reduce_123,
+  1, 103, :_reduce_124,
+  3, 103, :_reduce_125,
+  2, 103, :_reduce_126,
+  4, 103, :_reduce_127,
+  3, 101, :_reduce_128,
+  1, 98, :_reduce_none,
+  0, 121, :_reduce_130,
+  3, 60, :_reduce_131,
   1, 68, :_reduce_none,
-  1, 68, :_reduce_none,
-  1, 68, :_reduce_none,
-  1, 77, :_reduce_136,
-  2, 77, :_reduce_137,
-  1, 121, :_reduce_none,
-  1, 121, :_reduce_none,
-  1, 106, :_reduce_140 ]
+  0, 69, :_reduce_none,
+  1, 69, :_reduce_none,
+  1, 69, :_reduce_none,
+  1, 69, :_reduce_none,
+  1, 78, :_reduce_137,
+  2, 78, :_reduce_138,
+  1, 122, :_reduce_none,
+  1, 122, :_reduce_none,
+  1, 107, :_reduce_141 ]
 
-racc_reduce_n = 141
+racc_reduce_n = 142
 
-racc_shift_n = 244
+racc_shift_n = 245
 
 racc_token_table = {
   false => 0,
@@ -1193,7 +1194,8 @@ Racc_token_to_s_table = [
   "prologue_declarations",
   "bison_declarations",
   "grammar",
-  "epilogue_opt",
+  "epilogue",
+  "\"-option@epilogue\"",
   "prologue_declaration",
   "@1",
   "@2",
@@ -1269,8 +1271,12 @@ Racc_debug_parser = true
 
 # reduce 3 omitted
 
+# reduce 4 omitted
+
+# reduce 5 omitted
+
 module_eval(<<'.,.,', 'parser.y', 15)
-  def _reduce_4(val, _values, result)
+  def _reduce_6(val, _values, result)
                                 begin_c_declaration("%}")
                             @grammar.prologue_first_lineno = @lexer.line
 
@@ -1279,7 +1285,7 @@ module_eval(<<'.,.,', 'parser.y', 15)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 20)
-  def _reduce_5(val, _values, result)
+  def _reduce_7(val, _values, result)
                                 end_c_declaration
 
     result
@@ -1287,43 +1293,43 @@ module_eval(<<'.,.,', 'parser.y', 20)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 24)
-  def _reduce_6(val, _values, result)
+  def _reduce_8(val, _values, result)
                                 @grammar.prologue = val[2].s_value
 
     result
   end
 .,.,
 
-# reduce 7 omitted
-
-# reduce 8 omitted
-
 # reduce 9 omitted
 
+# reduce 10 omitted
+
+# reduce 11 omitted
+
 module_eval(<<'.,.,', 'parser.y', 28)
-  def _reduce_10(val, _values, result)
+  def _reduce_12(val, _values, result)
      result = ""
     result
   end
 .,.,
 
-# reduce 11 omitted
+# reduce 13 omitted
 
-# reduce 12 omitted
+# reduce 14 omitted
 
 module_eval(<<'.,.,', 'parser.y', 32)
-  def _reduce_13(val, _values, result)
+  def _reduce_15(val, _values, result)
      @grammar.expect = val[1]
     result
   end
 .,.,
 
-# reduce 14 omitted
+# reduce 16 omitted
 
-# reduce 15 omitted
+# reduce 17 omitted
 
 module_eval(<<'.,.,', 'parser.y', 37)
-  def _reduce_16(val, _values, result)
+  def _reduce_18(val, _values, result)
                              val[1].each {|token|
                            @grammar.lex_param = Grammar::Code::NoReferenceCode.new(type: :lex_param, token_code: token).token_code.s_value
                          }
@@ -1333,7 +1339,7 @@ module_eval(<<'.,.,', 'parser.y', 37)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 43)
-  def _reduce_17(val, _values, result)
+  def _reduce_19(val, _values, result)
                              val[1].each {|token|
                            @grammar.parse_param = Grammar::Code::NoReferenceCode.new(type: :parse_param, token_code: token).token_code.s_value
                          }
@@ -1343,7 +1349,7 @@ module_eval(<<'.,.,', 'parser.y', 43)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 49)
-  def _reduce_18(val, _values, result)
+  def _reduce_20(val, _values, result)
                              begin_c_declaration("}")
 
     result
@@ -1351,7 +1357,7 @@ module_eval(<<'.,.,', 'parser.y', 49)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 53)
-  def _reduce_19(val, _values, result)
+  def _reduce_21(val, _values, result)
                              end_c_declaration
 
     result
@@ -1359,7 +1365,7 @@ module_eval(<<'.,.,', 'parser.y', 53)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 57)
-  def _reduce_20(val, _values, result)
+  def _reduce_22(val, _values, result)
                              @grammar.add_percent_code(id: val[1], code: val[4])
 
     result
@@ -1367,7 +1373,7 @@ module_eval(<<'.,.,', 'parser.y', 57)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 61)
-  def _reduce_21(val, _values, result)
+  def _reduce_23(val, _values, result)
                              begin_c_declaration("}")
 
     result
@@ -1375,7 +1381,7 @@ module_eval(<<'.,.,', 'parser.y', 61)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 65)
-  def _reduce_22(val, _values, result)
+  def _reduce_24(val, _values, result)
                              end_c_declaration
 
     result
@@ -1383,7 +1389,7 @@ module_eval(<<'.,.,', 'parser.y', 65)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 69)
-  def _reduce_23(val, _values, result)
+  def _reduce_25(val, _values, result)
                              @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[3])
 
     result
@@ -1391,21 +1397,21 @@ module_eval(<<'.,.,', 'parser.y', 69)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 71)
-  def _reduce_24(val, _values, result)
+  def _reduce_26(val, _values, result)
      @grammar.no_stdlib = true
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 72)
-  def _reduce_25(val, _values, result)
+  def _reduce_27(val, _values, result)
      @grammar.locations = true
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 76)
-  def _reduce_26(val, _values, result)
+  def _reduce_28(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1413,7 +1419,7 @@ module_eval(<<'.,.,', 'parser.y', 76)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 80)
-  def _reduce_27(val, _values, result)
+  def _reduce_29(val, _values, result)
                                end_c_declaration
 
     result
@@ -1421,7 +1427,7 @@ module_eval(<<'.,.,', 'parser.y', 80)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 84)
-  def _reduce_28(val, _values, result)
+  def _reduce_30(val, _values, result)
                                @grammar.set_union(
                              Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[3]),
                              val[3].line
@@ -1431,14 +1437,14 @@ module_eval(<<'.,.,', 'parser.y', 84)
   end
 .,.,
 
-# reduce 29 omitted
-
-# reduce 30 omitted
-
 # reduce 31 omitted
 
+# reduce 32 omitted
+
+# reduce 33 omitted
+
 module_eval(<<'.,.,', 'parser.y', 94)
-  def _reduce_32(val, _values, result)
+  def _reduce_34(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1446,7 +1452,7 @@ module_eval(<<'.,.,', 'parser.y', 94)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 98)
-  def _reduce_33(val, _values, result)
+  def _reduce_35(val, _values, result)
                                end_c_declaration
 
     result
@@ -1454,7 +1460,7 @@ module_eval(<<'.,.,', 'parser.y', 98)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 102)
-  def _reduce_34(val, _values, result)
+  def _reduce_36(val, _values, result)
                                @grammar.add_destructor(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1466,7 +1472,7 @@ module_eval(<<'.,.,', 'parser.y', 102)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 110)
-  def _reduce_35(val, _values, result)
+  def _reduce_37(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1474,7 +1480,7 @@ module_eval(<<'.,.,', 'parser.y', 110)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 114)
-  def _reduce_36(val, _values, result)
+  def _reduce_38(val, _values, result)
                                end_c_declaration
 
     result
@@ -1482,7 +1488,7 @@ module_eval(<<'.,.,', 'parser.y', 114)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 118)
-  def _reduce_37(val, _values, result)
+  def _reduce_39(val, _values, result)
                                @grammar.add_printer(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1494,7 +1500,7 @@ module_eval(<<'.,.,', 'parser.y', 118)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 126)
-  def _reduce_38(val, _values, result)
+  def _reduce_40(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1502,7 +1508,7 @@ module_eval(<<'.,.,', 'parser.y', 126)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 130)
-  def _reduce_39(val, _values, result)
+  def _reduce_41(val, _values, result)
                                end_c_declaration
 
     result
@@ -1510,7 +1516,7 @@ module_eval(<<'.,.,', 'parser.y', 130)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 134)
-  def _reduce_40(val, _values, result)
+  def _reduce_42(val, _values, result)
                                @grammar.add_error_token(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1522,7 +1528,7 @@ module_eval(<<'.,.,', 'parser.y', 134)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 142)
-  def _reduce_41(val, _values, result)
+  def _reduce_43(val, _values, result)
                                @grammar.after_shift = val[1]
 
     result
@@ -1530,7 +1536,7 @@ module_eval(<<'.,.,', 'parser.y', 142)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 146)
-  def _reduce_42(val, _values, result)
+  def _reduce_44(val, _values, result)
                                @grammar.before_reduce = val[1]
 
     result
@@ -1538,7 +1544,7 @@ module_eval(<<'.,.,', 'parser.y', 146)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 150)
-  def _reduce_43(val, _values, result)
+  def _reduce_45(val, _values, result)
                                @grammar.after_reduce = val[1]
 
     result
@@ -1546,7 +1552,7 @@ module_eval(<<'.,.,', 'parser.y', 150)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 154)
-  def _reduce_44(val, _values, result)
+  def _reduce_46(val, _values, result)
                                @grammar.after_shift_error_token = val[1]
 
     result
@@ -1554,17 +1560,17 @@ module_eval(<<'.,.,', 'parser.y', 154)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 158)
-  def _reduce_45(val, _values, result)
+  def _reduce_47(val, _values, result)
                                @grammar.after_pop_stack = val[1]
 
     result
   end
 .,.,
 
-# reduce 46 omitted
+# reduce 48 omitted
 
 module_eval(<<'.,.,', 'parser.y', 164)
-  def _reduce_47(val, _values, result)
+  def _reduce_49(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               @grammar.add_type(id: id, tag: hash[:tag])
@@ -1576,7 +1582,7 @@ module_eval(<<'.,.,', 'parser.y', 164)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 172)
-  def _reduce_48(val, _values, result)
+  def _reduce_50(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1590,7 +1596,7 @@ module_eval(<<'.,.,', 'parser.y', 172)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 182)
-  def _reduce_49(val, _values, result)
+  def _reduce_51(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1604,7 +1610,7 @@ module_eval(<<'.,.,', 'parser.y', 182)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 192)
-  def _reduce_50(val, _values, result)
+  def _reduce_52(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1618,7 +1624,7 @@ module_eval(<<'.,.,', 'parser.y', 192)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 202)
-  def _reduce_51(val, _values, result)
+  def _reduce_53(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1632,7 +1638,7 @@ module_eval(<<'.,.,', 'parser.y', 202)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 213)
-  def _reduce_52(val, _values, result)
+  def _reduce_54(val, _values, result)
                               val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
                           }
@@ -1642,7 +1648,7 @@ module_eval(<<'.,.,', 'parser.y', 213)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 219)
-  def _reduce_53(val, _values, result)
+  def _reduce_55(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
@@ -1652,7 +1658,7 @@ module_eval(<<'.,.,', 'parser.y', 219)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 225)
-  def _reduce_54(val, _values, result)
+  def _reduce_56(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
@@ -1662,36 +1668,36 @@ module_eval(<<'.,.,', 'parser.y', 225)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 230)
-  def _reduce_55(val, _values, result)
+  def _reduce_57(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 231)
-  def _reduce_56(val, _values, result)
+  def _reduce_58(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 57 omitted
+# reduce 59 omitted
 
-# reduce 58 omitted
+# reduce 60 omitted
 
 module_eval(<<'.,.,', 'parser.y', 233)
-  def _reduce_59(val, _values, result)
+  def _reduce_61(val, _values, result)
      result = val
     result
   end
 .,.,
 
-# reduce 60 omitted
+# reduce 62 omitted
 
-# reduce 61 omitted
+# reduce 63 omitted
 
 module_eval(<<'.,.,', 'parser.y', 237)
-  def _reduce_62(val, _values, result)
+  def _reduce_64(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1700,7 +1706,7 @@ module_eval(<<'.,.,', 'parser.y', 237)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 243)
-  def _reduce_63(val, _values, result)
+  def _reduce_65(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1709,7 +1715,7 @@ module_eval(<<'.,.,', 'parser.y', 243)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 248)
-  def _reduce_64(val, _values, result)
+  def _reduce_66(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1718,21 +1724,21 @@ module_eval(<<'.,.,', 'parser.y', 248)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 252)
-  def _reduce_65(val, _values, result)
+  def _reduce_67(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 253)
-  def _reduce_66(val, _values, result)
+  def _reduce_68(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 257)
-  def _reduce_67(val, _values, result)
+  def _reduce_69(val, _values, result)
                       builder = val[0]
                   result = [builder]
 
@@ -1741,7 +1747,7 @@ module_eval(<<'.,.,', 'parser.y', 257)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 262)
-  def _reduce_68(val, _values, result)
+  def _reduce_70(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
 
@@ -1749,12 +1755,12 @@ module_eval(<<'.,.,', 'parser.y', 262)
   end
 .,.,
 
-# reduce 69 omitted
+# reduce 71 omitted
 
-# reduce 70 omitted
+# reduce 72 omitted
 
 module_eval(<<'.,.,', 'parser.y', 268)
-  def _reduce_71(val, _values, result)
+  def _reduce_73(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1763,7 +1769,7 @@ module_eval(<<'.,.,', 'parser.y', 268)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 273)
-  def _reduce_72(val, _values, result)
+  def _reduce_74(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1772,7 +1778,7 @@ module_eval(<<'.,.,', 'parser.y', 273)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 278)
-  def _reduce_73(val, _values, result)
+  def _reduce_75(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1784,7 +1790,7 @@ module_eval(<<'.,.,', 'parser.y', 278)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 286)
-  def _reduce_74(val, _values, result)
+  def _reduce_76(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1794,7 +1800,7 @@ module_eval(<<'.,.,', 'parser.y', 286)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 292)
-  def _reduce_75(val, _values, result)
+  def _reduce_77(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1804,7 +1810,7 @@ module_eval(<<'.,.,', 'parser.y', 292)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 298)
-  def _reduce_76(val, _values, result)
+  def _reduce_78(val, _values, result)
                   if @prec_seen
                 on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                 @code_after_prec = true
@@ -1816,7 +1822,7 @@ module_eval(<<'.,.,', 'parser.y', 298)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 306)
-  def _reduce_77(val, _values, result)
+  def _reduce_79(val, _values, result)
                   end_c_declaration
 
     result
@@ -1824,7 +1830,7 @@ module_eval(<<'.,.,', 'parser.y', 306)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 310)
-  def _reduce_78(val, _values, result)
+  def _reduce_80(val, _values, result)
                   user_code = val[3]
               user_code.alias_name = val[6]
               builder = val[0]
@@ -1836,7 +1842,7 @@ module_eval(<<'.,.,', 'parser.y', 310)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 318)
-  def _reduce_79(val, _values, result)
+  def _reduce_81(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1847,17 +1853,17 @@ module_eval(<<'.,.,', 'parser.y', 318)
   end
 .,.,
 
-# reduce 80 omitted
+# reduce 82 omitted
 
 module_eval(<<'.,.,', 'parser.y', 326)
-  def _reduce_81(val, _values, result)
+  def _reduce_83(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 330)
-  def _reduce_82(val, _values, result)
+  def _reduce_84(val, _values, result)
                                result = [{tag: nil, tokens: val[0]}]
 
     result
@@ -1865,7 +1871,7 @@ module_eval(<<'.,.,', 'parser.y', 330)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 334)
-  def _reduce_83(val, _values, result)
+  def _reduce_85(val, _values, result)
                                result = [{tag: val[0], tokens: val[1]}]
 
     result
@@ -1873,7 +1879,7 @@ module_eval(<<'.,.,', 'parser.y', 334)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 338)
-  def _reduce_84(val, _values, result)
+  def _reduce_86(val, _values, result)
                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
@@ -1881,25 +1887,25 @@ module_eval(<<'.,.,', 'parser.y', 338)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 341)
-  def _reduce_85(val, _values, result)
+  def _reduce_87(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 342)
-  def _reduce_86(val, _values, result)
+  def _reduce_88(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 87 omitted
+# reduce 89 omitted
 
-# reduce 88 omitted
+# reduce 90 omitted
 
 module_eval(<<'.,.,', 'parser.y', 349)
-  def _reduce_89(val, _values, result)
+  def _reduce_91(val, _values, result)
                   begin_c_declaration("}")
 
     result
@@ -1907,7 +1913,7 @@ module_eval(<<'.,.,', 'parser.y', 349)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 353)
-  def _reduce_90(val, _values, result)
+  def _reduce_92(val, _values, result)
                   end_c_declaration
 
     result
@@ -1915,7 +1921,7 @@ module_eval(<<'.,.,', 'parser.y', 353)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 357)
-  def _reduce_91(val, _values, result)
+  def _reduce_93(val, _values, result)
                   result = val[0].append(val[3])
 
     result
@@ -1923,7 +1929,7 @@ module_eval(<<'.,.,', 'parser.y', 357)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 361)
-  def _reduce_92(val, _values, result)
+  def _reduce_94(val, _values, result)
                   begin_c_declaration("}")
 
     result
@@ -1931,7 +1937,7 @@ module_eval(<<'.,.,', 'parser.y', 361)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 365)
-  def _reduce_93(val, _values, result)
+  def _reduce_95(val, _values, result)
                   end_c_declaration
 
     result
@@ -1939,7 +1945,7 @@ module_eval(<<'.,.,', 'parser.y', 365)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 369)
-  def _reduce_94(val, _values, result)
+  def _reduce_96(val, _values, result)
                   result = [val[2]]
 
     result
@@ -1947,7 +1953,7 @@ module_eval(<<'.,.,', 'parser.y', 369)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 374)
-  def _reduce_95(val, _values, result)
+  def _reduce_97(val, _values, result)
                                              result = [{tag: nil, tokens: val[0]}]
 
     result
@@ -1955,7 +1961,7 @@ module_eval(<<'.,.,', 'parser.y', 374)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 378)
-  def _reduce_96(val, _values, result)
+  def _reduce_98(val, _values, result)
                                              result = [{tag: val[0], tokens: val[1]}]
 
     result
@@ -1963,7 +1969,7 @@ module_eval(<<'.,.,', 'parser.y', 378)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 382)
-  def _reduce_97(val, _values, result)
+  def _reduce_99(val, _values, result)
                                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
@@ -1971,45 +1977,45 @@ module_eval(<<'.,.,', 'parser.y', 382)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 385)
-  def _reduce_98(val, _values, result)
+  def _reduce_100(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 386)
-  def _reduce_99(val, _values, result)
+  def _reduce_101(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 100 omitted
+# reduce 102 omitted
 
 module_eval(<<'.,.,', 'parser.y', 390)
-  def _reduce_101(val, _values, result)
+  def _reduce_103(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 391)
-  def _reduce_102(val, _values, result)
+  def _reduce_104(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-# reduce 103 omitted
-
-# reduce 104 omitted
-
 # reduce 105 omitted
 
 # reduce 106 omitted
 
+# reduce 107 omitted
+
+# reduce 108 omitted
+
 module_eval(<<'.,.,', 'parser.y', 401)
-  def _reduce_107(val, _values, result)
+  def _reduce_109(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -2023,7 +2029,7 @@ module_eval(<<'.,.,', 'parser.y', 401)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 412)
-  def _reduce_108(val, _values, result)
+  def _reduce_110(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2035,7 +2041,7 @@ module_eval(<<'.,.,', 'parser.y', 412)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 420)
-  def _reduce_109(val, _values, result)
+  def _reduce_111(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2047,7 +2053,7 @@ module_eval(<<'.,.,', 'parser.y', 420)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 429)
-  def _reduce_110(val, _values, result)
+  def _reduce_112(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -2056,7 +2062,7 @@ module_eval(<<'.,.,', 'parser.y', 429)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 434)
-  def _reduce_111(val, _values, result)
+  def _reduce_113(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -2065,7 +2071,7 @@ module_eval(<<'.,.,', 'parser.y', 434)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 439)
-  def _reduce_112(val, _values, result)
+  def _reduce_114(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -2077,7 +2083,7 @@ module_eval(<<'.,.,', 'parser.y', 439)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 447)
-  def _reduce_113(val, _values, result)
+  def _reduce_115(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -2089,7 +2095,7 @@ module_eval(<<'.,.,', 'parser.y', 447)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 455)
-  def _reduce_114(val, _values, result)
+  def _reduce_116(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -2101,7 +2107,7 @@ module_eval(<<'.,.,', 'parser.y', 455)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 463)
-  def _reduce_115(val, _values, result)
+  def _reduce_117(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
              @code_after_prec = true
@@ -2113,7 +2119,7 @@ module_eval(<<'.,.,', 'parser.y', 463)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 471)
-  def _reduce_116(val, _values, result)
+  def _reduce_118(val, _values, result)
                end_c_declaration
 
     result
@@ -2121,7 +2127,7 @@ module_eval(<<'.,.,', 'parser.y', 471)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 475)
-  def _reduce_117(val, _values, result)
+  def _reduce_119(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
            user_code.tag = val[7]
@@ -2134,7 +2140,7 @@ module_eval(<<'.,.,', 'parser.y', 475)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 484)
-  def _reduce_118(val, _values, result)
+  def _reduce_120(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2146,84 +2152,80 @@ module_eval(<<'.,.,', 'parser.y', 484)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 491)
-  def _reduce_119(val, _values, result)
+  def _reduce_121(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 492)
-  def _reduce_120(val, _values, result)
+  def _reduce_122(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 493)
-  def _reduce_121(val, _values, result)
+  def _reduce_123(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 495)
-  def _reduce_122(val, _values, result)
+  def _reduce_124(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 496)
-  def _reduce_123(val, _values, result)
+  def _reduce_125(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 497)
-  def _reduce_124(val, _values, result)
+  def _reduce_126(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 498)
-  def _reduce_125(val, _values, result)
+  def _reduce_127(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 500)
-  def _reduce_126(val, _values, result)
+  def _reduce_128(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-# reduce 127 omitted
+# reduce 129 omitted
 
-# reduce 128 omitted
-
-module_eval(<<'.,.,', 'parser.y', 507)
-  def _reduce_129(val, _values, result)
-                        begin_c_declaration('\Z')
-                    @grammar.epilogue_first_lineno = @lexer.line + 1
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 512)
+module_eval(<<'.,.,', 'parser.y', 506)
   def _reduce_130(val, _values, result)
-                        end_c_declaration
-                    @grammar.epilogue = val[2].s_value
+                    begin_c_declaration('\Z')
+                @grammar.epilogue_first_lineno = @lexer.line + 1
 
     result
   end
 .,.,
 
-# reduce 131 omitted
+module_eval(<<'.,.,', 'parser.y', 511)
+  def _reduce_131(val, _values, result)
+                    end_c_declaration
+                @grammar.epilogue = val[2].s_value
+
+    result
+  end
+.,.,
 
 # reduce 132 omitted
 
@@ -2233,26 +2235,28 @@ module_eval(<<'.,.,', 'parser.y', 512)
 
 # reduce 135 omitted
 
-module_eval(<<'.,.,', 'parser.y', 523)
-  def _reduce_136(val, _values, result)
+# reduce 136 omitted
+
+module_eval(<<'.,.,', 'parser.y', 522)
+  def _reduce_137(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 524)
-  def _reduce_137(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 523)
+  def _reduce_138(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 138 omitted
-
 # reduce 139 omitted
 
-module_eval(<<'.,.,', 'parser.y', 529)
-  def _reduce_140(val, _values, result)
+# reduce 140 omitted
+
+module_eval(<<'.,.,', 'parser.y', 528)
+  def _reduce_141(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 530)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 529)
 
 include Lrama::Report::Duration
 
@@ -728,334 +728,339 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-   105,    55,   106,   171,    92,    83,    55,    55,   188,   171,
-    83,    83,    55,     6,   188,    55,    83,    54,   173,   164,
-    74,    10,   165,   189,   173,     4,    55,     5,    54,   189,
-    83,    79,    11,    55,    55,    54,    54,    49,    86,    86,
-    55,   191,    54,    93,   165,    86,   174,    43,    55,   107,
-    54,   190,   174,    86,     4,    50,     5,   190,    24,    28,
-    29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-    39,    40,    41,    42,    49,    55,    55,    54,    54,    98,
-    83,   206,    55,    55,    54,    54,    83,   206,    55,    52,
-    54,   228,    83,   206,   229,    24,    28,    29,    30,    31,
-    32,    33,    34,    35,    36,    37,    38,    39,    40,    41,
-    42,    12,   196,   197,   198,   103,    15,    16,    17,    18,
-    19,    20,    49,   129,    21,    22,    23,    24,    28,    29,
-    30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
-    40,    41,    42,    55,    55,    54,    54,    83,   206,    55,
-    55,    54,    54,    83,   206,    55,    55,    54,    54,    83,
-   206,    55,    55,    54,    54,    83,    83,    55,    55,    54,
-    54,    83,    83,    55,    55,    54,    54,    83,    83,    55,
-    55,    54,   217,    83,    83,    55,    55,   217,   217,    83,
-    83,    55,    55,    54,    54,    83,   196,   197,   198,   103,
-   233,   241,    58,   229,   229,    55,    55,    54,    54,    55,
-    55,    54,    54,    55,    58,    54,   196,   197,   198,    58,
-    61,    62,    63,    64,    65,    66,    67,    68,    69,    70,
-    71,    50,   100,   103,   108,   108,   108,   110,   116,   119,
-   121,   124,   124,   124,   124,   127,   130,   132,   133,   135,
-   137,   138,   139,   140,   141,    83,   148,   149,   150,   151,
-   154,   155,   156,   158,   168,   148,   170,   176,   178,   179,
-   180,   181,   182,   183,   185,   186,   154,   193,   201,   202,
-   209,   168,   213,   216,   103,   221,   168,   225,   168,   227,
-   183,   186,   186,   103,   238,   183,   240,   183,   103,   103,
-   183 ]
+    95,    48,    96,   184,    85,    76,    48,    48,   189,   184,
+    76,    76,    48,    48,   189,    47,    76,   185,    67,    48,
+     6,    47,   191,   185,    79,    48,    40,    47,   191,    76,
+    72,    48,   160,    47,    41,   161,    79,    93,    44,    48,
+    48,    47,    47,    86,    79,    79,   186,   187,    45,    97,
+   161,   192,   186,   205,   206,   207,   130,   192,    20,    24,
+    25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
+    35,    36,    37,    38,    93,     4,    48,     5,    47,   124,
+    76,   198,    48,     4,    47,     5,    76,   198,    48,    51,
+    47,   228,    76,   198,   229,    20,    24,    25,    26,    27,
+    28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
+    38,    11,    12,    13,    14,    15,    16,    93,   119,    17,
+    18,    19,    51,    20,    24,    25,    26,    27,    28,    29,
+    30,    31,    32,    33,    34,    35,    36,    37,    38,    11,
+    12,    13,    14,    15,    16,    51,    54,    17,    18,    19,
+    43,    20,    24,    25,    26,    27,    28,    29,    30,    31,
+    32,    33,    34,    35,    36,    37,    38,    48,    48,    47,
+    47,    76,   198,    48,    48,    47,    47,    76,   198,    48,
+    48,    47,    47,    76,   198,    48,    48,    47,    47,    76,
+    76,    48,    48,    47,    47,    76,    76,    48,    48,    47,
+    47,    76,    76,    48,    48,    47,   221,    76,    76,    48,
+    48,   221,    47,    76,    76,    48,    48,   221,    47,    76,
+   205,   206,   207,   130,   233,   242,    55,   229,   229,    48,
+    48,    47,    47,    48,    48,    47,    47,    48,    48,    47,
+    47,    48,    56,    47,   205,   206,   207,    57,    58,    59,
+    60,    61,    62,    63,    64,    87,    98,    98,    98,   100,
+   106,   109,   111,   114,   114,   114,   114,   117,   125,   127,
+   130,   132,   134,   135,   136,   137,   138,    76,   145,   146,
+   147,   148,   150,   151,   152,   154,   164,   145,   166,   169,
+   170,   172,   174,   175,   176,   177,   178,   179,   181,   182,
+   188,   193,   194,   201,   164,   208,   211,   169,   213,   164,
+   223,   164,   130,   227,   182,   230,   182,   179,   179,   239,
+   130,   241,   130,   179,   130,   179 ]
 
 racc_action_check = [
-    53,   153,    53,   153,    42,   153,   167,   192,   167,   192,
-   167,   192,   210,     1,   210,    36,   210,    36,   153,   147,
-    36,     5,   147,   167,   192,     0,    37,     0,    37,   210,
-    37,    37,     6,    38,    39,    38,    39,    12,    38,    39,
-    40,   169,    40,    42,   169,    40,   153,     9,    41,    53,
-    41,   167,   192,    41,     2,    13,     2,   210,    12,    12,
-    12,    12,    12,    12,    12,    12,    12,    12,    12,    12,
-    12,    12,    12,    12,    44,    16,   180,    16,   180,    44,
-   180,   180,   181,    73,   181,    73,   181,   181,   182,    15,
-   182,   218,   182,   182,   218,    44,    44,    44,    44,    44,
+    46,   163,    46,   163,    38,   163,   168,   202,   168,   202,
+   168,   202,   212,    32,   212,    32,   212,   163,    32,    34,
+     1,    34,   168,   202,    34,    33,     5,    33,   212,    33,
+    33,    35,   144,    35,     6,   144,    35,    44,     9,    36,
+    37,    36,    37,    38,    36,    37,   163,   165,    11,    46,
+   165,   168,   202,   183,   183,   183,   183,   212,    44,    44,
     44,    44,    44,    44,    44,    44,    44,    44,    44,    44,
-    44,     8,   172,   172,   172,   172,     8,     8,     8,     8,
-     8,     8,    93,    93,     8,     8,     8,     8,     8,     8,
+    44,    44,    44,    44,    88,     0,   176,     0,   176,    88,
+   176,   176,   177,     2,   177,     2,   177,   177,   178,    13,
+   178,   220,   178,   178,   220,    88,    88,    88,    88,    88,
+    88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
+    88,     3,     3,     3,     3,     3,     3,    86,    86,     3,
+     3,     3,    14,     3,     3,     3,     3,     3,     3,     3,
+     3,     3,     3,     3,     3,     3,     3,     3,     3,     8,
+     8,     8,     8,     8,     8,    15,    16,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
-     8,     8,     8,   203,    74,   203,    74,   203,   203,   207,
-    85,   207,    85,   207,   207,   208,    86,   208,    86,   208,
-   208,    78,    79,    78,    79,    78,    79,   121,   123,   121,
-   123,   121,   123,   145,   174,   145,   174,   145,   174,   190,
-   193,   190,   193,   190,   193,   213,   227,   213,   227,   213,
-   227,   229,   116,   229,   116,   229,   187,   187,   187,   187,
-   224,   235,    17,   224,   235,   118,   124,   118,   124,   126,
-   142,   126,   142,   146,    18,   146,   219,   219,   219,    19,
-    20,    21,    24,    28,    29,    30,    31,    32,    33,    34,
-    35,    46,    47,    48,    57,    59,    60,    61,    72,    76,
-    77,    84,    89,    90,    91,    92,    94,   102,   103,   109,
-   111,   112,   113,   114,   115,   120,   127,   128,   129,   131,
-   132,   133,   134,   136,   149,   150,   152,   157,   159,   160,
-   161,   162,   163,   164,   165,   166,   170,   171,   175,   177,
-   184,   186,   188,   191,   195,   199,   209,   214,   216,   217,
-   220,   223,   226,   228,   232,   233,   234,   236,   238,   240,
-   243 ]
+     8,     8,     8,     8,     8,     8,     8,   195,    12,   195,
+    12,   195,   195,   199,    66,   199,    66,   199,   199,   200,
+    67,   200,    67,   200,   200,    71,    72,    71,    72,    71,
+    72,   111,   113,   111,   113,   111,   113,   142,   186,   142,
+   186,   142,   186,   192,   208,   192,   208,   192,   208,   213,
+   229,   213,   229,   213,   229,   230,    78,   230,    78,   230,
+   190,   190,   190,   190,   225,   238,    17,   225,   238,    79,
+   106,    79,   106,   108,   114,   108,   114,   116,   139,   116,
+   139,   143,    20,   143,   222,   222,   222,    24,    25,    26,
+    27,    28,    29,    30,    31,    39,    50,    52,    53,    54,
+    65,    69,    70,    77,    82,    83,    84,    85,    90,    91,
+    92,    99,   101,   102,   103,   104,   105,   110,   117,   118,
+   119,   120,   129,   130,   131,   133,   146,   147,   149,   150,
+   151,   153,   155,   156,   157,   158,   159,   160,   161,   162,
+   167,   171,   173,   180,   182,   184,   187,   188,   189,   201,
+   209,   211,   215,   216,   219,   221,   224,   226,   228,   232,
+   233,   235,   239,   240,   241,   245 ]
 
 racc_action_pointer = [
-    15,    13,    44,   nil,   nil,    14,    32,   nil,   102,    45,
-   nil,   nil,    33,    42,   nil,    83,    72,   182,   194,   199,
-   215,   201,   nil,   nil,   202,   nil,   nil,   nil,   203,   204,
-   205,   221,   222,   223,   224,   225,    12,    23,    30,    31,
-    37,    45,    -1,   nil,    70,   nil,   218,   219,   181,   nil,
-   nil,   nil,   nil,    -5,   nil,   nil,   nil,   214,   nil,   215,
-   216,   217,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   230,    80,   141,   nil,   233,   232,   158,   159,
-   nil,   nil,   nil,   nil,   233,   147,   153,   nil,   nil,   234,
-   235,   236,   204,   118,   235,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   204,   243,   nil,   nil,   nil,   nil,   nil,   247,
-   nil,   248,   249,   250,   251,   252,   189,   nil,   202,   nil,
-   248,   164,   nil,   165,   203,   nil,   206,   251,   214,   217,
-   nil,   257,   213,   208,   260,   nil,   261,   nil,   nil,   nil,
-   nil,   nil,   207,   nil,   nil,   170,   210,   -23,   nil,   217,
-   260,   nil,   220,    -2,   nil,   nil,   nil,   246,   nil,   247,
-   248,   249,   250,   251,   265,   269,   229,     3,   nil,    -1,
-   229,   236,    63,   nil,   171,   257,   nil,   258,   nil,   nil,
-    73,    79,    85,   nil,   237,   nil,   234,   147,   241,   nil,
-   176,   240,     4,   177,   nil,   232,   nil,   nil,   nil,   283,
-   nil,   nil,   nil,   140,   nil,   nil,   nil,   146,   152,   239,
-     9,   nil,   nil,   182,   285,   nil,   241,   248,    49,   167,
-   282,   nil,   nil,   245,   158,   nil,   246,   183,   241,   188,
-   nil,   nil,   273,   287,   275,   159,   289,   nil,   246,   nil,
-   247,   nil,   nil,   292,   nil,   nil ]
+    65,    20,    73,    98,   nil,    19,    34,   nil,   126,    29,
+   nil,    42,   165,    70,   103,   126,   141,   207,   nil,   nil,
+   223,   nil,   nil,   nil,   228,   229,   230,   245,   246,   247,
+   248,   249,    10,    22,    16,    28,    36,    37,    -1,   253,
+   nil,   nil,   nil,   nil,    33,   nil,    -5,   nil,   nil,   nil,
+   237,   nil,   238,   239,   240,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   252,   171,   177,   nil,   255,
+   254,   182,   183,   nil,   nil,   nil,   nil,   255,   213,   226,
+   nil,   nil,   256,   257,   258,   226,   113,   nil,    70,   nil,
+   244,   245,   218,   nil,   nil,   nil,   nil,   nil,   nil,   269,
+   nil,   270,   271,   272,   273,   274,   227,   nil,   230,   nil,
+   270,   188,   nil,   189,   231,   nil,   234,   273,   236,   239,
+   270,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   239,
+   278,   282,   nil,   283,   nil,   nil,   nil,   nil,   nil,   235,
+   nil,   nil,   194,   238,   -10,   nil,   239,   282,   nil,   286,
+   242,   237,   nil,   271,   nil,   272,   273,   274,   275,   276,
+   289,   293,   253,    -2,   nil,     5,   nil,   254,     3,   nil,
+   nil,   281,   nil,   282,   nil,   nil,    73,    79,    85,   nil,
+   260,   nil,   257,     4,   264,   nil,   195,   263,   260,   267,
+   171,   nil,   200,   nil,   nil,   164,   nil,   nil,   nil,   170,
+   176,   262,     4,   nil,   nil,   nil,   nil,   nil,   201,   308,
+   nil,   264,     9,   206,   nil,   260,   311,   nil,   nil,   268,
+    49,   274,   195,   nil,   270,   182,   309,   nil,   310,   207,
+   212,   nil,   299,   268,   nil,   301,   nil,   nil,   183,   270,
+   315,   272,   nil,   nil,   nil,   317,   nil ]
 
 racc_action_default = [
-    -1,  -142,    -1,   -12,    -6,  -142,  -142,    -2,  -142,  -142,
-    -9,   246,  -142,   -10,   -14,  -142,  -142,  -142,  -142,  -142,
-  -142,  -142,   -26,   -27,  -142,   -31,   -32,   -33,  -142,  -142,
-  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,
-  -142,  -142,  -142,    -7,    -3,  -105,   -10,  -142,   -71,  -129,
-   -11,   -13,   -15,  -133,  -103,  -104,  -132,   -17,   -94,   -18,
-   -19,  -142,   -23,   -28,   -34,   -37,   -40,   -43,   -44,   -45,
-   -46,   -47,   -48,   -54,  -142,   -57,   -59,   -49,   -84,  -142,
-   -87,   -89,   -90,  -141,   -50,   -97,  -142,  -100,  -102,   -51,
-   -52,   -53,  -142,  -142,  -142,    -4,    -5,  -106,  -130,  -107,
-  -108,   -72,  -142,  -142,   -16,  -134,  -135,  -136,   -91,  -142,
-   -20,  -142,  -142,  -142,  -142,  -142,  -142,   -58,   -55,   -60,
-   -82,  -142,   -88,   -85,  -142,  -101,   -98,  -142,  -142,  -142,
-    -8,  -142,  -112,  -142,  -142,   -95,  -142,   -24,   -29,   -35,
-   -38,   -41,   -56,   -61,   -83,   -86,   -99,  -142,   -67,   -73,
-  -142,  -131,  -109,  -110,  -113,  -128,   -92,  -142,   -21,  -142,
-  -142,  -142,  -142,  -142,   -62,  -142,   -65,   -69,   -74,  -142,
-  -112,  -103,   -71,  -117,  -142,  -142,   -96,  -142,   -25,   -30,
-  -142,  -142,  -142,   -63,  -142,   -68,   -73,   -71,  -103,   -78,
-  -142,  -142,  -111,  -142,  -114,   -71,  -121,  -122,  -123,  -142,
-  -120,   -93,   -22,   -36,  -137,  -139,  -140,   -39,   -42,   -73,
-   -70,   -75,   -76,  -142,  -142,   -81,   -73,  -103,  -142,  -124,
-   -62,  -118,  -138,   -64,  -142,   -79,   -66,  -142,   -71,  -142,
-  -126,  -115,  -142,   -62,  -142,  -142,   -62,  -125,   -71,   -77,
-   -71,  -127,  -116,   -62,   -80,  -119 ]
+    -1,  -143,    -1,    -3,    -8,  -143,  -143,    -2,    -3,  -143,
+   -12,  -143,  -143,  -143,  -143,  -143,  -143,  -143,   -24,   -25,
+  -143,   -30,   -31,   -32,  -143,  -143,  -143,  -143,  -143,  -143,
+  -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,
+   -11,   247,    -4,   -26,  -143,   -13,  -134,  -102,  -103,  -133,
+   -15,   -93,   -16,   -17,  -143,   -21,   -27,   -33,   -36,   -39,
+   -42,   -43,   -44,   -45,   -46,   -47,   -53,  -143,   -56,   -58,
+   -48,   -83,  -143,   -86,   -88,   -89,  -142,   -49,   -96,  -143,
+   -99,  -101,   -50,   -51,   -52,  -143,  -143,    -9,    -5,  -104,
+  -106,  -143,   -70,  -130,   -14,  -135,  -136,  -137,   -90,  -143,
+   -18,  -143,  -143,  -143,  -143,  -143,  -143,   -57,   -54,   -59,
+   -81,  -143,   -87,   -84,  -143,  -100,   -97,  -143,  -143,  -143,
+  -143,    -6,    -7,  -105,  -131,  -107,  -108,  -109,   -71,  -143,
+  -143,  -143,   -94,  -143,   -22,   -28,   -34,   -37,   -40,   -55,
+   -60,   -82,   -85,   -98,  -143,   -66,   -72,  -143,   -10,  -143,
+  -113,  -143,   -91,  -143,   -19,  -143,  -143,  -143,  -143,  -143,
+   -61,  -143,   -64,   -68,   -73,  -143,  -132,  -110,  -111,  -114,
+  -129,  -143,   -95,  -143,   -23,   -29,  -143,  -143,  -143,   -62,
+  -143,   -67,   -72,   -70,  -102,   -77,  -143,  -143,  -113,  -102,
+   -70,  -118,  -143,   -92,   -20,   -35,  -138,  -140,  -141,   -38,
+   -41,   -72,   -69,   -74,   -75,  -122,  -123,  -124,  -143,  -143,
+   -80,   -72,  -112,  -143,  -115,   -70,  -143,  -121,  -139,   -63,
+  -143,  -102,  -125,   -78,   -65,  -143,   -61,  -119,   -61,  -143,
+  -143,  -127,  -143,   -70,  -116,  -143,   -76,  -126,  -143,   -70,
+   -61,   -70,  -128,   -79,  -117,   -61,  -120 ]
 
 racc_goto_table = [
-    80,   102,    56,    78,   117,    73,   195,   166,   126,   184,
-   153,    51,   147,   218,   125,   222,     1,     8,    45,   222,
-   222,   212,    76,    44,    88,    88,    88,    88,    84,    89,
-    90,    91,     3,   224,     7,   169,    57,    59,    60,    95,
-    96,   122,    80,   118,    99,   123,   146,   235,   192,   117,
-    97,     9,    94,   230,    13,   125,   203,   207,   208,    76,
-    76,    14,    53,   104,   136,   231,   177,   223,   111,   159,
-   112,    88,    88,   117,   226,   125,   160,   113,   239,   161,
-   114,   242,   162,   115,    80,   142,   122,   145,   245,   163,
-    72,    77,   143,   120,   128,   210,   214,   234,   144,   134,
-   175,   109,    76,   157,    76,   152,   199,   232,   122,   131,
-    88,   nil,    88,   nil,   nil,   nil,   172,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   194,   nil,   nil,    76,   nil,
-   187,   nil,    88,   nil,   nil,   nil,   nil,   200,   nil,   nil,
-   211,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   220,   nil,
-   nil,   nil,   nil,   215,   nil,   172,   219,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   187,   nil,   nil,   219,   nil,   nil,   nil,
-   nil,   236,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   219,   243,   237,   244 ]
+    73,   129,    49,    71,   180,    66,   162,   168,   115,   107,
+    91,    89,   116,   204,   144,     3,     9,     7,     1,    88,
+   215,    42,    69,   121,    81,    81,    81,    81,   220,   122,
+   218,    39,   120,   225,   218,   218,    46,    94,   112,    73,
+   108,   133,   113,   173,   165,   212,   115,   143,   101,   155,
+   238,   107,   231,   102,    91,   123,    69,    69,    50,    52,
+    53,   219,    77,    82,    83,    84,   156,   103,    81,    81,
+   234,   224,   236,   115,   195,   199,   200,   157,    73,   139,
+   112,   142,   107,   104,   244,   158,   105,   159,    65,   246,
+    70,   140,   203,   110,   118,   202,    69,   209,    69,   214,
+   232,   141,   131,   171,    81,    99,    81,   153,   126,   112,
+   167,   216,   235,   149,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   226,   nil,   nil,   nil,   nil,    69,
+   183,   nil,   nil,    81,   nil,   190,   nil,   nil,   nil,   nil,
+   nil,   nil,   240,   nil,   nil,   nil,   nil,   nil,   243,   nil,
+   245,   nil,   nil,   210,   nil,   nil,   nil,   nil,   nil,   217,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   183,
+   nil,   nil,   nil,   nil,   nil,   222,   nil,   nil,   nil,   190,
+   222,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   237,   222 ]
 
 racc_goto_check = [
-    45,    49,    37,    53,    36,    35,    47,    41,    58,    42,
-    63,    11,    40,    48,    59,    67,     1,     3,    60,    67,
-    67,    47,    37,     4,    37,    37,    37,    37,    34,    34,
-    34,    34,     6,    48,     6,    40,    15,    15,    15,     5,
-     7,    45,    45,    35,    11,    53,    58,    48,    63,    36,
-    60,     8,     9,    47,    10,    59,    23,    23,    23,    37,
-    37,    12,    13,    14,    16,    42,    17,    41,    18,    19,
-    24,    37,    37,    36,    41,    59,    25,    26,    42,    27,
-    28,    42,    29,    30,    45,    35,    45,    53,    42,    31,
-    32,    33,    38,    39,    43,    44,    50,    51,    52,    54,
-    55,    56,    37,    57,    37,    62,    64,    65,    45,    66,
-    37,   nil,    37,   nil,   nil,   nil,    45,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    49,   nil,   nil,    37,   nil,
-    45,   nil,    37,   nil,   nil,   nil,   nil,    45,   nil,   nil,
-    49,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    49,   nil,
-   nil,   nil,   nil,    45,   nil,    45,    45,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,    45,   nil,   nil,    45,   nil,   nil,   nil,
-   nil,    49,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    45,    49,    45,    49 ]
+    44,    48,    36,    52,    41,    34,    40,    63,    58,    35,
+    11,    59,    57,    46,    39,     6,     7,     6,     1,     4,
+    46,     7,    36,     5,    36,    36,    36,    36,    47,     8,
+    67,     9,    10,    47,    67,    67,    12,    13,    44,    44,
+    34,    15,    52,    16,    39,    63,    58,    57,    17,    18,
+    47,    35,    46,    23,    11,    59,    36,    36,    14,    14,
+    14,    40,    33,    33,    33,    33,    24,    25,    36,    36,
+    41,    40,    41,    58,    22,    22,    22,    26,    44,    34,
+    44,    52,    35,    27,    41,    28,    29,    30,    31,    41,
+    32,    37,    48,    38,    42,    43,    36,    49,    36,    48,
+    50,    51,    53,    54,    36,    55,    36,    56,    61,    44,
+    62,    64,    65,    66,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,    48,   nil,   nil,   nil,   nil,    36,
+    44,   nil,   nil,    36,   nil,    44,   nil,   nil,   nil,   nil,
+   nil,   nil,    48,   nil,   nil,   nil,   nil,   nil,    48,   nil,
+    48,   nil,   nil,    44,   nil,   nil,   nil,   nil,   nil,    44,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    44,
+   nil,   nil,   nil,   nil,   nil,    44,   nil,   nil,   nil,    44,
+    44,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    44,    44 ]
 
 racc_goto_pointer = [
-   nil,    16,   nil,    14,    11,    -5,    32,    -4,    47,     9,
-    46,    -2,    53,    46,    10,    19,   -46,   -92,     6,   -68,
-   nil,   nil,   nil,  -124,     7,   -62,    13,   -60,    15,   -58,
-    17,   -52,    54,    54,   -10,   -31,   -69,   -14,   -28,    17,
-  -115,  -142,  -155,     1,   -91,   -37,   nil,  -166,  -180,   -47,
-   -93,  -128,   -22,   -34,    -9,   -56,    43,   -32,   -78,   -71,
-     6,   nil,   -27,  -122,   -67,  -114,    11,  -188 ]
+   nil,    18,   nil,   nil,   -25,   -65,    15,    13,   -59,    27,
+   -55,   -34,    24,    -9,    45,   -59,  -111,    -7,   -85,   nil,
+   nil,   nil,  -102,    -3,   -69,    10,   -59,    25,   -52,    27,
+   -51,    56,    57,    28,   -27,   -57,   -10,   -19,    24,  -103,
+  -140,  -156,     8,   -87,   -33,   nil,  -170,  -180,   -91,   -88,
+  -123,    -9,   -30,     4,   -49,    54,   -25,   -67,   -70,   -33,
+   nil,    18,   -40,  -143,   -80,  -115,   -11,  -165 ]
 
 racc_goto_default = [
-   nil,   nil,     2,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    47,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    25,    26,    27,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,    75,    81,   nil,   nil,
-   nil,   nil,   nil,    48,   167,   205,   101,   nil,   nil,   nil,
-   nil,   nil,    82,   nil,   nil,   nil,   nil,   nil,    85,    87,
-   nil,    46,   nil,   nil,   nil,   nil,   nil,   204 ]
+   nil,   nil,     2,     8,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,    10,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    21,
+    22,    23,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,    68,    74,   nil,   nil,   nil,
+   nil,   nil,    92,   163,   197,   128,   nil,   nil,   nil,   nil,
+   nil,    75,   nil,   nil,   nil,   nil,   nil,    78,    80,   nil,
+    90,   nil,   nil,   nil,   nil,   nil,   nil,   196 ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
   0, 61, :_reduce_1,
   2, 61, :_reduce_2,
-  0, 62, :_reduce_none,
-  1, 62, :_reduce_none,
+  0, 62, :_reduce_3,
+  2, 62, :_reduce_4,
+  0, 63, :_reduce_none,
+  1, 63, :_reduce_none,
   5, 56, :_reduce_none,
-  0, 63, :_reduce_6,
-  0, 64, :_reduce_7,
-  5, 57, :_reduce_8,
+  0, 64, :_reduce_8,
+  0, 65, :_reduce_9,
+  5, 57, :_reduce_10,
   2, 57, :_reduce_none,
-  0, 66, :_reduce_none,
-  1, 66, :_reduce_none,
-  0, 58, :_reduce_12,
+  1, 58, :_reduce_none,
+  2, 58, :_reduce_13,
   3, 58, :_reduce_none,
-  1, 65, :_reduce_none,
-  2, 65, :_reduce_15,
-  3, 65, :_reduce_none,
-  2, 65, :_reduce_none,
-  2, 65, :_reduce_18,
-  2, 65, :_reduce_19,
-  0, 71, :_reduce_20,
+  2, 58, :_reduce_none,
+  2, 58, :_reduce_16,
+  2, 58, :_reduce_17,
+  0, 70, :_reduce_18,
+  0, 71, :_reduce_19,
+  7, 58, :_reduce_20,
   0, 72, :_reduce_21,
-  7, 65, :_reduce_22,
-  0, 73, :_reduce_23,
-  0, 74, :_reduce_24,
-  6, 65, :_reduce_25,
-  1, 65, :_reduce_26,
-  1, 65, :_reduce_27,
+  0, 73, :_reduce_22,
+  6, 58, :_reduce_23,
+  1, 58, :_reduce_24,
+  1, 58, :_reduce_25,
+  2, 58, :_reduce_none,
+  0, 78, :_reduce_27,
   0, 79, :_reduce_28,
-  0, 80, :_reduce_29,
-  6, 67, :_reduce_30,
-  1, 67, :_reduce_none,
-  1, 67, :_reduce_none,
-  1, 67, :_reduce_none,
+  6, 66, :_reduce_29,
+  1, 66, :_reduce_none,
+  1, 66, :_reduce_none,
+  1, 66, :_reduce_none,
+  0, 80, :_reduce_33,
   0, 81, :_reduce_34,
-  0, 82, :_reduce_35,
-  7, 67, :_reduce_36,
+  7, 66, :_reduce_35,
+  0, 82, :_reduce_36,
   0, 83, :_reduce_37,
-  0, 84, :_reduce_38,
-  7, 67, :_reduce_39,
+  7, 66, :_reduce_38,
+  0, 84, :_reduce_39,
   0, 85, :_reduce_40,
-  0, 86, :_reduce_41,
-  7, 67, :_reduce_42,
-  2, 67, :_reduce_43,
-  2, 67, :_reduce_44,
-  2, 67, :_reduce_45,
-  2, 67, :_reduce_46,
-  2, 67, :_reduce_47,
-  2, 75, :_reduce_none,
-  2, 75, :_reduce_49,
-  2, 75, :_reduce_50,
-  2, 75, :_reduce_51,
-  2, 75, :_reduce_52,
-  2, 75, :_reduce_53,
-  1, 87, :_reduce_54,
-  2, 87, :_reduce_55,
-  3, 87, :_reduce_56,
-  1, 90, :_reduce_57,
-  2, 90, :_reduce_58,
-  0, 94, :_reduce_none,
-  1, 94, :_reduce_none,
-  3, 91, :_reduce_61,
-  0, 97, :_reduce_none,
-  1, 97, :_reduce_none,
-  8, 76, :_reduce_64,
-  5, 77, :_reduce_65,
-  8, 77, :_reduce_66,
-  1, 95, :_reduce_67,
-  3, 95, :_reduce_68,
-  1, 96, :_reduce_69,
-  3, 96, :_reduce_70,
-  0, 104, :_reduce_none,
-  1, 104, :_reduce_none,
-  0, 99, :_reduce_73,
-  1, 99, :_reduce_74,
-  3, 99, :_reduce_75,
-  3, 99, :_reduce_76,
-  6, 99, :_reduce_77,
-  0, 105, :_reduce_78,
-  0, 106, :_reduce_79,
-  7, 99, :_reduce_80,
-  3, 99, :_reduce_81,
+  7, 66, :_reduce_41,
+  2, 66, :_reduce_42,
+  2, 66, :_reduce_43,
+  2, 66, :_reduce_44,
+  2, 66, :_reduce_45,
+  2, 66, :_reduce_46,
+  2, 74, :_reduce_none,
+  2, 74, :_reduce_48,
+  2, 74, :_reduce_49,
+  2, 74, :_reduce_50,
+  2, 74, :_reduce_51,
+  2, 74, :_reduce_52,
+  1, 86, :_reduce_53,
+  2, 86, :_reduce_54,
+  3, 86, :_reduce_55,
+  1, 89, :_reduce_56,
+  2, 89, :_reduce_57,
   0, 93, :_reduce_none,
-  1, 93, :_reduce_83,
-  1, 88, :_reduce_84,
-  2, 88, :_reduce_85,
-  3, 88, :_reduce_86,
-  1, 108, :_reduce_87,
-  2, 108, :_reduce_88,
-  1, 100, :_reduce_none,
-  1, 100, :_reduce_none,
+  1, 93, :_reduce_none,
+  3, 90, :_reduce_60,
+  0, 96, :_reduce_none,
+  1, 96, :_reduce_none,
+  8, 75, :_reduce_63,
+  5, 76, :_reduce_64,
+  8, 76, :_reduce_65,
+  1, 94, :_reduce_66,
+  3, 94, :_reduce_67,
+  1, 95, :_reduce_68,
+  3, 95, :_reduce_69,
+  0, 103, :_reduce_none,
+  1, 103, :_reduce_none,
+  0, 98, :_reduce_72,
+  1, 98, :_reduce_73,
+  3, 98, :_reduce_74,
+  3, 98, :_reduce_75,
+  6, 98, :_reduce_76,
+  0, 104, :_reduce_77,
+  0, 105, :_reduce_78,
+  7, 98, :_reduce_79,
+  3, 98, :_reduce_80,
+  0, 92, :_reduce_none,
+  1, 92, :_reduce_82,
+  1, 87, :_reduce_83,
+  2, 87, :_reduce_84,
+  3, 87, :_reduce_85,
+  1, 107, :_reduce_86,
+  2, 107, :_reduce_87,
+  1, 99, :_reduce_none,
+  1, 99, :_reduce_none,
+  0, 108, :_reduce_90,
   0, 109, :_reduce_91,
-  0, 110, :_reduce_92,
-  6, 70, :_reduce_93,
+  6, 69, :_reduce_92,
+  0, 110, :_reduce_93,
   0, 111, :_reduce_94,
-  0, 112, :_reduce_95,
-  5, 70, :_reduce_96,
-  1, 89, :_reduce_97,
-  2, 89, :_reduce_98,
-  3, 89, :_reduce_99,
-  1, 113, :_reduce_100,
-  2, 113, :_reduce_101,
-  1, 114, :_reduce_none,
-  1, 92, :_reduce_103,
-  1, 92, :_reduce_104,
+  5, 69, :_reduce_95,
+  1, 88, :_reduce_96,
+  2, 88, :_reduce_97,
+  3, 88, :_reduce_98,
+  1, 112, :_reduce_99,
+  2, 112, :_reduce_100,
+  1, 113, :_reduce_none,
+  1, 91, :_reduce_102,
+  1, 91, :_reduce_103,
   1, 59, :_reduce_none,
   2, 59, :_reduce_none,
-  2, 115, :_reduce_none,
-  2, 115, :_reduce_none,
-  4, 116, :_reduce_109,
-  1, 117, :_reduce_110,
-  3, 117, :_reduce_111,
-  0, 118, :_reduce_112,
-  1, 118, :_reduce_113,
-  3, 118, :_reduce_114,
-  5, 118, :_reduce_115,
-  7, 118, :_reduce_116,
-  0, 119, :_reduce_117,
-  0, 120, :_reduce_118,
-  8, 118, :_reduce_119,
-  3, 118, :_reduce_120,
-  1, 102, :_reduce_121,
-  1, 102, :_reduce_122,
-  1, 102, :_reduce_123,
-  1, 103, :_reduce_124,
-  3, 103, :_reduce_125,
-  2, 103, :_reduce_126,
-  4, 103, :_reduce_127,
-  3, 101, :_reduce_128,
-  1, 98, :_reduce_none,
-  0, 121, :_reduce_130,
-  3, 60, :_reduce_131,
+  0, 116, :_reduce_none,
+  1, 116, :_reduce_none,
+  2, 114, :_reduce_none,
+  2, 114, :_reduce_none,
+  4, 115, :_reduce_110,
+  1, 117, :_reduce_111,
+  3, 117, :_reduce_112,
+  0, 118, :_reduce_113,
+  1, 118, :_reduce_114,
+  3, 118, :_reduce_115,
+  5, 118, :_reduce_116,
+  7, 118, :_reduce_117,
+  0, 119, :_reduce_118,
+  0, 120, :_reduce_119,
+  8, 118, :_reduce_120,
+  3, 118, :_reduce_121,
+  1, 101, :_reduce_122,
+  1, 101, :_reduce_123,
+  1, 101, :_reduce_124,
+  1, 102, :_reduce_125,
+  3, 102, :_reduce_126,
+  2, 102, :_reduce_127,
+  4, 102, :_reduce_128,
+  3, 100, :_reduce_129,
+  1, 97, :_reduce_none,
+  0, 121, :_reduce_131,
+  3, 60, :_reduce_132,
+  1, 67, :_reduce_none,
+  0, 68, :_reduce_none,
   1, 68, :_reduce_none,
-  0, 69, :_reduce_none,
-  1, 69, :_reduce_none,
-  1, 69, :_reduce_none,
-  1, 69, :_reduce_none,
-  1, 78, :_reduce_137,
-  2, 78, :_reduce_138,
+  1, 68, :_reduce_none,
+  1, 68, :_reduce_none,
+  1, 77, :_reduce_138,
+  2, 77, :_reduce_139,
   1, 122, :_reduce_none,
   1, 122, :_reduce_none,
-  1, 107, :_reduce_141 ]
+  1, 106, :_reduce_142 ]
 
-racc_reduce_n = 142
+racc_reduce_n = 143
 
-racc_shift_n = 246
+racc_shift_n = 247
 
 racc_token_table = {
   false => 0,
@@ -1071,18 +1076,18 @@ racc_token_table = {
   "%{" => 10,
   "%}" => 11,
   "%require" => 12,
-  ";" => 13,
-  "%expect" => 14,
-  "%define" => 15,
-  "%param" => 16,
-  "%lex-param" => 17,
-  "%parse-param" => 18,
-  "%code" => 19,
-  "{" => 20,
-  "}" => 21,
-  "%initial-action" => 22,
-  "%no-stdlib" => 23,
-  "%locations" => 24,
+  "%expect" => 13,
+  "%define" => 14,
+  "%param" => 15,
+  "%lex-param" => 16,
+  "%parse-param" => 17,
+  "%code" => 18,
+  "{" => 19,
+  "}" => 20,
+  "%initial-action" => 21,
+  "%no-stdlib" => 22,
+  "%locations" => 23,
+  ";" => 24,
   "%union" => 25,
   "%destructor" => 26,
   "%printer" => 27,
@@ -1149,7 +1154,6 @@ Racc_token_to_s_table = [
   "\"%{\"",
   "\"%}\"",
   "\"%require\"",
-  "\";\"",
   "\"%expect\"",
   "\"%define\"",
   "\"%param\"",
@@ -1161,6 +1165,7 @@ Racc_token_to_s_table = [
   "\"%initial-action\"",
   "\"%no-stdlib\"",
   "\"%locations\"",
+  "\";\"",
   "\"%union\"",
   "\"%destructor\"",
   "\"%printer\"",
@@ -1194,15 +1199,14 @@ Racc_token_to_s_table = [
   "$start",
   "input",
   "prologue_declaration",
-  "bison_declarations",
+  "bison_declaration",
   "grammar",
   "epilogue",
   "\"-many@prologue_declaration\"",
+  "\"-many@bison_declaration\"",
   "\"-option@epilogue\"",
   "@1",
   "@2",
-  "bison_declaration",
-  "\"-option@;\"",
   "grammar_declaration",
   "variable",
   "value",
@@ -1253,6 +1257,7 @@ Racc_token_to_s_table = [
   "token_declaration_for_precedence",
   "rules_or_grammar_declaration",
   "rules",
+  "\"-option@;\"",
   "rhs_list",
   "rhs",
   "@21",
@@ -1281,14 +1286,28 @@ module_eval(<<'.,.,', 'parser.y', 11)
   end
 .,.,
 
-# reduce 3 omitted
+module_eval(<<'.,.,', 'parser.y', 11)
+  def _reduce_3(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
-# reduce 4 omitted
+module_eval(<<'.,.,', 'parser.y', 11)
+  def _reduce_4(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
 # reduce 5 omitted
 
+# reduce 6 omitted
+
+# reduce 7 omitted
+
 module_eval(<<'.,.,', 'parser.y', 12)
-  def _reduce_6(val, _values, result)
+  def _reduce_8(val, _values, result)
                                 begin_c_declaration("%}")
                             @grammar.prologue_first_lineno = @lexer.line
 
@@ -1297,7 +1316,7 @@ module_eval(<<'.,.,', 'parser.y', 12)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 17)
-  def _reduce_7(val, _values, result)
+  def _reduce_9(val, _values, result)
                                 end_c_declaration
 
     result
@@ -1305,43 +1324,30 @@ module_eval(<<'.,.,', 'parser.y', 17)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 21)
-  def _reduce_8(val, _values, result)
+  def _reduce_10(val, _values, result)
                                 @grammar.prologue = val[2].s_value
 
     result
   end
 .,.,
 
-# reduce 9 omitted
-
-# reduce 10 omitted
-
 # reduce 11 omitted
 
-module_eval(<<'.,.,', 'parser.y', 25)
-  def _reduce_12(val, _values, result)
-     result = ""
-    result
-  end
-.,.,
+# reduce 12 omitted
 
-# reduce 13 omitted
-
-# reduce 14 omitted
-
-module_eval(<<'.,.,', 'parser.y', 29)
-  def _reduce_15(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 27)
+  def _reduce_13(val, _values, result)
      @grammar.expect = val[1]
     result
   end
 .,.,
 
-# reduce 16 omitted
+# reduce 14 omitted
 
-# reduce 17 omitted
+# reduce 15 omitted
 
-module_eval(<<'.,.,', 'parser.y', 34)
-  def _reduce_18(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 32)
+  def _reduce_16(val, _values, result)
                              val[1].each {|token|
                            @grammar.lex_param = Grammar::Code::NoReferenceCode.new(type: :lex_param, token_code: token).token_code.s_value
                          }
@@ -1350,8 +1356,8 @@ module_eval(<<'.,.,', 'parser.y', 34)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 40)
-  def _reduce_19(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 38)
+  def _reduce_17(val, _values, result)
                              val[1].each {|token|
                            @grammar.parse_param = Grammar::Code::NoReferenceCode.new(type: :parse_param, token_code: token).token_code.s_value
                          }
@@ -1360,86 +1366,88 @@ module_eval(<<'.,.,', 'parser.y', 40)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 46)
-  def _reduce_20(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 44)
+  def _reduce_18(val, _values, result)
                              begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 50)
-  def _reduce_21(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 48)
+  def _reduce_19(val, _values, result)
                              end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 54)
-  def _reduce_22(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 52)
+  def _reduce_20(val, _values, result)
                              @grammar.add_percent_code(id: val[1], code: val[4])
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 58)
-  def _reduce_23(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 56)
+  def _reduce_21(val, _values, result)
                              begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 62)
-  def _reduce_24(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 60)
+  def _reduce_22(val, _values, result)
                              end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 66)
-  def _reduce_25(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 64)
+  def _reduce_23(val, _values, result)
                              @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[3])
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 68)
-  def _reduce_26(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 66)
+  def _reduce_24(val, _values, result)
      @grammar.no_stdlib = true
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 69)
-  def _reduce_27(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 67)
+  def _reduce_25(val, _values, result)
      @grammar.locations = true
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 73)
-  def _reduce_28(val, _values, result)
+# reduce 26 omitted
+
+module_eval(<<'.,.,', 'parser.y', 72)
+  def _reduce_27(val, _values, result)
                                begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 77)
-  def _reduce_29(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 76)
+  def _reduce_28(val, _values, result)
                                end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 81)
-  def _reduce_30(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 80)
+  def _reduce_29(val, _values, result)
                                @grammar.set_union(
                              Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[3]),
                              val[3].line
@@ -1449,30 +1457,30 @@ module_eval(<<'.,.,', 'parser.y', 81)
   end
 .,.,
 
+# reduce 30 omitted
+
 # reduce 31 omitted
 
 # reduce 32 omitted
 
-# reduce 33 omitted
-
-module_eval(<<'.,.,', 'parser.y', 91)
-  def _reduce_34(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 90)
+  def _reduce_33(val, _values, result)
                                begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 95)
-  def _reduce_35(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 94)
+  def _reduce_34(val, _values, result)
                                end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 99)
-  def _reduce_36(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 98)
+  def _reduce_35(val, _values, result)
                                @grammar.add_destructor(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1483,24 +1491,24 @@ module_eval(<<'.,.,', 'parser.y', 99)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 107)
-  def _reduce_37(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 106)
+  def _reduce_36(val, _values, result)
                                begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 111)
-  def _reduce_38(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 110)
+  def _reduce_37(val, _values, result)
                                end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 115)
-  def _reduce_39(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 114)
+  def _reduce_38(val, _values, result)
                                @grammar.add_printer(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1511,24 +1519,24 @@ module_eval(<<'.,.,', 'parser.y', 115)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 123)
-  def _reduce_40(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 122)
+  def _reduce_39(val, _values, result)
                                begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 127)
-  def _reduce_41(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 126)
+  def _reduce_40(val, _values, result)
                                end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 131)
-  def _reduce_42(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 130)
+  def _reduce_41(val, _values, result)
                                @grammar.add_error_token(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1539,50 +1547,50 @@ module_eval(<<'.,.,', 'parser.y', 131)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 139)
-  def _reduce_43(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 138)
+  def _reduce_42(val, _values, result)
                                @grammar.after_shift = val[1]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 143)
-  def _reduce_44(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 142)
+  def _reduce_43(val, _values, result)
                                @grammar.before_reduce = val[1]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 147)
-  def _reduce_45(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 146)
+  def _reduce_44(val, _values, result)
                                @grammar.after_reduce = val[1]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 151)
-  def _reduce_46(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 150)
+  def _reduce_45(val, _values, result)
                                @grammar.after_shift_error_token = val[1]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 155)
-  def _reduce_47(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 154)
+  def _reduce_46(val, _values, result)
                                @grammar.after_pop_stack = val[1]
 
     result
   end
 .,.,
 
-# reduce 48 omitted
+# reduce 47 omitted
 
-module_eval(<<'.,.,', 'parser.y', 161)
-  def _reduce_49(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 160)
+  def _reduce_48(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               @grammar.add_type(id: id, tag: hash[:tag])
@@ -1593,8 +1601,8 @@ module_eval(<<'.,.,', 'parser.y', 161)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 169)
-  def _reduce_50(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 168)
+  def _reduce_49(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1607,8 +1615,8 @@ module_eval(<<'.,.,', 'parser.y', 169)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 179)
-  def _reduce_51(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 178)
+  def _reduce_50(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1621,8 +1629,8 @@ module_eval(<<'.,.,', 'parser.y', 179)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 189)
-  def _reduce_52(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 188)
+  def _reduce_51(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1635,8 +1643,8 @@ module_eval(<<'.,.,', 'parser.y', 189)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 199)
-  def _reduce_53(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 198)
+  def _reduce_52(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1649,8 +1657,8 @@ module_eval(<<'.,.,', 'parser.y', 199)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 210)
-  def _reduce_54(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 209)
+  def _reduce_53(val, _values, result)
                               val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
                           }
@@ -1659,8 +1667,8 @@ module_eval(<<'.,.,', 'parser.y', 210)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 216)
-  def _reduce_55(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 215)
+  def _reduce_54(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
@@ -1669,8 +1677,8 @@ module_eval(<<'.,.,', 'parser.y', 216)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 222)
-  def _reduce_56(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 221)
+  def _reduce_55(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
@@ -1679,37 +1687,37 @@ module_eval(<<'.,.,', 'parser.y', 222)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 227)
-  def _reduce_57(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 226)
+  def _reduce_56(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 228)
-  def _reduce_58(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 227)
+  def _reduce_57(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
+# reduce 58 omitted
+
 # reduce 59 omitted
 
-# reduce 60 omitted
-
-module_eval(<<'.,.,', 'parser.y', 230)
-  def _reduce_61(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 229)
+  def _reduce_60(val, _values, result)
      result = val
     result
   end
 .,.,
 
+# reduce 61 omitted
+
 # reduce 62 omitted
 
-# reduce 63 omitted
-
-module_eval(<<'.,.,', 'parser.y', 234)
-  def _reduce_64(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 233)
+  def _reduce_63(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1717,8 +1725,8 @@ module_eval(<<'.,.,', 'parser.y', 234)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 240)
-  def _reduce_65(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 239)
+  def _reduce_64(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1726,8 +1734,8 @@ module_eval(<<'.,.,', 'parser.y', 240)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 245)
-  def _reduce_66(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 244)
+  def _reduce_65(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1735,22 +1743,22 @@ module_eval(<<'.,.,', 'parser.y', 245)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 249)
-  def _reduce_67(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 248)
+  def _reduce_66(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 250)
-  def _reduce_68(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 249)
+  def _reduce_67(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 254)
-  def _reduce_69(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 253)
+  def _reduce_68(val, _values, result)
                       builder = val[0]
                   result = [builder]
 
@@ -1758,8 +1766,8 @@ module_eval(<<'.,.,', 'parser.y', 254)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 259)
-  def _reduce_70(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 258)
+  def _reduce_69(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
 
@@ -1767,11 +1775,20 @@ module_eval(<<'.,.,', 'parser.y', 259)
   end
 .,.,
 
+# reduce 70 omitted
+
 # reduce 71 omitted
 
-# reduce 72 omitted
+module_eval(<<'.,.,', 'parser.y', 264)
+  def _reduce_72(val, _values, result)
+                  reset_precs
+              result = Grammar::ParameterizingRule::Rhs.new
 
-module_eval(<<'.,.,', 'parser.y', 265)
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 269)
   def _reduce_73(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
@@ -1780,17 +1797,8 @@ module_eval(<<'.,.,', 'parser.y', 265)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 270)
+module_eval(<<'.,.,', 'parser.y', 274)
   def _reduce_74(val, _values, result)
-                  reset_precs
-              result = Grammar::ParameterizingRule::Rhs.new
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 275)
-  def _reduce_75(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1801,8 +1809,8 @@ module_eval(<<'.,.,', 'parser.y', 275)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 283)
-  def _reduce_76(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 282)
+  def _reduce_75(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1811,8 +1819,8 @@ module_eval(<<'.,.,', 'parser.y', 283)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 289)
-  def _reduce_77(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 288)
+  def _reduce_76(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1821,8 +1829,8 @@ module_eval(<<'.,.,', 'parser.y', 289)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 295)
-  def _reduce_78(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 294)
+  def _reduce_77(val, _values, result)
                   if @prec_seen
                 on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                 @code_after_prec = true
@@ -1833,16 +1841,16 @@ module_eval(<<'.,.,', 'parser.y', 295)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 303)
-  def _reduce_79(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 302)
+  def _reduce_78(val, _values, result)
                   end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 307)
-  def _reduce_80(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 306)
+  def _reduce_79(val, _values, result)
                   user_code = val[3]
               user_code.alias_name = val[6]
               builder = val[0]
@@ -1853,8 +1861,8 @@ module_eval(<<'.,.,', 'parser.y', 307)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 315)
-  def _reduce_81(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 314)
+  def _reduce_80(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1865,158 +1873,160 @@ module_eval(<<'.,.,', 'parser.y', 315)
   end
 .,.,
 
-# reduce 82 omitted
+# reduce 81 omitted
 
-module_eval(<<'.,.,', 'parser.y', 323)
-  def _reduce_83(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 322)
+  def _reduce_82(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 327)
-  def _reduce_84(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 326)
+  def _reduce_83(val, _values, result)
                                result = [{tag: nil, tokens: val[0]}]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 331)
-  def _reduce_85(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 330)
+  def _reduce_84(val, _values, result)
                                result = [{tag: val[0], tokens: val[1]}]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 335)
-  def _reduce_86(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 334)
+  def _reduce_85(val, _values, result)
                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 338)
-  def _reduce_87(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 337)
+  def _reduce_86(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 339)
-  def _reduce_88(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 338)
+  def _reduce_87(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
+# reduce 88 omitted
+
 # reduce 89 omitted
 
-# reduce 90 omitted
-
-module_eval(<<'.,.,', 'parser.y', 346)
-  def _reduce_91(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 345)
+  def _reduce_90(val, _values, result)
                   begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 350)
-  def _reduce_92(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 349)
+  def _reduce_91(val, _values, result)
                   end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 354)
-  def _reduce_93(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 353)
+  def _reduce_92(val, _values, result)
                   result = val[0].append(val[3])
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 358)
-  def _reduce_94(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 357)
+  def _reduce_93(val, _values, result)
                   begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 362)
-  def _reduce_95(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 361)
+  def _reduce_94(val, _values, result)
                   end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 366)
-  def _reduce_96(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 365)
+  def _reduce_95(val, _values, result)
                   result = [val[2]]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 371)
-  def _reduce_97(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 370)
+  def _reduce_96(val, _values, result)
                                              result = [{tag: nil, tokens: val[0]}]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 375)
-  def _reduce_98(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 374)
+  def _reduce_97(val, _values, result)
                                              result = [{tag: val[0], tokens: val[1]}]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 379)
-  def _reduce_99(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 378)
+  def _reduce_98(val, _values, result)
                                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 382)
-  def _reduce_100(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 381)
+  def _reduce_99(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 383)
-  def _reduce_101(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 382)
+  def _reduce_100(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 102 omitted
+# reduce 101 omitted
 
-module_eval(<<'.,.,', 'parser.y', 387)
-  def _reduce_103(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 386)
+  def _reduce_102(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 388)
-  def _reduce_104(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 387)
+  def _reduce_103(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
+
+# reduce 104 omitted
 
 # reduce 105 omitted
 
@@ -2026,8 +2036,10 @@ module_eval(<<'.,.,', 'parser.y', 388)
 
 # reduce 108 omitted
 
-module_eval(<<'.,.,', 'parser.y', 398)
-  def _reduce_109(val, _values, result)
+# reduce 109 omitted
+
+module_eval(<<'.,.,', 'parser.y', 397)
+  def _reduce_110(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -2040,8 +2052,8 @@ module_eval(<<'.,.,', 'parser.y', 398)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 409)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 408)
+  def _reduce_111(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2052,8 +2064,8 @@ module_eval(<<'.,.,', 'parser.y', 409)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 417)
-  def _reduce_111(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 416)
+  def _reduce_112(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2064,16 +2076,7 @@ module_eval(<<'.,.,', 'parser.y', 417)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 426)
-  def _reduce_112(val, _values, result)
-               reset_precs
-           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 431)
+module_eval(<<'.,.,', 'parser.y', 425)
   def _reduce_113(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -2082,8 +2085,17 @@ module_eval(<<'.,.,', 'parser.y', 431)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 436)
+module_eval(<<'.,.,', 'parser.y', 430)
   def _reduce_114(val, _values, result)
+               reset_precs
+           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 435)
+  def _reduce_115(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -2094,8 +2106,8 @@ module_eval(<<'.,.,', 'parser.y', 436)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 444)
-  def _reduce_115(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 443)
+  def _reduce_116(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -2106,8 +2118,8 @@ module_eval(<<'.,.,', 'parser.y', 444)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 452)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 451)
+  def _reduce_117(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -2118,8 +2130,8 @@ module_eval(<<'.,.,', 'parser.y', 452)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 460)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 459)
+  def _reduce_118(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
              @code_after_prec = true
@@ -2130,16 +2142,16 @@ module_eval(<<'.,.,', 'parser.y', 460)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 468)
-  def _reduce_118(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 467)
+  def _reduce_119(val, _values, result)
                end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 472)
-  def _reduce_119(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 471)
+  def _reduce_120(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
            user_code.tag = val[7]
@@ -2151,8 +2163,8 @@ module_eval(<<'.,.,', 'parser.y', 472)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 481)
-  def _reduce_120(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 480)
+  def _reduce_121(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2163,66 +2175,66 @@ module_eval(<<'.,.,', 'parser.y', 481)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 488)
-  def _reduce_121(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 487)
+  def _reduce_122(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 489)
-  def _reduce_122(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 488)
+  def _reduce_123(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 490)
-  def _reduce_123(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 489)
+  def _reduce_124(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 492)
-  def _reduce_124(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 491)
+  def _reduce_125(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 493)
-  def _reduce_125(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 492)
+  def _reduce_126(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 494)
-  def _reduce_126(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 493)
+  def _reduce_127(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 495)
-  def _reduce_127(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 494)
+  def _reduce_128(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 497)
-  def _reduce_128(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 496)
+  def _reduce_129(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-# reduce 129 omitted
+# reduce 130 omitted
 
-module_eval(<<'.,.,', 'parser.y', 503)
-  def _reduce_130(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 502)
+  def _reduce_131(val, _values, result)
                     begin_c_declaration('\Z')
                 @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2230,16 +2242,14 @@ module_eval(<<'.,.,', 'parser.y', 503)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 508)
-  def _reduce_131(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 507)
+  def _reduce_132(val, _values, result)
                     end_c_declaration
                 @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
-
-# reduce 132 omitted
 
 # reduce 133 omitted
 
@@ -2249,26 +2259,28 @@ module_eval(<<'.,.,', 'parser.y', 508)
 
 # reduce 136 omitted
 
-module_eval(<<'.,.,', 'parser.y', 519)
-  def _reduce_137(val, _values, result)
+# reduce 137 omitted
+
+module_eval(<<'.,.,', 'parser.y', 518)
+  def _reduce_138(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 520)
-  def _reduce_138(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 519)
+  def _reduce_139(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 139 omitted
-
 # reduce 140 omitted
 
-module_eval(<<'.,.,', 'parser.y', 525)
-  def _reduce_141(val, _values, result)
+# reduce 141 omitted
+
+module_eval(<<'.,.,', 'parser.y', 524)
+  def _reduce_142(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 526)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 510)
 
 include Lrama::Report::Duration
 
@@ -728,39 +728,38 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    95,    48,    96,   184,    85,    76,    48,    48,   189,   184,
+    94,    48,    95,   184,    84,    76,    48,    48,   189,   184,
     76,    76,    48,    48,   189,    47,    76,   185,    68,    48,
-     6,    47,   191,   185,    79,    48,    40,    47,   191,    76,
-    72,    48,   160,    47,    41,   161,    79,    93,    44,    48,
-    48,    47,    47,    86,    79,    79,   186,   187,    45,    97,
-   161,   192,   186,   205,   206,   207,   130,   192,    20,    24,
+     6,    47,   191,   185,    80,    48,    40,    47,   191,    76,
+    72,    48,   160,    47,    41,   161,    80,    92,    44,    48,
+    48,    47,    47,    85,    80,    80,   186,   187,    45,    96,
+   161,   192,   186,    92,     4,    51,     5,   192,    20,    24,
     25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
-    35,    36,    37,    38,    93,     4,    48,     5,    47,   124,
-    76,   198,    48,     4,    47,     5,    76,   198,    48,    51,
-    47,   228,    76,   198,   229,    20,    24,    25,    26,    27,
-    28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
-    38,    11,    12,    13,    14,    15,    16,    93,   119,    17,
-    18,    19,    51,    20,    24,    25,    26,    27,    28,    29,
-    30,    31,    32,    33,    34,    35,    36,    37,    38,    11,
-    12,    13,    14,    15,    16,    51,    54,    17,    18,    19,
-    43,    20,    24,    25,    26,    27,    28,    29,    30,    31,
-    32,    33,    34,    35,    36,    37,    38,    48,    48,    47,
-    47,    76,   198,    48,    48,    47,    47,    76,   198,    48,
-    48,    47,    47,    76,   198,    48,    48,    47,    47,    76,
-    76,    48,    48,    47,    47,    76,    76,    48,    48,    47,
-    47,    76,    76,    48,    48,    47,   221,    76,    76,    48,
-    48,   221,    47,    76,    76,    48,    48,   221,    47,    76,
-   205,   206,   207,   130,   233,   242,    55,   229,   229,    48,
-    48,    47,    47,    48,    48,    47,    47,    48,    56,    47,
-   205,   206,   207,    57,    58,    59,    60,    61,    62,    63,
-    64,    87,    98,    98,    98,   100,   106,   109,   111,   114,
-   114,   114,   114,   117,   125,   127,   130,   132,   134,   135,
-   136,   137,   138,    76,   145,   146,   147,   148,   150,   151,
-   152,   154,   164,   145,   166,   169,   170,   172,   174,   175,
-   176,   177,   178,   179,   181,   182,   188,   193,   194,   201,
-   164,   208,   211,   169,   213,   164,   223,   164,   130,   227,
-   182,   230,   182,   179,   179,   239,   130,   241,   130,   179,
-   130,   179 ]
+    35,    36,    37,    38,    20,    24,    25,    26,    27,    28,
+    29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
+    11,    12,    13,    14,    15,    16,    92,   119,    17,    18,
+    19,    51,    20,    24,    25,    26,    27,    28,    29,    30,
+    31,    32,    33,    34,    35,    36,    37,    38,    11,    12,
+    13,    14,    15,    16,    51,    54,    17,    18,    19,    43,
+    20,    24,    25,    26,    27,    28,    29,    30,    31,    32,
+    33,    34,    35,    36,    37,    38,    48,     4,    47,     5,
+    48,   115,    47,    55,    76,   198,    48,    48,    47,    47,
+    76,   198,    48,    48,    47,    47,    76,   198,    48,    48,
+    47,    47,    76,   198,    48,    48,    47,    47,    76,   198,
+    48,    48,    47,    47,    76,   198,    48,    48,    47,    47,
+    76,    76,    48,    48,    47,    47,    76,    76,    48,    48,
+    47,    47,    76,    76,    48,    48,    47,   221,    76,    76,
+    48,    48,   221,    47,    76,    76,    48,    48,   221,    47,
+    76,   205,   206,   207,   130,   205,   206,   207,   130,   228,
+   233,   242,   229,   229,   229,    48,    56,    47,   205,   206,
+   207,    57,    58,    59,    60,    61,    62,    63,    64,    86,
+    97,    97,    97,    99,   105,   108,   110,   117,   124,   125,
+   127,   130,   132,   134,   135,   136,   137,   138,    76,   145,
+   146,   147,   148,   150,   151,   152,   154,   164,   145,   166,
+   169,   170,   172,   174,   175,   176,   177,   178,   179,   181,
+   182,   188,   193,   194,   201,   164,   208,   211,   169,   213,
+   164,   223,   164,   130,   227,   182,   230,   182,   179,   179,
+   239,   130,   241,   130,   179,   130,   179 ]
 
 racc_action_check = [
     46,   163,    46,   163,    38,   163,   168,   202,   168,   202,
@@ -768,150 +767,149 @@ racc_action_check = [
      1,    34,   168,   202,    34,    33,     5,    33,   212,    33,
     33,    35,   144,    35,     6,   144,    35,    44,     9,    36,
     37,    36,    37,    38,    36,    37,   163,   165,    11,    46,
-   165,   168,   202,   183,   183,   183,   183,   212,    44,    44,
+   165,   168,   202,    87,     0,    13,     0,   212,    44,    44,
     44,    44,    44,    44,    44,    44,    44,    44,    44,    44,
-    44,    44,    44,    44,    88,     0,   176,     0,   176,    88,
-   176,   176,   177,     2,   177,     2,   177,   177,   178,    13,
-   178,   220,   178,   178,   220,    88,    88,    88,    88,    88,
-    88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
-    88,     3,     3,     3,     3,     3,     3,    86,    86,     3,
-     3,     3,    14,     3,     3,     3,     3,     3,     3,     3,
-     3,     3,     3,     3,     3,     3,     3,     3,     3,     8,
-     8,     8,     8,     8,     8,    15,    16,     8,     8,     8,
+    44,    44,    44,    44,    87,    87,    87,    87,    87,    87,
+    87,    87,    87,    87,    87,    87,    87,    87,    87,    87,
+     3,     3,     3,     3,     3,     3,    85,    85,     3,     3,
+     3,    14,     3,     3,     3,     3,     3,     3,     3,     3,
+     3,     3,     3,     3,     3,     3,     3,     3,     8,     8,
+     8,     8,     8,     8,    15,    16,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
-     8,     8,     8,     8,     8,     8,     8,   195,    12,   195,
-    12,   195,   195,   199,    66,   199,    66,   199,   199,   200,
-    68,   200,    68,   200,   200,    71,    72,    71,    72,    71,
-    72,   111,   113,   111,   113,   111,   113,   142,   186,   142,
-   186,   142,   186,   192,   208,   192,   208,   192,   208,   213,
-   229,   213,   229,   213,   229,   230,    78,   230,    78,   230,
-   190,   190,   190,   190,   225,   238,    17,   225,   238,    79,
-   106,    79,   106,   114,   116,   114,   116,   143,    20,   143,
-   222,   222,   222,    24,    25,    26,    27,    28,    29,    30,
-    31,    39,    50,    52,    53,    54,    65,    69,    70,    77,
-    82,    83,    84,    85,    90,    91,    92,    99,   101,   102,
-   103,   104,   105,   110,   117,   118,   119,   120,   129,   130,
-   131,   133,   146,   147,   149,   150,   151,   153,   155,   156,
-   157,   158,   159,   160,   161,   162,   167,   171,   173,   180,
-   182,   184,   187,   188,   189,   201,   209,   211,   215,   216,
-   219,   221,   224,   226,   228,   232,   233,   235,   239,   240,
-   241,   245 ]
+     8,     8,     8,     8,     8,     8,    78,     2,    78,     2,
+   176,    78,   176,    17,   176,   176,   177,    12,   177,    12,
+   177,   177,   178,    66,   178,    66,   178,   178,   195,    68,
+   195,    68,   195,   195,   199,    80,   199,    80,   199,   199,
+   200,   105,   200,   105,   200,   200,    71,    72,    71,    72,
+    71,    72,   110,   112,   110,   112,   110,   112,   142,   186,
+   142,   186,   142,   186,   192,   208,   192,   208,   192,   208,
+   213,   229,   213,   229,   213,   229,   230,   113,   230,   113,
+   230,   183,   183,   183,   183,   190,   190,   190,   190,   220,
+   225,   238,   220,   225,   238,   115,    20,   115,   222,   222,
+   222,    24,    25,    26,    27,    28,    29,    30,    31,    39,
+    50,    52,    53,    54,    65,    69,    70,    84,    88,    89,
+    90,    91,    98,   100,   101,   102,   103,   104,   109,   117,
+   118,   119,   120,   129,   130,   131,   133,   146,   147,   149,
+   150,   151,   153,   155,   156,   157,   158,   159,   160,   161,
+   162,   167,   171,   173,   180,   182,   184,   187,   188,   189,
+   201,   209,   211,   215,   216,   219,   221,   224,   226,   228,
+   232,   233,   235,   239,   240,   241,   245 ]
 
 racc_action_pointer = [
-    65,    20,    73,    98,   nil,    19,    34,   nil,   126,    29,
-   nil,    42,   165,    70,   103,   126,   141,   207,   nil,   nil,
-   219,   nil,   nil,   nil,   224,   225,   226,   241,   242,   243,
-   244,   245,    10,    22,    16,    28,    36,    37,    -1,   249,
+    44,    20,   137,    77,   nil,    19,    34,   nil,   105,    29,
+   nil,    42,   154,    36,    82,   105,   120,   134,   nil,   nil,
+   217,   nil,   nil,   nil,   222,   223,   224,   239,   240,   241,
+   242,   243,    10,    22,    16,    28,    36,    37,    -1,   247,
    nil,   nil,   nil,   nil,    33,   nil,    -5,   nil,   nil,   nil,
-   233,   nil,   234,   235,   236,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   248,   171,   nil,   177,   251,
-   250,   182,   183,   nil,   nil,   nil,   nil,   251,   213,   226,
-   nil,   nil,   252,   253,   254,   222,   113,   nil,    70,   nil,
-   240,   241,   214,   nil,   nil,   nil,   nil,   nil,   nil,   265,
-   nil,   266,   267,   268,   269,   270,   227,   nil,   nil,   nil,
-   266,   188,   nil,   189,   230,   nil,   231,   269,   232,   235,
-   266,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   235,
-   274,   278,   nil,   279,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   194,   234,   -10,   nil,   235,   278,   nil,   282,
-   238,   233,   nil,   267,   nil,   268,   269,   270,   271,   272,
-   285,   289,   249,    -2,   nil,     5,   nil,   250,     3,   nil,
-   nil,   277,   nil,   278,   nil,   nil,    73,    79,    85,   nil,
-   256,   nil,   253,     4,   260,   nil,   195,   259,   256,   263,
-   171,   nil,   200,   nil,   nil,   164,   nil,   nil,   nil,   170,
-   176,   258,     4,   nil,   nil,   nil,   nil,   nil,   201,   304,
-   nil,   260,     9,   206,   nil,   256,   307,   nil,   nil,   264,
-    49,   270,   191,   nil,   266,   182,   305,   nil,   306,   207,
-   212,   nil,   295,   264,   nil,   297,   nil,   nil,   183,   266,
-   311,   268,   nil,   nil,   nil,   313,   nil ]
+   231,   nil,   232,   233,   234,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   246,   160,   nil,   166,   249,
+   248,   183,   184,   nil,   nil,   nil,   nil,   nil,   143,   nil,
+   172,   nil,   nil,   nil,   216,    92,   nil,    49,   249,   235,
+   236,   209,   nil,   nil,   nil,   nil,   nil,   nil,   260,   nil,
+   261,   262,   263,   264,   265,   178,   nil,   nil,   nil,   261,
+   189,   nil,   190,   214,   nil,   232,   nil,   264,   227,   230,
+   261,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   230,
+   269,   273,   nil,   274,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   195,   nil,   -10,   nil,   230,   273,   nil,   277,
+   233,   228,   nil,   262,   nil,   263,   264,   265,   266,   267,
+   280,   284,   244,    -2,   nil,     5,   nil,   245,     3,   nil,
+   nil,   272,   nil,   273,   nil,   nil,   147,   153,   159,   nil,
+   251,   nil,   248,   172,   255,   nil,   196,   254,   251,   258,
+   176,   nil,   201,   nil,   nil,   165,   nil,   nil,   nil,   171,
+   177,   253,     4,   nil,   nil,   nil,   nil,   nil,   202,   299,
+   nil,   255,     9,   207,   nil,   251,   302,   nil,   nil,   259,
+   187,   265,   189,   nil,   261,   188,   300,   nil,   301,   208,
+   213,   nil,   290,   259,   nil,   292,   nil,   nil,   189,   261,
+   306,   263,   nil,   nil,   nil,   308,   nil ]
 
 racc_action_default = [
-    -1,  -143,    -1,    -3,    -8,  -143,  -143,    -2,    -3,  -143,
-   -12,  -143,  -143,  -143,  -143,  -143,  -143,  -143,   -24,   -25,
-  -143,   -30,   -31,   -32,  -143,  -143,  -143,  -143,  -143,  -143,
-  -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,
-   -11,   247,    -4,   -26,  -143,   -13,  -134,  -102,  -103,  -133,
-   -15,   -93,   -16,   -17,  -143,   -21,   -27,   -33,   -36,   -39,
-   -42,   -43,   -44,   -45,   -46,   -47,   -53,   -55,  -143,   -58,
-   -48,   -83,  -143,   -86,   -88,   -89,  -142,   -49,   -96,  -143,
-   -99,  -101,   -50,   -51,   -52,  -143,  -143,    -9,    -5,  -104,
-  -106,  -143,   -70,  -130,   -14,  -135,  -136,  -137,   -90,  -143,
-   -18,  -143,  -143,  -143,  -143,  -143,  -143,   -54,   -56,   -59,
-   -81,  -143,   -87,   -84,  -143,  -100,   -97,  -143,  -143,  -143,
-  -143,    -6,    -7,  -105,  -131,  -107,  -108,  -109,   -71,  -143,
-  -143,  -143,   -94,  -143,   -22,   -28,   -34,   -37,   -40,   -57,
-   -60,   -82,   -85,   -98,  -143,   -66,   -72,  -143,   -10,  -143,
-  -113,  -143,   -91,  -143,   -19,  -143,  -143,  -143,  -143,  -143,
-   -61,  -143,   -64,   -68,   -73,  -143,  -132,  -110,  -111,  -114,
-  -129,  -143,   -95,  -143,   -23,   -29,  -143,  -143,  -143,   -62,
-  -143,   -67,   -72,   -70,  -102,   -77,  -143,  -143,  -113,  -102,
-   -70,  -118,  -143,   -92,   -20,   -35,  -138,  -140,  -141,   -38,
-   -41,   -72,   -69,   -74,   -75,  -122,  -123,  -124,  -143,  -143,
-   -80,   -72,  -112,  -143,  -115,   -70,  -143,  -121,  -139,   -63,
-  -143,  -102,  -125,   -78,   -65,  -143,   -61,  -119,   -61,  -143,
-  -143,  -127,  -143,   -70,  -116,  -143,   -76,  -126,  -143,   -70,
-   -61,   -70,  -128,   -79,  -117,   -61,  -120 ]
+    -1,  -142,    -1,    -3,   -10,  -142,  -142,    -2,    -3,  -142,
+   -14,  -142,  -142,  -142,  -142,  -142,  -142,  -142,   -26,   -27,
+  -142,   -32,   -33,   -34,  -142,  -142,  -142,  -142,  -142,  -142,
+  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,
+   -13,   247,    -4,   -28,  -142,   -15,  -133,  -103,  -104,  -132,
+   -17,   -95,   -18,   -19,  -142,   -23,   -29,   -35,   -38,   -41,
+   -44,   -45,   -46,   -47,   -48,   -49,   -55,   -57,  -142,   -60,
+   -50,   -85,  -142,   -88,   -90,   -91,  -141,   -51,   -98,  -100,
+  -142,   -52,   -53,   -54,  -142,  -142,   -11,    -5,    -7,  -105,
+  -142,   -72,  -129,   -16,  -134,  -135,  -136,   -92,  -142,   -20,
+  -142,  -142,  -142,  -142,  -142,  -142,   -56,   -58,   -61,   -83,
+  -142,   -89,   -86,   -98,   -99,  -142,  -101,  -142,  -142,  -142,
+  -142,    -6,    -8,    -9,  -130,  -106,  -107,  -108,   -73,  -142,
+  -142,  -142,   -96,  -142,   -24,   -30,   -36,   -39,   -42,   -59,
+   -62,   -84,   -87,  -102,  -142,   -68,   -74,  -142,   -12,  -142,
+  -112,  -142,   -93,  -142,   -21,  -142,  -142,  -142,  -142,  -142,
+   -63,  -142,   -66,   -70,   -75,  -142,  -131,  -109,  -110,  -113,
+  -128,  -142,   -97,  -142,   -25,   -31,  -142,  -142,  -142,   -64,
+  -142,   -69,   -74,   -72,  -103,   -79,  -142,  -142,  -112,  -103,
+   -72,  -117,  -142,   -94,   -22,   -37,  -137,  -139,  -140,   -40,
+   -43,   -74,   -71,   -76,   -77,  -121,  -122,  -123,  -142,  -142,
+   -82,   -74,  -111,  -142,  -114,   -72,  -142,  -120,  -138,   -65,
+  -142,  -103,  -124,   -80,   -67,  -142,   -63,  -118,   -63,  -142,
+  -142,  -126,  -142,   -72,  -115,  -142,   -78,  -125,  -142,   -72,
+   -63,   -72,  -127,   -81,  -116,   -63,  -119 ]
 
 racc_goto_table = [
-    73,   129,    49,    71,   180,    91,   162,    89,   115,    67,
-   168,   204,   116,     1,   144,   220,     9,     3,   215,     7,
-   225,    42,    69,    88,    81,    81,    81,    81,   218,    50,
-    52,    53,   218,   218,   195,   199,   200,   238,   112,    73,
-   121,   122,   113,   107,   165,   108,   115,   143,   212,    91,
-   231,   123,    77,    82,    83,    84,    69,    39,    69,   120,
-    46,   219,    94,   133,   173,   101,   155,   102,    81,    81,
-   234,   224,   236,   115,   156,   103,   157,   104,    73,   158,
-   112,   142,   105,   139,   244,   159,    65,    70,   140,   246,
-   110,   118,   203,   202,   209,   232,    69,   141,   131,   214,
-   171,    99,   153,   126,    81,   167,    81,   216,   235,   112,
-   149,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   226,   nil,   nil,   nil,   nil,   nil,
-   183,   nil,   nil,    81,   nil,   190,   nil,   nil,   nil,   nil,
-   nil,   nil,   240,   nil,   nil,   nil,   nil,   nil,   243,   nil,
-   245,   nil,   nil,   210,   nil,   nil,   nil,   nil,   nil,   217,
+    73,   129,    49,   180,    71,    88,    90,   162,   168,   220,
+   144,    67,   204,     9,   225,   114,   218,   116,    42,   215,
+   218,   218,    69,     1,    78,    78,    78,    78,     3,   122,
+     7,   238,    77,    81,    82,    83,   123,    39,   111,    73,
+   165,   120,    46,   112,    93,   106,   212,   107,   121,    90,
+   114,   231,   143,    50,    52,    53,    69,   133,    69,   195,
+   199,   200,   219,   173,   100,   155,   101,   156,   113,   234,
+   113,   236,   224,   102,   157,   103,   158,    73,   104,   111,
+   159,   142,    65,   244,   139,    70,   140,   109,   246,   118,
+   202,   209,   232,   203,   141,    69,   131,   171,    98,   153,
+   214,   126,   167,   113,   216,   113,   235,   149,   nil,   111,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   226,   nil,   nil,   nil,   nil,
+   183,   nil,   nil,   nil,   nil,   190,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   240,   nil,   nil,   nil,   nil,   nil,   243,
+   nil,   245,   nil,   210,   nil,   nil,   nil,   nil,   nil,   217,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   183,
    nil,   nil,   nil,   nil,   nil,   222,   nil,   nil,   nil,   190,
    222,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   237,   222 ]
 
 racc_goto_check = [
-    44,    48,    36,    52,    41,    11,    40,    59,    58,    35,
-    63,    46,    57,     1,    39,    47,     7,     6,    46,     6,
-    47,     7,    36,     4,    36,    36,    36,    36,    67,    14,
-    14,    14,    67,    67,    22,    22,    22,    47,    44,    44,
-     5,     8,    52,    35,    39,    35,    58,    57,    63,    11,
-    46,    59,    33,    33,    33,    33,    36,     9,    36,    10,
-    12,    40,    13,    15,    16,    17,    18,    23,    36,    36,
-    41,    40,    41,    58,    24,    25,    26,    27,    44,    28,
-    44,    52,    29,    35,    41,    30,    31,    32,    37,    41,
-    38,    42,    48,    43,    49,    50,    36,    51,    53,    48,
-    54,    55,    56,    61,    36,    62,    36,    64,    65,    44,
-    66,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,    48,   nil,   nil,   nil,   nil,   nil,
-    44,   nil,   nil,    36,   nil,    44,   nil,   nil,   nil,   nil,
-   nil,   nil,    48,   nil,   nil,   nil,   nil,   nil,    48,   nil,
-    48,   nil,   nil,    44,   nil,   nil,   nil,   nil,   nil,    44,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    44,
-   nil,   nil,   nil,   nil,   nil,    44,   nil,   nil,   nil,    44,
-    44,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,    44,    44 ]
+    45,    49,    37,    42,    53,     8,    12,    41,    62,    48,
+    40,    36,    47,     7,    48,    58,    66,    58,     7,    47,
+    66,    66,    37,     1,    37,    37,    37,    37,     6,     5,
+     6,    48,    34,    34,    34,    34,     9,    10,    45,    45,
+    40,    11,    13,    53,    14,    36,    62,    36,     8,    12,
+    58,    47,    58,    15,    15,    15,    37,    16,    37,    23,
+    23,    23,    41,    17,    18,    19,    24,    25,    37,    42,
+    37,    42,    41,    26,    27,    28,    29,    45,    30,    45,
+    31,    53,    32,    42,    36,    33,    38,    39,    42,    43,
+    44,    50,    51,    49,    52,    37,    54,    55,    56,    57,
+    49,    60,    61,    37,    63,    37,    64,    65,   nil,    45,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,    49,   nil,   nil,   nil,   nil,
+    45,   nil,   nil,   nil,   nil,    45,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,    49,   nil,   nil,   nil,   nil,   nil,    49,
+   nil,    49,   nil,    45,   nil,   nil,   nil,   nil,   nil,    45,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    45,
+   nil,   nil,   nil,   nil,   nil,    45,   nil,   nil,   nil,    45,
+    45,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    45,    45 ]
 
 racc_goto_pointer = [
-   nil,    13,   nil,   nil,   -21,   -48,    17,    13,   -47,    53,
-   -28,   -39,    48,    16,    16,   -37,   -90,    10,   -68,   nil,
-   nil,   nil,  -142,    11,   -61,    18,   -60,    19,   -58,    23,
-   -53,    54,    54,    18,   nil,   -23,   -10,   -22,    21,  -103,
-  -140,  -156,     5,   -89,   -33,   nil,  -172,  -193,   -91,   -91,
-  -128,   -13,   -30,     0,   -52,    50,   -30,   -67,   -70,   -37,
-   nil,    13,   -45,  -140,   -84,  -119,   -14,  -167 ]
+   nil,    23,   nil,   nil,   nil,   -59,    28,    10,   -39,   -52,
+    33,   -45,   -38,    30,    -2,    40,   -42,   -91,     9,   -69,
+   nil,   nil,   nil,  -117,    10,   -68,    16,   -62,    17,   -61,
+    19,   -58,    50,    52,    -2,   nil,   -21,   -10,   -23,    18,
+  -107,  -139,  -157,     4,   -92,   -33,   nil,  -171,  -199,   -90,
+   -94,  -131,   -15,   -29,    -1,   -55,    47,   -33,   -63,   nil,
+    12,   -48,  -142,   -87,  -121,   -17,  -179 ]
 
 racc_goto_default = [
-   nil,   nil,     2,     8,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,    10,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    21,
-    22,    23,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,    66,   nil,    74,   nil,   nil,   nil,
-   nil,   nil,    92,   163,   197,   128,   nil,   nil,   nil,   nil,
-   nil,    75,   nil,   nil,   nil,   nil,   nil,    78,    80,   nil,
-    90,   nil,   nil,   nil,   nil,   nil,   nil,   196 ]
+   nil,   nil,     2,     8,    87,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    10,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+    21,    22,    23,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,    66,   nil,    74,   nil,   nil,
+   nil,   nil,   nil,    91,   163,   197,   128,   nil,   nil,   nil,
+   nil,   nil,    75,   nil,   nil,   nil,   nil,   nil,    79,    89,
+   nil,   nil,   nil,   nil,   nil,   nil,   196 ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -919,146 +917,145 @@ racc_reduce_table = [
   2, 61, :_reduce_2,
   0, 62, :_reduce_3,
   2, 62, :_reduce_4,
-  0, 63, :_reduce_none,
-  1, 63, :_reduce_none,
+  1, 63, :_reduce_5,
+  2, 63, :_reduce_6,
+  0, 64, :_reduce_none,
+  1, 64, :_reduce_none,
   5, 56, :_reduce_none,
-  0, 64, :_reduce_8,
-  0, 65, :_reduce_9,
-  5, 57, :_reduce_10,
+  0, 65, :_reduce_10,
+  0, 66, :_reduce_11,
+  5, 57, :_reduce_12,
   2, 57, :_reduce_none,
   1, 58, :_reduce_none,
-  2, 58, :_reduce_13,
+  2, 58, :_reduce_15,
   3, 58, :_reduce_none,
   2, 58, :_reduce_none,
-  2, 58, :_reduce_16,
-  2, 58, :_reduce_17,
-  0, 70, :_reduce_18,
-  0, 71, :_reduce_19,
-  7, 58, :_reduce_20,
+  2, 58, :_reduce_18,
+  2, 58, :_reduce_19,
+  0, 71, :_reduce_20,
   0, 72, :_reduce_21,
-  0, 73, :_reduce_22,
-  6, 58, :_reduce_23,
-  1, 58, :_reduce_24,
-  1, 58, :_reduce_25,
+  7, 58, :_reduce_22,
+  0, 73, :_reduce_23,
+  0, 74, :_reduce_24,
+  6, 58, :_reduce_25,
+  1, 58, :_reduce_26,
+  1, 58, :_reduce_27,
   2, 58, :_reduce_none,
-  0, 78, :_reduce_27,
-  0, 79, :_reduce_28,
-  6, 66, :_reduce_29,
-  1, 66, :_reduce_none,
-  1, 66, :_reduce_none,
-  1, 66, :_reduce_none,
-  0, 80, :_reduce_33,
-  0, 81, :_reduce_34,
-  7, 66, :_reduce_35,
+  0, 79, :_reduce_29,
+  0, 80, :_reduce_30,
+  6, 67, :_reduce_31,
+  1, 67, :_reduce_none,
+  1, 67, :_reduce_none,
+  1, 67, :_reduce_none,
+  0, 81, :_reduce_35,
   0, 82, :_reduce_36,
-  0, 83, :_reduce_37,
-  7, 66, :_reduce_38,
+  7, 67, :_reduce_37,
+  0, 83, :_reduce_38,
   0, 84, :_reduce_39,
-  0, 85, :_reduce_40,
-  7, 66, :_reduce_41,
-  2, 66, :_reduce_42,
-  2, 66, :_reduce_43,
-  2, 66, :_reduce_44,
-  2, 66, :_reduce_45,
-  2, 66, :_reduce_46,
-  2, 74, :_reduce_none,
-  2, 74, :_reduce_48,
-  2, 74, :_reduce_49,
-  2, 74, :_reduce_50,
-  2, 74, :_reduce_51,
-  2, 74, :_reduce_52,
-  1, 90, :_reduce_53,
-  2, 90, :_reduce_54,
-  1, 86, :_reduce_55,
-  2, 86, :_reduce_56,
-  3, 86, :_reduce_57,
-  0, 93, :_reduce_none,
-  1, 93, :_reduce_none,
-  3, 89, :_reduce_60,
-  0, 96, :_reduce_none,
-  1, 96, :_reduce_none,
-  8, 75, :_reduce_63,
-  5, 76, :_reduce_64,
+  7, 67, :_reduce_40,
+  0, 85, :_reduce_41,
+  0, 86, :_reduce_42,
+  7, 67, :_reduce_43,
+  2, 67, :_reduce_44,
+  2, 67, :_reduce_45,
+  2, 67, :_reduce_46,
+  2, 67, :_reduce_47,
+  2, 67, :_reduce_48,
+  2, 75, :_reduce_none,
+  2, 75, :_reduce_50,
+  2, 75, :_reduce_51,
+  2, 75, :_reduce_52,
+  2, 75, :_reduce_53,
+  2, 75, :_reduce_54,
+  1, 91, :_reduce_55,
+  2, 91, :_reduce_56,
+  1, 87, :_reduce_57,
+  2, 87, :_reduce_58,
+  3, 87, :_reduce_59,
+  0, 94, :_reduce_none,
+  1, 94, :_reduce_none,
+  3, 90, :_reduce_62,
+  0, 97, :_reduce_none,
+  1, 97, :_reduce_none,
   8, 76, :_reduce_65,
-  1, 94, :_reduce_66,
-  3, 94, :_reduce_67,
+  5, 77, :_reduce_66,
+  8, 77, :_reduce_67,
   1, 95, :_reduce_68,
   3, 95, :_reduce_69,
-  0, 103, :_reduce_none,
-  1, 103, :_reduce_none,
-  0, 98, :_reduce_72,
-  1, 98, :_reduce_73,
-  3, 98, :_reduce_74,
-  3, 98, :_reduce_75,
-  6, 98, :_reduce_76,
-  0, 104, :_reduce_77,
-  0, 105, :_reduce_78,
-  7, 98, :_reduce_79,
-  3, 98, :_reduce_80,
-  0, 92, :_reduce_none,
-  1, 92, :_reduce_82,
-  1, 87, :_reduce_83,
-  2, 87, :_reduce_84,
-  3, 87, :_reduce_85,
-  1, 107, :_reduce_86,
-  2, 107, :_reduce_87,
-  1, 99, :_reduce_none,
-  1, 99, :_reduce_none,
-  0, 108, :_reduce_90,
-  0, 109, :_reduce_91,
-  6, 69, :_reduce_92,
+  1, 96, :_reduce_70,
+  3, 96, :_reduce_71,
+  0, 104, :_reduce_none,
+  1, 104, :_reduce_none,
+  0, 99, :_reduce_74,
+  1, 99, :_reduce_75,
+  3, 99, :_reduce_76,
+  3, 99, :_reduce_77,
+  6, 99, :_reduce_78,
+  0, 105, :_reduce_79,
+  0, 106, :_reduce_80,
+  7, 99, :_reduce_81,
+  3, 99, :_reduce_82,
+  0, 93, :_reduce_none,
+  1, 93, :_reduce_84,
+  1, 88, :_reduce_85,
+  2, 88, :_reduce_86,
+  3, 88, :_reduce_87,
+  1, 108, :_reduce_88,
+  2, 108, :_reduce_89,
+  1, 100, :_reduce_none,
+  1, 100, :_reduce_none,
+  0, 109, :_reduce_92,
   0, 110, :_reduce_93,
-  0, 111, :_reduce_94,
-  5, 69, :_reduce_95,
-  1, 88, :_reduce_96,
-  2, 88, :_reduce_97,
-  3, 88, :_reduce_98,
-  1, 112, :_reduce_99,
-  2, 112, :_reduce_100,
-  1, 113, :_reduce_none,
-  1, 91, :_reduce_102,
-  1, 91, :_reduce_103,
-  1, 59, :_reduce_none,
+  6, 70, :_reduce_94,
+  0, 111, :_reduce_95,
+  0, 112, :_reduce_96,
+  5, 70, :_reduce_97,
+  1, 113, :_reduce_98,
+  2, 113, :_reduce_99,
+  1, 89, :_reduce_100,
+  2, 89, :_reduce_101,
+  3, 89, :_reduce_102,
+  1, 92, :_reduce_103,
+  1, 92, :_reduce_104,
+  0, 115, :_reduce_none,
+  1, 115, :_reduce_none,
   2, 59, :_reduce_none,
-  0, 116, :_reduce_none,
-  1, 116, :_reduce_none,
-  2, 114, :_reduce_none,
-  2, 114, :_reduce_none,
-  4, 115, :_reduce_110,
-  1, 117, :_reduce_111,
-  3, 117, :_reduce_112,
-  0, 118, :_reduce_113,
-  1, 118, :_reduce_114,
-  3, 118, :_reduce_115,
-  5, 118, :_reduce_116,
-  7, 118, :_reduce_117,
+  2, 59, :_reduce_none,
+  4, 114, :_reduce_109,
+  1, 116, :_reduce_110,
+  3, 116, :_reduce_111,
+  0, 117, :_reduce_112,
+  1, 117, :_reduce_113,
+  3, 117, :_reduce_114,
+  5, 117, :_reduce_115,
+  7, 117, :_reduce_116,
+  0, 118, :_reduce_117,
   0, 119, :_reduce_118,
-  0, 120, :_reduce_119,
-  8, 118, :_reduce_120,
-  3, 118, :_reduce_121,
-  1, 101, :_reduce_122,
-  1, 101, :_reduce_123,
-  1, 101, :_reduce_124,
-  1, 102, :_reduce_125,
-  3, 102, :_reduce_126,
-  2, 102, :_reduce_127,
-  4, 102, :_reduce_128,
-  3, 100, :_reduce_129,
-  1, 97, :_reduce_none,
-  0, 121, :_reduce_131,
-  3, 60, :_reduce_132,
-  1, 67, :_reduce_none,
-  0, 68, :_reduce_none,
+  8, 117, :_reduce_119,
+  3, 117, :_reduce_120,
+  1, 102, :_reduce_121,
+  1, 102, :_reduce_122,
+  1, 102, :_reduce_123,
+  1, 103, :_reduce_124,
+  3, 103, :_reduce_125,
+  2, 103, :_reduce_126,
+  4, 103, :_reduce_127,
+  3, 101, :_reduce_128,
+  1, 98, :_reduce_none,
+  0, 120, :_reduce_130,
+  3, 60, :_reduce_131,
   1, 68, :_reduce_none,
-  1, 68, :_reduce_none,
-  1, 68, :_reduce_none,
-  1, 77, :_reduce_138,
-  2, 77, :_reduce_139,
-  1, 122, :_reduce_none,
-  1, 122, :_reduce_none,
-  1, 106, :_reduce_142 ]
+  0, 69, :_reduce_none,
+  1, 69, :_reduce_none,
+  1, 69, :_reduce_none,
+  1, 69, :_reduce_none,
+  1, 78, :_reduce_137,
+  2, 78, :_reduce_138,
+  1, 121, :_reduce_none,
+  1, 121, :_reduce_none,
+  1, 107, :_reduce_141 ]
 
-racc_reduce_n = 143
+racc_reduce_n = 142
 
 racc_shift_n = 247
 
@@ -1200,10 +1197,11 @@ Racc_token_to_s_table = [
   "input",
   "prologue_declaration",
   "bison_declaration",
-  "grammar",
+  "rules_or_grammar_declaration",
   "epilogue",
   "\"-many@prologue_declaration\"",
   "\"-many@bison_declaration\"",
+  "\"-many1@rules_or_grammar_declaration\"",
   "\"-option@epilogue\"",
   "@1",
   "@2",
@@ -1253,9 +1251,7 @@ Racc_token_to_s_table = [
   "@18",
   "@19",
   "@20",
-  "token_declaration_list_for_precedence",
-  "token_declaration_for_precedence",
-  "rules_or_grammar_declaration",
+  "\"-many1@id\"",
   "rules",
   "\"-option@;\"",
   "rhs_list",
@@ -1300,14 +1296,28 @@ module_eval(<<'.,.,', 'parser.y', 11)
   end
 .,.,
 
-# reduce 5 omitted
+module_eval(<<'.,.,', 'parser.y', 11)
+  def _reduce_5(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
-# reduce 6 omitted
+module_eval(<<'.,.,', 'parser.y', 11)
+  def _reduce_6(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
 # reduce 7 omitted
 
+# reduce 8 omitted
+
+# reduce 9 omitted
+
 module_eval(<<'.,.,', 'parser.y', 12)
-  def _reduce_8(val, _values, result)
+  def _reduce_10(val, _values, result)
                                 begin_c_declaration("%}")
                             @grammar.prologue_first_lineno = @lexer.line
 
@@ -1316,7 +1326,7 @@ module_eval(<<'.,.,', 'parser.y', 12)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 17)
-  def _reduce_9(val, _values, result)
+  def _reduce_11(val, _values, result)
                                 end_c_declaration
 
     result
@@ -1324,30 +1334,30 @@ module_eval(<<'.,.,', 'parser.y', 17)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 21)
-  def _reduce_10(val, _values, result)
+  def _reduce_12(val, _values, result)
                                 @grammar.prologue = val[2].s_value
 
     result
   end
 .,.,
 
-# reduce 11 omitted
+# reduce 13 omitted
 
-# reduce 12 omitted
+# reduce 14 omitted
 
 module_eval(<<'.,.,', 'parser.y', 27)
-  def _reduce_13(val, _values, result)
+  def _reduce_15(val, _values, result)
      @grammar.expect = val[1]
     result
   end
 .,.,
 
-# reduce 14 omitted
+# reduce 16 omitted
 
-# reduce 15 omitted
+# reduce 17 omitted
 
 module_eval(<<'.,.,', 'parser.y', 32)
-  def _reduce_16(val, _values, result)
+  def _reduce_18(val, _values, result)
                              val[1].each {|token|
                            @grammar.lex_param = Grammar::Code::NoReferenceCode.new(type: :lex_param, token_code: token).token_code.s_value
                          }
@@ -1357,7 +1367,7 @@ module_eval(<<'.,.,', 'parser.y', 32)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 38)
-  def _reduce_17(val, _values, result)
+  def _reduce_19(val, _values, result)
                              val[1].each {|token|
                            @grammar.parse_param = Grammar::Code::NoReferenceCode.new(type: :parse_param, token_code: token).token_code.s_value
                          }
@@ -1367,7 +1377,7 @@ module_eval(<<'.,.,', 'parser.y', 38)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 44)
-  def _reduce_18(val, _values, result)
+  def _reduce_20(val, _values, result)
                              begin_c_declaration("}")
 
     result
@@ -1375,7 +1385,7 @@ module_eval(<<'.,.,', 'parser.y', 44)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 48)
-  def _reduce_19(val, _values, result)
+  def _reduce_21(val, _values, result)
                              end_c_declaration
 
     result
@@ -1383,7 +1393,7 @@ module_eval(<<'.,.,', 'parser.y', 48)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 52)
-  def _reduce_20(val, _values, result)
+  def _reduce_22(val, _values, result)
                              @grammar.add_percent_code(id: val[1], code: val[4])
 
     result
@@ -1391,7 +1401,7 @@ module_eval(<<'.,.,', 'parser.y', 52)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 56)
-  def _reduce_21(val, _values, result)
+  def _reduce_23(val, _values, result)
                              begin_c_declaration("}")
 
     result
@@ -1399,7 +1409,7 @@ module_eval(<<'.,.,', 'parser.y', 56)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 60)
-  def _reduce_22(val, _values, result)
+  def _reduce_24(val, _values, result)
                              end_c_declaration
 
     result
@@ -1407,7 +1417,7 @@ module_eval(<<'.,.,', 'parser.y', 60)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 64)
-  def _reduce_23(val, _values, result)
+  def _reduce_25(val, _values, result)
                              @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[3])
 
     result
@@ -1415,23 +1425,23 @@ module_eval(<<'.,.,', 'parser.y', 64)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 66)
-  def _reduce_24(val, _values, result)
+  def _reduce_26(val, _values, result)
      @grammar.no_stdlib = true
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 67)
-  def _reduce_25(val, _values, result)
+  def _reduce_27(val, _values, result)
      @grammar.locations = true
     result
   end
 .,.,
 
-# reduce 26 omitted
+# reduce 28 omitted
 
 module_eval(<<'.,.,', 'parser.y', 72)
-  def _reduce_27(val, _values, result)
+  def _reduce_29(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1439,7 +1449,7 @@ module_eval(<<'.,.,', 'parser.y', 72)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 76)
-  def _reduce_28(val, _values, result)
+  def _reduce_30(val, _values, result)
                                end_c_declaration
 
     result
@@ -1447,7 +1457,7 @@ module_eval(<<'.,.,', 'parser.y', 76)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 80)
-  def _reduce_29(val, _values, result)
+  def _reduce_31(val, _values, result)
                                @grammar.set_union(
                              Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[3]),
                              val[3].line
@@ -1457,14 +1467,14 @@ module_eval(<<'.,.,', 'parser.y', 80)
   end
 .,.,
 
-# reduce 30 omitted
-
-# reduce 31 omitted
-
 # reduce 32 omitted
 
+# reduce 33 omitted
+
+# reduce 34 omitted
+
 module_eval(<<'.,.,', 'parser.y', 90)
-  def _reduce_33(val, _values, result)
+  def _reduce_35(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1472,7 +1482,7 @@ module_eval(<<'.,.,', 'parser.y', 90)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 94)
-  def _reduce_34(val, _values, result)
+  def _reduce_36(val, _values, result)
                                end_c_declaration
 
     result
@@ -1480,7 +1490,7 @@ module_eval(<<'.,.,', 'parser.y', 94)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 98)
-  def _reduce_35(val, _values, result)
+  def _reduce_37(val, _values, result)
                                @grammar.add_destructor(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1492,7 +1502,7 @@ module_eval(<<'.,.,', 'parser.y', 98)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 106)
-  def _reduce_36(val, _values, result)
+  def _reduce_38(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1500,7 +1510,7 @@ module_eval(<<'.,.,', 'parser.y', 106)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 110)
-  def _reduce_37(val, _values, result)
+  def _reduce_39(val, _values, result)
                                end_c_declaration
 
     result
@@ -1508,7 +1518,7 @@ module_eval(<<'.,.,', 'parser.y', 110)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 114)
-  def _reduce_38(val, _values, result)
+  def _reduce_40(val, _values, result)
                                @grammar.add_printer(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1520,7 +1530,7 @@ module_eval(<<'.,.,', 'parser.y', 114)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 122)
-  def _reduce_39(val, _values, result)
+  def _reduce_41(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1528,7 +1538,7 @@ module_eval(<<'.,.,', 'parser.y', 122)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 126)
-  def _reduce_40(val, _values, result)
+  def _reduce_42(val, _values, result)
                                end_c_declaration
 
     result
@@ -1536,7 +1546,7 @@ module_eval(<<'.,.,', 'parser.y', 126)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 130)
-  def _reduce_41(val, _values, result)
+  def _reduce_43(val, _values, result)
                                @grammar.add_error_token(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1548,7 +1558,7 @@ module_eval(<<'.,.,', 'parser.y', 130)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 138)
-  def _reduce_42(val, _values, result)
+  def _reduce_44(val, _values, result)
                                @grammar.after_shift = val[1]
 
     result
@@ -1556,7 +1566,7 @@ module_eval(<<'.,.,', 'parser.y', 138)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 142)
-  def _reduce_43(val, _values, result)
+  def _reduce_45(val, _values, result)
                                @grammar.before_reduce = val[1]
 
     result
@@ -1564,7 +1574,7 @@ module_eval(<<'.,.,', 'parser.y', 142)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 146)
-  def _reduce_44(val, _values, result)
+  def _reduce_46(val, _values, result)
                                @grammar.after_reduce = val[1]
 
     result
@@ -1572,7 +1582,7 @@ module_eval(<<'.,.,', 'parser.y', 146)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 150)
-  def _reduce_45(val, _values, result)
+  def _reduce_47(val, _values, result)
                                @grammar.after_shift_error_token = val[1]
 
     result
@@ -1580,17 +1590,17 @@ module_eval(<<'.,.,', 'parser.y', 150)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 154)
-  def _reduce_46(val, _values, result)
+  def _reduce_48(val, _values, result)
                                @grammar.after_pop_stack = val[1]
 
     result
   end
 .,.,
 
-# reduce 47 omitted
+# reduce 49 omitted
 
 module_eval(<<'.,.,', 'parser.y', 160)
-  def _reduce_48(val, _values, result)
+  def _reduce_50(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               @grammar.add_type(id: id, tag: hash[:tag])
@@ -1602,7 +1612,7 @@ module_eval(<<'.,.,', 'parser.y', 160)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 168)
-  def _reduce_49(val, _values, result)
+  def _reduce_51(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1616,7 +1626,7 @@ module_eval(<<'.,.,', 'parser.y', 168)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 178)
-  def _reduce_50(val, _values, result)
+  def _reduce_52(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1630,7 +1640,7 @@ module_eval(<<'.,.,', 'parser.y', 178)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 188)
-  def _reduce_51(val, _values, result)
+  def _reduce_53(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1644,7 +1654,7 @@ module_eval(<<'.,.,', 'parser.y', 188)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 198)
-  def _reduce_52(val, _values, result)
+  def _reduce_54(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1658,21 +1668,21 @@ module_eval(<<'.,.,', 'parser.y', 198)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 227)
-  def _reduce_53(val, _values, result)
+  def _reduce_55(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 227)
-  def _reduce_54(val, _values, result)
+  def _reduce_56(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 209)
-  def _reduce_55(val, _values, result)
+  def _reduce_57(val, _values, result)
                               val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
                           }
@@ -1682,7 +1692,7 @@ module_eval(<<'.,.,', 'parser.y', 209)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 215)
-  def _reduce_56(val, _values, result)
+  def _reduce_58(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
@@ -1692,7 +1702,7 @@ module_eval(<<'.,.,', 'parser.y', 215)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 221)
-  def _reduce_57(val, _values, result)
+  def _reduce_59(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
@@ -1701,23 +1711,23 @@ module_eval(<<'.,.,', 'parser.y', 221)
   end
 .,.,
 
-# reduce 58 omitted
+# reduce 60 omitted
 
-# reduce 59 omitted
+# reduce 61 omitted
 
 module_eval(<<'.,.,', 'parser.y', 226)
-  def _reduce_60(val, _values, result)
+  def _reduce_62(val, _values, result)
      result = val
     result
   end
 .,.,
 
-# reduce 61 omitted
+# reduce 63 omitted
 
-# reduce 62 omitted
+# reduce 64 omitted
 
 module_eval(<<'.,.,', 'parser.y', 230)
-  def _reduce_63(val, _values, result)
+  def _reduce_65(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1726,7 +1736,7 @@ module_eval(<<'.,.,', 'parser.y', 230)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 236)
-  def _reduce_64(val, _values, result)
+  def _reduce_66(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1735,7 +1745,7 @@ module_eval(<<'.,.,', 'parser.y', 236)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 241)
-  def _reduce_65(val, _values, result)
+  def _reduce_67(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1744,21 +1754,21 @@ module_eval(<<'.,.,', 'parser.y', 241)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 245)
-  def _reduce_66(val, _values, result)
+  def _reduce_68(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 246)
-  def _reduce_67(val, _values, result)
+  def _reduce_69(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 250)
-  def _reduce_68(val, _values, result)
+  def _reduce_70(val, _values, result)
                       builder = val[0]
                   result = [builder]
 
@@ -1767,7 +1777,7 @@ module_eval(<<'.,.,', 'parser.y', 250)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 255)
-  def _reduce_69(val, _values, result)
+  def _reduce_71(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
 
@@ -1775,12 +1785,12 @@ module_eval(<<'.,.,', 'parser.y', 255)
   end
 .,.,
 
-# reduce 70 omitted
+# reduce 72 omitted
 
-# reduce 71 omitted
+# reduce 73 omitted
 
 module_eval(<<'.,.,', 'parser.y', 261)
-  def _reduce_72(val, _values, result)
+  def _reduce_74(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1789,7 +1799,7 @@ module_eval(<<'.,.,', 'parser.y', 261)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 266)
-  def _reduce_73(val, _values, result)
+  def _reduce_75(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1798,7 +1808,7 @@ module_eval(<<'.,.,', 'parser.y', 266)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 271)
-  def _reduce_74(val, _values, result)
+  def _reduce_76(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1810,7 +1820,7 @@ module_eval(<<'.,.,', 'parser.y', 271)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 279)
-  def _reduce_75(val, _values, result)
+  def _reduce_77(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1820,7 +1830,7 @@ module_eval(<<'.,.,', 'parser.y', 279)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 285)
-  def _reduce_76(val, _values, result)
+  def _reduce_78(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1830,7 +1840,7 @@ module_eval(<<'.,.,', 'parser.y', 285)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 291)
-  def _reduce_77(val, _values, result)
+  def _reduce_79(val, _values, result)
                   if @prec_seen
                 on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                 @code_after_prec = true
@@ -1842,7 +1852,7 @@ module_eval(<<'.,.,', 'parser.y', 291)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 299)
-  def _reduce_78(val, _values, result)
+  def _reduce_80(val, _values, result)
                   end_c_declaration
 
     result
@@ -1850,7 +1860,7 @@ module_eval(<<'.,.,', 'parser.y', 299)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 303)
-  def _reduce_79(val, _values, result)
+  def _reduce_81(val, _values, result)
                   user_code = val[3]
               user_code.alias_name = val[6]
               builder = val[0]
@@ -1862,7 +1872,7 @@ module_eval(<<'.,.,', 'parser.y', 303)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 311)
-  def _reduce_80(val, _values, result)
+  def _reduce_82(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1873,17 +1883,17 @@ module_eval(<<'.,.,', 'parser.y', 311)
   end
 .,.,
 
-# reduce 81 omitted
+# reduce 83 omitted
 
 module_eval(<<'.,.,', 'parser.y', 319)
-  def _reduce_82(val, _values, result)
+  def _reduce_84(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 323)
-  def _reduce_83(val, _values, result)
+  def _reduce_85(val, _values, result)
                                result = [{tag: nil, tokens: val[0]}]
 
     result
@@ -1891,7 +1901,7 @@ module_eval(<<'.,.,', 'parser.y', 323)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 327)
-  def _reduce_84(val, _values, result)
+  def _reduce_86(val, _values, result)
                                result = [{tag: val[0], tokens: val[1]}]
 
     result
@@ -1899,7 +1909,7 @@ module_eval(<<'.,.,', 'parser.y', 327)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 331)
-  def _reduce_85(val, _values, result)
+  def _reduce_87(val, _values, result)
                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
@@ -1907,25 +1917,25 @@ module_eval(<<'.,.,', 'parser.y', 331)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 334)
-  def _reduce_86(val, _values, result)
+  def _reduce_88(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 335)
-  def _reduce_87(val, _values, result)
+  def _reduce_89(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 88 omitted
+# reduce 90 omitted
 
-# reduce 89 omitted
+# reduce 91 omitted
 
 module_eval(<<'.,.,', 'parser.y', 342)
-  def _reduce_90(val, _values, result)
+  def _reduce_92(val, _values, result)
                   begin_c_declaration("}")
 
     result
@@ -1933,7 +1943,7 @@ module_eval(<<'.,.,', 'parser.y', 342)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 346)
-  def _reduce_91(val, _values, result)
+  def _reduce_93(val, _values, result)
                   end_c_declaration
 
     result
@@ -1941,7 +1951,7 @@ module_eval(<<'.,.,', 'parser.y', 346)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 350)
-  def _reduce_92(val, _values, result)
+  def _reduce_94(val, _values, result)
                   result = val[0].append(val[3])
 
     result
@@ -1949,7 +1959,7 @@ module_eval(<<'.,.,', 'parser.y', 350)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 354)
-  def _reduce_93(val, _values, result)
+  def _reduce_95(val, _values, result)
                   begin_c_declaration("}")
 
     result
@@ -1957,7 +1967,7 @@ module_eval(<<'.,.,', 'parser.y', 354)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 358)
-  def _reduce_94(val, _values, result)
+  def _reduce_96(val, _values, result)
                   end_c_declaration
 
     result
@@ -1965,68 +1975,61 @@ module_eval(<<'.,.,', 'parser.y', 358)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 362)
-  def _reduce_95(val, _values, result)
+  def _reduce_97(val, _values, result)
                   result = [val[2]]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 367)
-  def _reduce_96(val, _values, result)
-                                             result = [{tag: nil, tokens: val[0]}]
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 371)
-  def _reduce_97(val, _values, result)
-                                             result = [{tag: val[0], tokens: val[1]}]
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 375)
+module_eval(<<'.,.,', 'parser.y', 370)
   def _reduce_98(val, _values, result)
-                                             result = val[0].append({tag: val[1], tokens: val[2]})
-
+    result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 378)
+module_eval(<<'.,.,', 'parser.y', 370)
   def _reduce_99(val, _values, result)
-     result = [val[0]]
+    result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 379)
+module_eval(<<'.,.,', 'parser.y', 365)
   def _reduce_100(val, _values, result)
-     result = val[0].append(val[1])
+     result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-# reduce 101 omitted
+module_eval(<<'.,.,', 'parser.y', 366)
+  def _reduce_101(val, _values, result)
+     result = [{tag: val[0], tokens: val[1]}]
+    result
+  end
+.,.,
 
-module_eval(<<'.,.,', 'parser.y', 383)
+module_eval(<<'.,.,', 'parser.y', 367)
   def _reduce_102(val, _values, result)
+     result = val[0].append({tag: val[1], tokens: val[2]})
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 369)
+  def _reduce_103(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 384)
-  def _reduce_103(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 370)
+  def _reduce_104(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
-
-# reduce 104 omitted
 
 # reduce 105 omitted
 
@@ -2036,10 +2039,8 @@ module_eval(<<'.,.,', 'parser.y', 384)
 
 # reduce 108 omitted
 
-# reduce 109 omitted
-
-module_eval(<<'.,.,', 'parser.y', 394)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 378)
+  def _reduce_109(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -2052,8 +2053,8 @@ module_eval(<<'.,.,', 'parser.y', 394)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 405)
-  def _reduce_111(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 389)
+  def _reduce_110(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2064,8 +2065,8 @@ module_eval(<<'.,.,', 'parser.y', 405)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 413)
-  def _reduce_112(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 397)
+  def _reduce_111(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2076,7 +2077,16 @@ module_eval(<<'.,.,', 'parser.y', 413)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 422)
+module_eval(<<'.,.,', 'parser.y', 406)
+  def _reduce_112(val, _values, result)
+               reset_precs
+           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 411)
   def _reduce_113(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -2085,17 +2095,8 @@ module_eval(<<'.,.,', 'parser.y', 422)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 427)
+module_eval(<<'.,.,', 'parser.y', 416)
   def _reduce_114(val, _values, result)
-               reset_precs
-           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 432)
-  def _reduce_115(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -2106,8 +2107,8 @@ module_eval(<<'.,.,', 'parser.y', 432)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 440)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 424)
+  def _reduce_115(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -2118,8 +2119,8 @@ module_eval(<<'.,.,', 'parser.y', 440)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 448)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 432)
+  def _reduce_116(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -2130,8 +2131,8 @@ module_eval(<<'.,.,', 'parser.y', 448)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 456)
-  def _reduce_118(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 440)
+  def _reduce_117(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
              @code_after_prec = true
@@ -2142,16 +2143,16 @@ module_eval(<<'.,.,', 'parser.y', 456)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 464)
-  def _reduce_119(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 448)
+  def _reduce_118(val, _values, result)
                end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 468)
-  def _reduce_120(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 452)
+  def _reduce_119(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
            user_code.tag = val[7]
@@ -2163,8 +2164,8 @@ module_eval(<<'.,.,', 'parser.y', 468)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 477)
-  def _reduce_121(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 461)
+  def _reduce_120(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2175,66 +2176,66 @@ module_eval(<<'.,.,', 'parser.y', 477)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 484)
-  def _reduce_122(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 468)
+  def _reduce_121(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 485)
-  def _reduce_123(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 469)
+  def _reduce_122(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 486)
-  def _reduce_124(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 470)
+  def _reduce_123(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 488)
-  def _reduce_125(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 472)
+  def _reduce_124(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 489)
-  def _reduce_126(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 473)
+  def _reduce_125(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 490)
-  def _reduce_127(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 474)
+  def _reduce_126(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 491)
-  def _reduce_128(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 475)
+  def _reduce_127(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 493)
-  def _reduce_129(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 477)
+  def _reduce_128(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-# reduce 130 omitted
+# reduce 129 omitted
 
-module_eval(<<'.,.,', 'parser.y', 499)
-  def _reduce_131(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 483)
+  def _reduce_130(val, _values, result)
                     begin_c_declaration('\Z')
                 @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2242,14 +2243,16 @@ module_eval(<<'.,.,', 'parser.y', 499)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 504)
-  def _reduce_132(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 488)
+  def _reduce_131(val, _values, result)
                     end_c_declaration
                 @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
+
+# reduce 132 omitted
 
 # reduce 133 omitted
 
@@ -2259,28 +2262,26 @@ module_eval(<<'.,.,', 'parser.y', 504)
 
 # reduce 136 omitted
 
-# reduce 137 omitted
-
-module_eval(<<'.,.,', 'parser.y', 515)
-  def _reduce_138(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 499)
+  def _reduce_137(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 516)
-  def _reduce_139(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 500)
+  def _reduce_138(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
+# reduce 139 omitted
+
 # reduce 140 omitted
 
-# reduce 141 omitted
-
-module_eval(<<'.,.,', 'parser.y', 521)
-  def _reduce_142(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 505)
+  def _reduce_141(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 510)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 482)
 
 include Lrama::Report::Duration
 
@@ -728,188 +728,174 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    94,    48,    95,   184,    84,    76,    48,    48,   189,   184,
-    76,    76,    48,    48,   189,    47,    76,   185,    68,    48,
-     6,    47,   191,   185,    80,    48,    40,    47,   191,    76,
-    72,    48,   160,    47,    41,   161,    80,    92,    44,    48,
-    48,    47,    47,    85,    80,    80,   186,   187,    45,    96,
-   161,   192,   186,    92,     4,    51,     5,   192,    20,    24,
+    95,    48,    96,   182,    85,    77,    48,    48,   187,   182,
+    77,    77,    48,    48,   187,    47,    77,   183,    69,    48,
+     6,    47,   189,   183,    81,    48,    40,    47,   189,    77,
+    74,    48,   159,    47,    41,   160,    81,    93,    44,    48,
+    48,    47,    47,    86,    81,    81,   184,   185,    45,    97,
+   160,   190,   184,    93,     4,    52,     5,   190,    20,    24,
     25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
     35,    36,    37,    38,    20,    24,    25,    26,    27,    28,
     29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-    11,    12,    13,    14,    15,    16,    92,   119,    17,    18,
-    19,    51,    20,    24,    25,    26,    27,    28,    29,    30,
+    11,    12,    13,    14,    15,    16,    93,   120,    17,    18,
+    19,    52,    20,    24,    25,    26,    27,    28,    29,    30,
     31,    32,    33,    34,    35,    36,    37,    38,    11,    12,
-    13,    14,    15,    16,    51,    54,    17,    18,    19,    43,
+    13,    14,    15,    16,    52,    55,    17,    18,    19,    43,
     20,    24,    25,    26,    27,    28,    29,    30,    31,    32,
     33,    34,    35,    36,    37,    38,    48,     4,    47,     5,
-    48,   115,    47,    55,    76,   198,    48,    48,    47,    47,
-    76,   198,    48,    48,    47,    47,    76,   198,    48,    48,
-    47,    47,    76,   198,    48,    48,    47,    47,    76,   198,
-    48,    48,    47,    47,    76,   198,    48,    48,    47,    47,
-    76,    76,    48,    48,    47,    47,    76,    76,    48,    48,
-    47,    47,    76,    76,    48,    48,    47,   221,    76,    76,
-    48,    48,   221,    47,    76,    76,    48,    48,   221,    47,
-    76,   205,   206,   207,   130,   205,   206,   207,   130,   228,
-   233,   242,   229,   229,   229,    48,    56,    47,   205,   206,
-   207,    57,    58,    59,    60,    61,    62,    63,    64,    86,
-    97,    97,    97,    99,   105,   108,   110,   117,   124,   125,
-   127,   130,   132,   134,   135,   136,   137,   138,    76,   145,
-   146,   147,   148,   150,   151,   152,   154,   164,   145,   166,
-   169,   170,   172,   174,   175,   176,   177,   178,   179,   181,
-   182,   188,   193,   194,   201,   164,   208,   211,   169,   213,
-   164,   223,   164,   130,   227,   182,   230,   182,   179,   179,
-   239,   130,   241,   130,   179,   130,   179 ]
+    48,   116,    47,    56,    77,   195,    48,    48,    47,    47,
+    77,   195,    48,    48,    47,    47,    77,   195,    48,    48,
+    47,    47,    77,   195,    48,    48,    47,    47,    77,    77,
+    48,    48,    47,    47,    77,    77,    48,    48,    47,   218,
+    77,    77,    48,    48,   218,    47,    77,    77,    48,    48,
+   218,    47,    77,   202,   203,   204,   131,   202,   203,   204,
+   131,   225,   230,   239,   226,   226,   226,    48,    48,    47,
+    47,    48,    57,    47,   202,   203,   204,    58,    59,    60,
+    61,    62,    63,    64,    65,    87,    52,   100,   106,   109,
+   111,   118,   125,   126,   128,   131,   132,   134,   135,   136,
+   137,   138,    77,   145,   146,   147,   148,   150,   151,   153,
+   163,   145,   165,   168,   169,   170,   172,   173,   174,   175,
+   176,   177,   179,   180,   186,   191,   198,   163,   205,   208,
+   168,   210,   163,   220,   163,   131,   224,   180,   227,   180,
+   177,   177,   236,   131,   238,   131,   177,   131,   177 ]
 
 racc_action_check = [
-    46,   163,    46,   163,    38,   163,   168,   202,   168,   202,
-   168,   202,   212,    32,   212,    32,   212,   163,    32,    34,
-     1,    34,   168,   202,    34,    33,     5,    33,   212,    33,
+    46,   162,    46,   162,    38,   162,   167,   199,   167,   199,
+   167,   199,   209,    32,   209,    32,   209,   162,    32,    34,
+     1,    34,   167,   199,    34,    33,     5,    33,   209,    33,
     33,    35,   144,    35,     6,   144,    35,    44,     9,    36,
-    37,    36,    37,    38,    36,    37,   163,   165,    11,    46,
-   165,   168,   202,    87,     0,    13,     0,   212,    44,    44,
+    37,    36,    37,    38,    36,    37,   162,   164,    11,    46,
+   164,   167,   199,    88,     0,    13,     0,   209,    44,    44,
     44,    44,    44,    44,    44,    44,    44,    44,    44,    44,
-    44,    44,    44,    44,    87,    87,    87,    87,    87,    87,
-    87,    87,    87,    87,    87,    87,    87,    87,    87,    87,
-     3,     3,     3,     3,     3,     3,    85,    85,     3,     3,
+    44,    44,    44,    44,    88,    88,    88,    88,    88,    88,
+    88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
+     3,     3,     3,     3,     3,     3,    86,    86,     3,     3,
      3,    14,     3,     3,     3,     3,     3,     3,     3,     3,
      3,     3,     3,     3,     3,     3,     3,     3,     8,     8,
      8,     8,     8,     8,    15,    16,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
-     8,     8,     8,     8,     8,     8,    78,     2,    78,     2,
-   176,    78,   176,    17,   176,   176,   177,    12,   177,    12,
-   177,   177,   178,    66,   178,    66,   178,   178,   195,    68,
-   195,    68,   195,   195,   199,    80,   199,    80,   199,   199,
-   200,   105,   200,   105,   200,   200,    71,    72,    71,    72,
-    71,    72,   110,   112,   110,   112,   110,   112,   142,   186,
-   142,   186,   142,   186,   192,   208,   192,   208,   192,   208,
-   213,   229,   213,   229,   213,   229,   230,   113,   230,   113,
-   230,   183,   183,   183,   183,   190,   190,   190,   190,   220,
-   225,   238,   220,   225,   238,   115,    20,   115,   222,   222,
-   222,    24,    25,    26,    27,    28,    29,    30,    31,    39,
-    50,    52,    53,    54,    65,    69,    70,    84,    88,    89,
-    90,    91,    98,   100,   101,   102,   103,   104,   109,   117,
-   118,   119,   120,   129,   130,   131,   133,   146,   147,   149,
-   150,   151,   153,   155,   156,   157,   158,   159,   160,   161,
-   162,   167,   171,   173,   180,   182,   184,   187,   188,   189,
-   201,   209,   211,   215,   216,   219,   221,   224,   226,   228,
-   232,   233,   235,   239,   240,   241,   245 ]
+     8,     8,     8,     8,     8,     8,    79,     2,    79,     2,
+   174,    79,   174,    17,   174,   174,   175,    12,   175,    12,
+   175,   175,   176,    67,   176,    67,   176,   176,   192,    69,
+   192,    69,   192,   192,    72,    74,    72,    74,    72,    74,
+   111,   184,   111,   184,   111,   184,   190,   205,   190,   205,
+   190,   205,   210,   226,   210,   226,   210,   226,   227,    81,
+   227,    81,   227,   181,   181,   181,   181,   188,   188,   188,
+   188,   217,   222,   235,   217,   222,   235,   106,   114,   106,
+   114,   116,    20,   116,   219,   219,   219,    24,    25,    26,
+    27,    28,    29,    30,    31,    39,    50,    55,    66,    70,
+    71,    85,    89,    90,    91,    92,    99,   101,   102,   103,
+   104,   105,   110,   118,   119,   120,   121,   130,   131,   133,
+   146,   147,   149,   150,   151,   152,   154,   155,   156,   157,
+   158,   159,   160,   161,   166,   171,   178,   180,   182,   185,
+   186,   187,   198,   206,   208,   212,   213,   216,   218,   221,
+   223,   225,   229,   230,   232,   236,   237,   238,   242 ]
 
 racc_action_pointer = [
     44,    20,   137,    77,   nil,    19,    34,   nil,   105,    29,
    nil,    42,   154,    36,    82,   105,   120,   134,   nil,   nil,
-   217,   nil,   nil,   nil,   222,   223,   224,   239,   240,   241,
-   242,   243,    10,    22,    16,    28,    36,    37,    -1,   247,
+   203,   nil,   nil,   nil,   208,   209,   210,   225,   226,   227,
+   228,   229,    10,    22,    16,    28,    36,    37,    -1,   233,
    nil,   nil,   nil,   nil,    33,   nil,    -5,   nil,   nil,   nil,
-   231,   nil,   232,   233,   234,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   246,   160,   nil,   166,   249,
-   248,   183,   184,   nil,   nil,   nil,   nil,   nil,   143,   nil,
-   172,   nil,   nil,   nil,   216,    92,   nil,    49,   249,   235,
-   236,   209,   nil,   nil,   nil,   nil,   nil,   nil,   260,   nil,
-   261,   262,   263,   264,   265,   178,   nil,   nil,   nil,   261,
-   189,   nil,   190,   214,   nil,   232,   nil,   264,   227,   230,
-   261,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   230,
-   269,   273,   nil,   274,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   195,   nil,   -10,   nil,   230,   273,   nil,   277,
-   233,   228,   nil,   262,   nil,   263,   264,   265,   266,   267,
-   280,   284,   244,    -2,   nil,     5,   nil,   245,     3,   nil,
-   nil,   272,   nil,   273,   nil,   nil,   147,   153,   159,   nil,
-   251,   nil,   248,   172,   255,   nil,   196,   254,   251,   258,
-   176,   nil,   201,   nil,   nil,   165,   nil,   nil,   nil,   171,
-   177,   253,     4,   nil,   nil,   nil,   nil,   nil,   202,   299,
-   nil,   255,     9,   207,   nil,   251,   302,   nil,   nil,   259,
-   187,   265,   189,   nil,   261,   188,   300,   nil,   301,   208,
-   213,   nil,   290,   259,   nil,   292,   nil,   nil,   189,   261,
-   306,   263,   nil,   nil,   nil,   308,   nil ]
+   217,   nil,   nil,   nil,   nil,   218,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   230,   160,   nil,   166,
+   233,   232,   171,   nil,   172,   nil,   nil,   nil,   nil,   143,
+   nil,   196,   nil,   nil,   nil,   200,    92,   nil,    49,   233,
+   219,   220,   193,   nil,   nil,   nil,   nil,   nil,   nil,   244,
+   nil,   245,   246,   247,   248,   249,   214,   nil,   nil,   nil,
+   245,   177,   nil,   nil,   215,   nil,   218,   nil,   248,   211,
+   214,   245,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   214,   253,   nil,   257,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   -10,   nil,   213,   256,   nil,   260,
+   216,   211,   245,   nil,   246,   247,   248,   249,   250,   263,
+   267,   227,    -2,   nil,     5,   nil,   228,     3,   nil,   nil,
+   nil,   255,   nil,   nil,   147,   153,   159,   nil,   233,   nil,
+   230,   154,   237,   nil,   178,   236,   233,   240,   158,   nil,
+   183,   nil,   165,   nil,   nil,   nil,   nil,   nil,   235,     4,
+   nil,   nil,   nil,   nil,   nil,   184,   281,   nil,   237,     9,
+   189,   nil,   233,   284,   nil,   nil,   241,   169,   247,   175,
+   nil,   243,   170,   282,   nil,   283,   190,   195,   nil,   272,
+   241,   nil,   274,   nil,   nil,   171,   243,   288,   245,   nil,
+   nil,   nil,   290,   nil ]
 
 racc_action_default = [
-    -1,  -142,    -1,    -3,   -10,  -142,  -142,    -2,    -3,  -142,
-   -14,  -142,  -142,  -142,  -142,  -142,  -142,  -142,   -26,   -27,
-  -142,   -32,   -33,   -34,  -142,  -142,  -142,  -142,  -142,  -142,
-  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,
-   -13,   247,    -4,   -28,  -142,   -15,  -133,  -103,  -104,  -132,
-   -17,   -95,   -18,   -19,  -142,   -23,   -29,   -35,   -38,   -41,
-   -44,   -45,   -46,   -47,   -48,   -49,   -55,   -57,  -142,   -60,
-   -50,   -85,  -142,   -88,   -90,   -91,  -141,   -51,   -98,  -100,
-  -142,   -52,   -53,   -54,  -142,  -142,   -11,    -5,    -7,  -105,
-  -142,   -72,  -129,   -16,  -134,  -135,  -136,   -92,  -142,   -20,
-  -142,  -142,  -142,  -142,  -142,  -142,   -56,   -58,   -61,   -83,
-  -142,   -89,   -86,   -98,   -99,  -142,  -101,  -142,  -142,  -142,
-  -142,    -6,    -8,    -9,  -130,  -106,  -107,  -108,   -73,  -142,
-  -142,  -142,   -96,  -142,   -24,   -30,   -36,   -39,   -42,   -59,
-   -62,   -84,   -87,  -102,  -142,   -68,   -74,  -142,   -12,  -142,
-  -112,  -142,   -93,  -142,   -21,  -142,  -142,  -142,  -142,  -142,
-   -63,  -142,   -66,   -70,   -75,  -142,  -131,  -109,  -110,  -113,
-  -128,  -142,   -97,  -142,   -25,   -31,  -142,  -142,  -142,   -64,
-  -142,   -69,   -74,   -72,  -103,   -79,  -142,  -142,  -112,  -103,
-   -72,  -117,  -142,   -94,   -22,   -37,  -137,  -139,  -140,   -40,
-   -43,   -74,   -71,   -76,   -77,  -121,  -122,  -123,  -142,  -142,
-   -82,   -74,  -111,  -142,  -114,   -72,  -142,  -120,  -138,   -65,
-  -142,  -103,  -124,   -80,   -67,  -142,   -63,  -118,   -63,  -142,
-  -142,  -126,  -142,   -72,  -115,  -142,   -78,  -125,  -142,   -72,
-   -63,   -72,  -127,   -81,  -116,   -63,  -119 ]
+    -1,  -141,    -1,    -3,   -10,  -141,  -141,    -2,    -3,  -141,
+   -16,  -141,  -141,  -141,  -141,  -141,  -141,  -141,   -28,   -29,
+  -141,   -36,   -37,   -38,  -141,  -141,  -141,  -141,  -141,  -141,
+  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,
+   -13,   244,    -4,   -30,  -141,   -17,  -134,  -104,  -105,  -133,
+   -14,   -19,   -96,   -20,   -21,  -141,   -25,   -33,   -39,   -42,
+   -45,   -48,   -49,   -50,   -51,   -52,   -53,   -59,   -61,  -141,
+   -64,   -54,   -89,   -91,  -141,   -94,   -95,  -140,   -55,   -99,
+  -101,  -141,   -56,   -57,   -58,  -141,  -141,   -11,    -5,    -7,
+  -106,  -141,   -76,  -130,   -18,  -135,  -136,  -137,   -15,  -141,
+   -22,  -141,  -141,  -141,  -141,  -141,  -141,   -60,   -62,   -65,
+   -87,  -141,   -90,   -92,   -99,  -100,  -141,  -102,  -141,  -141,
+  -141,  -141,    -6,    -8,    -9,  -131,  -107,  -108,  -109,   -77,
+  -141,  -141,   -97,  -141,   -26,   -34,   -40,   -43,   -46,   -63,
+   -66,   -88,   -93,  -103,  -141,   -72,   -78,  -141,   -12,  -141,
+  -113,  -141,  -141,   -23,  -141,  -141,  -141,  -141,  -141,   -67,
+  -141,   -70,   -74,   -79,  -141,  -132,  -110,  -111,  -114,  -129,
+   -98,  -141,   -27,   -35,  -141,  -141,  -141,   -68,  -141,   -73,
+   -78,   -76,  -104,   -83,  -141,  -141,  -113,  -104,   -76,  -118,
+  -141,   -24,   -31,   -41,  -138,  -139,   -44,   -47,   -78,   -75,
+   -80,   -81,  -122,  -123,  -124,  -141,  -141,   -86,   -78,  -112,
+  -141,  -115,   -76,  -141,  -121,   -32,   -69,  -141,  -104,  -125,
+   -84,   -71,  -141,   -67,  -119,   -67,  -141,  -141,  -127,  -141,
+   -76,  -116,  -141,   -82,  -126,  -141,   -76,   -67,   -76,  -128,
+   -85,  -117,   -67,  -120 ]
 
 racc_goto_table = [
-    73,   129,    49,   180,    71,    88,    90,   162,   168,   220,
-   144,    67,   204,     9,   225,   114,   218,   116,    42,   215,
-   218,   218,    69,     1,    78,    78,    78,    78,     3,   122,
-     7,   238,    77,    81,    82,    83,   123,    39,   111,    73,
-   165,   120,    46,   112,    93,   106,   212,   107,   121,    90,
-   114,   231,   143,    50,    52,    53,    69,   133,    69,   195,
-   199,   200,   219,   173,   100,   155,   101,   156,   113,   234,
-   113,   236,   224,   102,   157,   103,   158,    73,   104,   111,
-   159,   142,    65,   244,   139,    70,   140,   109,   246,   118,
-   202,   209,   232,   203,   141,    69,   131,   171,    98,   153,
-   214,   126,   167,   113,   216,   113,   235,   149,   nil,   111,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   226,   nil,   nil,   nil,   nil,
-   183,   nil,   nil,   nil,   nil,   190,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   240,   nil,   nil,   nil,   nil,   nil,   243,
-   nil,   245,   nil,   210,   nil,   nil,   nil,   nil,   nil,   217,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   183,
-   nil,   nil,   nil,   nil,   nil,   222,   nil,   nil,   nil,   190,
-   222,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   237,   222 ]
+   130,    49,    73,   178,    89,    68,    91,   201,   144,   115,
+   161,   117,     1,   167,   212,    51,    53,    54,   193,   196,
+   197,    70,     9,    79,    79,    79,    79,    42,   123,   217,
+    78,    82,    83,    84,   222,   124,   215,   164,    39,   121,
+   107,   112,   108,   113,   115,   228,   143,    46,   122,   209,
+    91,   235,    98,     3,    94,     7,    70,   133,    70,   171,
+   101,   154,   216,   102,   155,   103,   156,   231,   114,   233,
+   114,   181,   221,   104,   157,   105,   188,   158,    66,   139,
+   142,   241,    71,   194,   194,   194,   243,   140,   110,   200,
+   119,   199,   206,   207,   229,    70,   211,   141,    99,   214,
+   152,   194,   127,   114,   166,   114,   213,   232,   181,   149,
+   nil,   nil,   nil,   nil,   219,   nil,   nil,   nil,   188,   219,
+   223,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   234,   219,   nil,   237,   nil,
+   nil,   nil,   nil,   nil,   240,   nil,   242 ]
 
 racc_goto_check = [
-    45,    49,    37,    42,    53,     8,    12,    41,    62,    48,
-    40,    36,    47,     7,    48,    58,    66,    58,     7,    47,
-    66,    66,    37,     1,    37,    37,    37,    37,     6,     5,
-     6,    48,    34,    34,    34,    34,     9,    10,    45,    45,
-    40,    11,    13,    53,    14,    36,    62,    36,     8,    12,
-    58,    47,    58,    15,    15,    15,    37,    16,    37,    23,
-    23,    23,    41,    17,    18,    19,    24,    25,    37,    42,
-    37,    42,    41,    26,    27,    28,    29,    45,    30,    45,
-    31,    53,    32,    42,    36,    33,    38,    39,    42,    43,
-    44,    50,    51,    49,    52,    37,    54,    55,    56,    57,
-    49,    60,    61,    37,    63,    37,    64,    65,   nil,    45,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    49,   nil,   nil,   nil,   nil,
-    45,   nil,   nil,   nil,   nil,    45,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,    49,   nil,   nil,   nil,   nil,   nil,    49,
-   nil,    49,   nil,    45,   nil,   nil,   nil,   nil,   nil,    45,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    45,
-   nil,   nil,   nil,   nil,   nil,    45,   nil,   nil,   nil,    45,
-    45,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,    45,    45 ]
+    51,    39,    55,    44,     8,    38,    12,    49,    42,    58,
+    43,    58,     1,    62,    49,    16,    16,    16,    25,    25,
+    25,    39,     7,    39,    39,    39,    39,     7,     5,    50,
+    36,    36,    36,    36,    50,     9,    25,    42,    10,    11,
+    38,    55,    38,    55,    58,    49,    58,    13,     8,    62,
+    12,    50,    16,     6,    14,     6,    39,    17,    39,    18,
+    19,    20,    43,    26,    27,    28,    29,    44,    39,    44,
+    39,    47,    43,    30,    31,    32,    47,    33,    34,    38,
+    55,    44,    35,    47,    47,    47,    44,    40,    41,    51,
+    45,    46,    52,    47,    53,    39,    51,    54,    56,    47,
+    57,    47,    60,    39,    61,    39,    63,    64,    47,    65,
+   nil,   nil,   nil,   nil,    47,   nil,   nil,   nil,    47,    47,
+    51,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,    47,    47,   nil,    51,   nil,
+   nil,   nil,   nil,   nil,    51,   nil,    51 ]
 
 racc_goto_pointer = [
-   nil,    23,   nil,   nil,   nil,   -59,    28,    10,   -39,   -52,
-    33,   -45,   -38,    30,    -2,    40,   -42,   -91,     9,   -69,
-   nil,   nil,   nil,  -117,    10,   -68,    16,   -62,    17,   -61,
-    19,   -58,    50,    52,    -2,   nil,   -21,   -10,   -23,    18,
-  -107,  -139,  -157,     4,   -92,   -33,   nil,  -171,  -199,   -90,
-   -94,  -131,   -15,   -29,    -1,   -55,    47,   -33,   -63,   nil,
-    12,   -48,  -142,   -87,  -121,   -17,  -179 ]
+   nil,    12,   nil,   nil,   nil,   -61,    53,    19,   -40,   -54,
+    34,   -48,   -38,    35,     8,   nil,     2,   -43,   -94,     4,
+   -73,   nil,   nil,   nil,   nil,  -156,     6,   -71,     7,   -70,
+    14,   -63,    15,   -61,    46,    49,    -4,   nil,   -27,   -11,
+   -23,    18,  -110,  -136,  -156,     4,   -89,   -91,   nil,  -174,
+  -176,   -92,   -91,  -126,   -13,   -31,    46,   -32,   -70,   nil,
+    12,   -46,  -137,   -83,  -117,   -16 ]
 
 racc_goto_default = [
-   nil,   nil,     2,     8,    87,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    10,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    21,    22,    23,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    66,   nil,    74,   nil,   nil,
-   nil,   nil,   nil,    91,   163,   197,   128,   nil,   nil,   nil,
-   nil,   nil,    75,   nil,   nil,   nil,   nil,   nil,    79,    89,
-   nil,   nil,   nil,   nil,   nil,   nil,   196 ]
+   nil,   nil,     2,     8,    88,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    10,   nil,   nil,    50,   nil,   nil,   nil,   nil,
+   nil,    21,    22,    23,   192,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,    67,   nil,    75,
+   nil,   nil,   nil,   nil,   nil,    92,   162,    72,   129,   nil,
+   nil,   nil,   nil,   nil,    76,   nil,   nil,   nil,    80,    90,
+   nil,   nil,   nil,   nil,   nil,   nil ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -926,138 +912,137 @@ racc_reduce_table = [
   0, 66, :_reduce_11,
   5, 57, :_reduce_12,
   2, 57, :_reduce_none,
+  1, 71, :_reduce_14,
+  2, 71, :_reduce_15,
   1, 58, :_reduce_none,
-  2, 58, :_reduce_15,
+  2, 58, :_reduce_17,
   3, 58, :_reduce_none,
   2, 58, :_reduce_none,
-  2, 58, :_reduce_18,
-  2, 58, :_reduce_19,
-  0, 71, :_reduce_20,
-  0, 72, :_reduce_21,
-  7, 58, :_reduce_22,
+  2, 58, :_reduce_20,
+  2, 58, :_reduce_21,
+  0, 72, :_reduce_22,
   0, 73, :_reduce_23,
-  0, 74, :_reduce_24,
-  6, 58, :_reduce_25,
-  1, 58, :_reduce_26,
-  1, 58, :_reduce_27,
+  7, 58, :_reduce_24,
+  0, 74, :_reduce_25,
+  0, 75, :_reduce_26,
+  6, 58, :_reduce_27,
+  1, 58, :_reduce_28,
+  1, 58, :_reduce_29,
   2, 58, :_reduce_none,
-  0, 79, :_reduce_29,
-  0, 80, :_reduce_30,
-  6, 67, :_reduce_31,
+  1, 80, :_reduce_31,
+  2, 80, :_reduce_32,
+  0, 81, :_reduce_33,
+  0, 82, :_reduce_34,
+  6, 67, :_reduce_35,
   1, 67, :_reduce_none,
   1, 67, :_reduce_none,
   1, 67, :_reduce_none,
-  0, 81, :_reduce_35,
-  0, 82, :_reduce_36,
-  7, 67, :_reduce_37,
-  0, 83, :_reduce_38,
-  0, 84, :_reduce_39,
-  7, 67, :_reduce_40,
-  0, 85, :_reduce_41,
-  0, 86, :_reduce_42,
-  7, 67, :_reduce_43,
-  2, 67, :_reduce_44,
-  2, 67, :_reduce_45,
-  2, 67, :_reduce_46,
-  2, 67, :_reduce_47,
+  0, 83, :_reduce_39,
+  0, 84, :_reduce_40,
+  7, 67, :_reduce_41,
+  0, 85, :_reduce_42,
+  0, 86, :_reduce_43,
+  7, 67, :_reduce_44,
+  0, 87, :_reduce_45,
+  0, 88, :_reduce_46,
+  7, 67, :_reduce_47,
   2, 67, :_reduce_48,
-  2, 75, :_reduce_none,
-  2, 75, :_reduce_50,
-  2, 75, :_reduce_51,
-  2, 75, :_reduce_52,
-  2, 75, :_reduce_53,
-  2, 75, :_reduce_54,
-  1, 91, :_reduce_55,
-  2, 91, :_reduce_56,
-  1, 87, :_reduce_57,
-  2, 87, :_reduce_58,
-  3, 87, :_reduce_59,
-  0, 94, :_reduce_none,
-  1, 94, :_reduce_none,
-  3, 90, :_reduce_62,
-  0, 97, :_reduce_none,
-  1, 97, :_reduce_none,
-  8, 76, :_reduce_65,
-  5, 77, :_reduce_66,
-  8, 77, :_reduce_67,
-  1, 95, :_reduce_68,
-  3, 95, :_reduce_69,
-  1, 96, :_reduce_70,
-  3, 96, :_reduce_71,
-  0, 104, :_reduce_none,
-  1, 104, :_reduce_none,
-  0, 99, :_reduce_74,
-  1, 99, :_reduce_75,
-  3, 99, :_reduce_76,
-  3, 99, :_reduce_77,
-  6, 99, :_reduce_78,
-  0, 105, :_reduce_79,
-  0, 106, :_reduce_80,
-  7, 99, :_reduce_81,
-  3, 99, :_reduce_82,
-  0, 93, :_reduce_none,
-  1, 93, :_reduce_84,
-  1, 88, :_reduce_85,
-  2, 88, :_reduce_86,
-  3, 88, :_reduce_87,
-  1, 108, :_reduce_88,
-  2, 108, :_reduce_89,
-  1, 100, :_reduce_none,
-  1, 100, :_reduce_none,
-  0, 109, :_reduce_92,
-  0, 110, :_reduce_93,
-  6, 70, :_reduce_94,
-  0, 111, :_reduce_95,
-  0, 112, :_reduce_96,
-  5, 70, :_reduce_97,
-  1, 113, :_reduce_98,
-  2, 113, :_reduce_99,
-  1, 89, :_reduce_100,
-  2, 89, :_reduce_101,
-  3, 89, :_reduce_102,
-  1, 92, :_reduce_103,
-  1, 92, :_reduce_104,
+  2, 67, :_reduce_49,
+  2, 67, :_reduce_50,
+  2, 67, :_reduce_51,
+  2, 67, :_reduce_52,
+  2, 76, :_reduce_none,
+  2, 76, :_reduce_54,
+  2, 76, :_reduce_55,
+  2, 76, :_reduce_56,
+  2, 76, :_reduce_57,
+  2, 76, :_reduce_58,
+  1, 93, :_reduce_59,
+  2, 93, :_reduce_60,
+  1, 89, :_reduce_61,
+  2, 89, :_reduce_62,
+  3, 89, :_reduce_63,
+  0, 96, :_reduce_none,
+  1, 96, :_reduce_none,
+  3, 92, :_reduce_66,
+  0, 99, :_reduce_none,
+  1, 99, :_reduce_none,
+  8, 77, :_reduce_69,
+  5, 78, :_reduce_70,
+  8, 78, :_reduce_71,
+  1, 97, :_reduce_72,
+  3, 97, :_reduce_73,
+  1, 98, :_reduce_74,
+  3, 98, :_reduce_75,
+  0, 106, :_reduce_none,
+  1, 106, :_reduce_none,
+  0, 101, :_reduce_78,
+  1, 101, :_reduce_79,
+  3, 101, :_reduce_80,
+  3, 101, :_reduce_81,
+  6, 101, :_reduce_82,
+  0, 107, :_reduce_83,
+  0, 108, :_reduce_84,
+  7, 101, :_reduce_85,
+  3, 101, :_reduce_86,
+  0, 95, :_reduce_none,
+  1, 95, :_reduce_88,
+  1, 110, :_reduce_89,
+  2, 110, :_reduce_90,
+  1, 90, :_reduce_91,
+  2, 90, :_reduce_92,
+  3, 90, :_reduce_93,
+  1, 102, :_reduce_none,
+  1, 102, :_reduce_none,
+  0, 111, :_reduce_96,
+  0, 112, :_reduce_97,
+  5, 70, :_reduce_98,
+  1, 113, :_reduce_99,
+  2, 113, :_reduce_100,
+  1, 91, :_reduce_101,
+  2, 91, :_reduce_102,
+  3, 91, :_reduce_103,
+  1, 94, :_reduce_104,
+  1, 94, :_reduce_105,
   0, 115, :_reduce_none,
   1, 115, :_reduce_none,
   2, 59, :_reduce_none,
   2, 59, :_reduce_none,
-  4, 114, :_reduce_109,
-  1, 116, :_reduce_110,
-  3, 116, :_reduce_111,
-  0, 117, :_reduce_112,
-  1, 117, :_reduce_113,
-  3, 117, :_reduce_114,
-  5, 117, :_reduce_115,
-  7, 117, :_reduce_116,
-  0, 118, :_reduce_117,
-  0, 119, :_reduce_118,
-  8, 117, :_reduce_119,
-  3, 117, :_reduce_120,
-  1, 102, :_reduce_121,
-  1, 102, :_reduce_122,
-  1, 102, :_reduce_123,
-  1, 103, :_reduce_124,
-  3, 103, :_reduce_125,
-  2, 103, :_reduce_126,
-  4, 103, :_reduce_127,
-  3, 101, :_reduce_128,
-  1, 98, :_reduce_none,
-  0, 120, :_reduce_130,
-  3, 60, :_reduce_131,
+  4, 114, :_reduce_110,
+  1, 116, :_reduce_111,
+  3, 116, :_reduce_112,
+  0, 117, :_reduce_113,
+  1, 117, :_reduce_114,
+  3, 117, :_reduce_115,
+  5, 117, :_reduce_116,
+  7, 117, :_reduce_117,
+  0, 118, :_reduce_118,
+  0, 119, :_reduce_119,
+  8, 117, :_reduce_120,
+  3, 117, :_reduce_121,
+  1, 104, :_reduce_122,
+  1, 104, :_reduce_123,
+  1, 104, :_reduce_124,
+  1, 105, :_reduce_125,
+  3, 105, :_reduce_126,
+  2, 105, :_reduce_127,
+  4, 105, :_reduce_128,
+  3, 103, :_reduce_129,
+  1, 100, :_reduce_none,
+  0, 120, :_reduce_131,
+  3, 60, :_reduce_132,
   1, 68, :_reduce_none,
   0, 69, :_reduce_none,
   1, 69, :_reduce_none,
   1, 69, :_reduce_none,
   1, 69, :_reduce_none,
-  1, 78, :_reduce_137,
-  2, 78, :_reduce_138,
-  1, 121, :_reduce_none,
-  1, 121, :_reduce_none,
-  1, 107, :_reduce_141 ]
+  1, 79, :_reduce_none,
+  1, 79, :_reduce_none,
+  1, 109, :_reduce_140 ]
 
-racc_reduce_n = 142
+racc_reduce_n = 141
 
-racc_shift_n = 247
+racc_shift_n = 244
 
 racc_token_table = {
   false => 0,
@@ -1208,7 +1193,8 @@ Racc_token_to_s_table = [
   "grammar_declaration",
   "variable",
   "value",
-  "params",
+  "param",
+  "\"-many1@param\"",
   "@3",
   "@4",
   "@5",
@@ -1216,7 +1202,8 @@ Racc_token_to_s_table = [
   "symbol_declaration",
   "rule_declaration",
   "inline_declaration",
-  "generic_symlist",
+  "generic_symbol",
+  "\"-many1@generic_symbol\"",
   "@7",
   "@8",
   "@9",
@@ -1246,20 +1233,17 @@ Racc_token_to_s_table = [
   "@15",
   "@16",
   "string_as_id",
-  "symbol_declaration_list",
+  "\"-many1@symbol\"",
   "@17",
   "@18",
-  "@19",
-  "@20",
   "\"-many1@id\"",
   "rules",
   "\"-option@;\"",
   "rhs_list",
   "rhs",
-  "@21",
-  "@22",
-  "@23",
-  "generic_symlist_item" ]
+  "@19",
+  "@20",
+  "@21" ]
 Ractor.make_shareable(Racc_token_to_s_table) if defined?(Ractor)
 
 Racc_debug_parser = true
@@ -1343,21 +1327,35 @@ module_eval(<<'.,.,', 'parser.y', 21)
 
 # reduce 13 omitted
 
-# reduce 14 omitted
+module_eval(<<'.,.,', 'parser.y', 71)
+  def _reduce_14(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
-module_eval(<<'.,.,', 'parser.y', 27)
+module_eval(<<'.,.,', 'parser.y', 71)
   def _reduce_15(val, _values, result)
-     @grammar.expect = val[1]
+    result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 # reduce 16 omitted
 
-# reduce 17 omitted
+module_eval(<<'.,.,', 'parser.y', 27)
+  def _reduce_17(val, _values, result)
+     @grammar.expect = val[1]
+    result
+  end
+.,.,
+
+# reduce 18 omitted
+
+# reduce 19 omitted
 
 module_eval(<<'.,.,', 'parser.y', 32)
-  def _reduce_18(val, _values, result)
+  def _reduce_20(val, _values, result)
                              val[1].each {|token|
                            @grammar.lex_param = Grammar::Code::NoReferenceCode.new(type: :lex_param, token_code: token).token_code.s_value
                          }
@@ -1367,7 +1365,7 @@ module_eval(<<'.,.,', 'parser.y', 32)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 38)
-  def _reduce_19(val, _values, result)
+  def _reduce_21(val, _values, result)
                              val[1].each {|token|
                            @grammar.parse_param = Grammar::Code::NoReferenceCode.new(type: :parse_param, token_code: token).token_code.s_value
                          }
@@ -1377,7 +1375,7 @@ module_eval(<<'.,.,', 'parser.y', 38)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 44)
-  def _reduce_20(val, _values, result)
+  def _reduce_22(val, _values, result)
                              begin_c_declaration("}")
 
     result
@@ -1385,7 +1383,7 @@ module_eval(<<'.,.,', 'parser.y', 44)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 48)
-  def _reduce_21(val, _values, result)
+  def _reduce_23(val, _values, result)
                              end_c_declaration
 
     result
@@ -1393,7 +1391,7 @@ module_eval(<<'.,.,', 'parser.y', 48)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 52)
-  def _reduce_22(val, _values, result)
+  def _reduce_24(val, _values, result)
                              @grammar.add_percent_code(id: val[1], code: val[4])
 
     result
@@ -1401,7 +1399,7 @@ module_eval(<<'.,.,', 'parser.y', 52)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 56)
-  def _reduce_23(val, _values, result)
+  def _reduce_25(val, _values, result)
                              begin_c_declaration("}")
 
     result
@@ -1409,7 +1407,7 @@ module_eval(<<'.,.,', 'parser.y', 56)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 60)
-  def _reduce_24(val, _values, result)
+  def _reduce_26(val, _values, result)
                              end_c_declaration
 
     result
@@ -1417,7 +1415,7 @@ module_eval(<<'.,.,', 'parser.y', 60)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 64)
-  def _reduce_25(val, _values, result)
+  def _reduce_27(val, _values, result)
                              @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[3])
 
     result
@@ -1425,23 +1423,37 @@ module_eval(<<'.,.,', 'parser.y', 64)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 66)
-  def _reduce_26(val, _values, result)
+  def _reduce_28(val, _values, result)
      @grammar.no_stdlib = true
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 67)
-  def _reduce_27(val, _values, result)
+  def _reduce_29(val, _values, result)
      @grammar.locations = true
     result
   end
 .,.,
 
-# reduce 28 omitted
+# reduce 30 omitted
+
+module_eval(<<'.,.,', 'parser.y', 158)
+  def _reduce_31(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 158)
+  def _reduce_32(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
 module_eval(<<'.,.,', 'parser.y', 72)
-  def _reduce_29(val, _values, result)
+  def _reduce_33(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1449,7 +1461,7 @@ module_eval(<<'.,.,', 'parser.y', 72)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 76)
-  def _reduce_30(val, _values, result)
+  def _reduce_34(val, _values, result)
                                end_c_declaration
 
     result
@@ -1457,7 +1469,7 @@ module_eval(<<'.,.,', 'parser.y', 76)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 80)
-  def _reduce_31(val, _values, result)
+  def _reduce_35(val, _values, result)
                                @grammar.set_union(
                              Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[3]),
                              val[3].line
@@ -1467,14 +1479,14 @@ module_eval(<<'.,.,', 'parser.y', 80)
   end
 .,.,
 
-# reduce 32 omitted
+# reduce 36 omitted
 
-# reduce 33 omitted
+# reduce 37 omitted
 
-# reduce 34 omitted
+# reduce 38 omitted
 
 module_eval(<<'.,.,', 'parser.y', 90)
-  def _reduce_35(val, _values, result)
+  def _reduce_39(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1482,7 +1494,7 @@ module_eval(<<'.,.,', 'parser.y', 90)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 94)
-  def _reduce_36(val, _values, result)
+  def _reduce_40(val, _values, result)
                                end_c_declaration
 
     result
@@ -1490,7 +1502,7 @@ module_eval(<<'.,.,', 'parser.y', 94)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 98)
-  def _reduce_37(val, _values, result)
+  def _reduce_41(val, _values, result)
                                @grammar.add_destructor(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1502,7 +1514,7 @@ module_eval(<<'.,.,', 'parser.y', 98)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 106)
-  def _reduce_38(val, _values, result)
+  def _reduce_42(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1510,7 +1522,7 @@ module_eval(<<'.,.,', 'parser.y', 106)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 110)
-  def _reduce_39(val, _values, result)
+  def _reduce_43(val, _values, result)
                                end_c_declaration
 
     result
@@ -1518,7 +1530,7 @@ module_eval(<<'.,.,', 'parser.y', 110)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 114)
-  def _reduce_40(val, _values, result)
+  def _reduce_44(val, _values, result)
                                @grammar.add_printer(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1530,7 +1542,7 @@ module_eval(<<'.,.,', 'parser.y', 114)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 122)
-  def _reduce_41(val, _values, result)
+  def _reduce_45(val, _values, result)
                                begin_c_declaration("}")
 
     result
@@ -1538,7 +1550,7 @@ module_eval(<<'.,.,', 'parser.y', 122)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 126)
-  def _reduce_42(val, _values, result)
+  def _reduce_46(val, _values, result)
                                end_c_declaration
 
     result
@@ -1546,7 +1558,7 @@ module_eval(<<'.,.,', 'parser.y', 126)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 130)
-  def _reduce_43(val, _values, result)
+  def _reduce_47(val, _values, result)
                                @grammar.add_error_token(
                              ident_or_tags: val[6],
                              token_code: val[3],
@@ -1558,7 +1570,7 @@ module_eval(<<'.,.,', 'parser.y', 130)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 138)
-  def _reduce_44(val, _values, result)
+  def _reduce_48(val, _values, result)
                                @grammar.after_shift = val[1]
 
     result
@@ -1566,7 +1578,7 @@ module_eval(<<'.,.,', 'parser.y', 138)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 142)
-  def _reduce_45(val, _values, result)
+  def _reduce_49(val, _values, result)
                                @grammar.before_reduce = val[1]
 
     result
@@ -1574,7 +1586,7 @@ module_eval(<<'.,.,', 'parser.y', 142)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 146)
-  def _reduce_46(val, _values, result)
+  def _reduce_50(val, _values, result)
                                @grammar.after_reduce = val[1]
 
     result
@@ -1582,7 +1594,7 @@ module_eval(<<'.,.,', 'parser.y', 146)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 150)
-  def _reduce_47(val, _values, result)
+  def _reduce_51(val, _values, result)
                                @grammar.after_shift_error_token = val[1]
 
     result
@@ -1590,17 +1602,17 @@ module_eval(<<'.,.,', 'parser.y', 150)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 154)
-  def _reduce_48(val, _values, result)
+  def _reduce_52(val, _values, result)
                                @grammar.after_pop_stack = val[1]
 
     result
   end
 .,.,
 
-# reduce 49 omitted
+# reduce 53 omitted
 
 module_eval(<<'.,.,', 'parser.y', 160)
-  def _reduce_50(val, _values, result)
+  def _reduce_54(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               @grammar.add_type(id: id, tag: hash[:tag])
@@ -1612,7 +1624,7 @@ module_eval(<<'.,.,', 'parser.y', 160)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 168)
-  def _reduce_51(val, _values, result)
+  def _reduce_55(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1626,7 +1638,7 @@ module_eval(<<'.,.,', 'parser.y', 168)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 178)
-  def _reduce_52(val, _values, result)
+  def _reduce_56(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1640,7 +1652,7 @@ module_eval(<<'.,.,', 'parser.y', 178)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 188)
-  def _reduce_53(val, _values, result)
+  def _reduce_57(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1654,7 +1666,7 @@ module_eval(<<'.,.,', 'parser.y', 188)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 198)
-  def _reduce_54(val, _values, result)
+  def _reduce_58(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1668,21 +1680,21 @@ module_eval(<<'.,.,', 'parser.y', 198)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 227)
-  def _reduce_55(val, _values, result)
+  def _reduce_59(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 227)
-  def _reduce_56(val, _values, result)
+  def _reduce_60(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 209)
-  def _reduce_57(val, _values, result)
+  def _reduce_61(val, _values, result)
                               val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
                           }
@@ -1692,7 +1704,7 @@ module_eval(<<'.,.,', 'parser.y', 209)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 215)
-  def _reduce_58(val, _values, result)
+  def _reduce_62(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
@@ -1702,7 +1714,7 @@ module_eval(<<'.,.,', 'parser.y', 215)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 221)
-  def _reduce_59(val, _values, result)
+  def _reduce_63(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
@@ -1711,23 +1723,23 @@ module_eval(<<'.,.,', 'parser.y', 221)
   end
 .,.,
 
-# reduce 60 omitted
+# reduce 64 omitted
 
-# reduce 61 omitted
+# reduce 65 omitted
 
 module_eval(<<'.,.,', 'parser.y', 226)
-  def _reduce_62(val, _values, result)
+  def _reduce_66(val, _values, result)
      result = val
     result
   end
 .,.,
 
-# reduce 63 omitted
+# reduce 67 omitted
 
-# reduce 64 omitted
+# reduce 68 omitted
 
 module_eval(<<'.,.,', 'parser.y', 230)
-  def _reduce_65(val, _values, result)
+  def _reduce_69(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1736,7 +1748,7 @@ module_eval(<<'.,.,', 'parser.y', 230)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 236)
-  def _reduce_66(val, _values, result)
+  def _reduce_70(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1745,7 +1757,7 @@ module_eval(<<'.,.,', 'parser.y', 236)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 241)
-  def _reduce_67(val, _values, result)
+  def _reduce_71(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1754,21 +1766,21 @@ module_eval(<<'.,.,', 'parser.y', 241)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 245)
-  def _reduce_68(val, _values, result)
+  def _reduce_72(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 246)
-  def _reduce_69(val, _values, result)
+  def _reduce_73(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 250)
-  def _reduce_70(val, _values, result)
+  def _reduce_74(val, _values, result)
                       builder = val[0]
                   result = [builder]
 
@@ -1777,7 +1789,7 @@ module_eval(<<'.,.,', 'parser.y', 250)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 255)
-  def _reduce_71(val, _values, result)
+  def _reduce_75(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
 
@@ -1785,12 +1797,12 @@ module_eval(<<'.,.,', 'parser.y', 255)
   end
 .,.,
 
-# reduce 72 omitted
+# reduce 76 omitted
 
-# reduce 73 omitted
+# reduce 77 omitted
 
 module_eval(<<'.,.,', 'parser.y', 261)
-  def _reduce_74(val, _values, result)
+  def _reduce_78(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1799,7 +1811,7 @@ module_eval(<<'.,.,', 'parser.y', 261)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 266)
-  def _reduce_75(val, _values, result)
+  def _reduce_79(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1808,7 +1820,7 @@ module_eval(<<'.,.,', 'parser.y', 266)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 271)
-  def _reduce_76(val, _values, result)
+  def _reduce_80(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1820,7 +1832,7 @@ module_eval(<<'.,.,', 'parser.y', 271)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 279)
-  def _reduce_77(val, _values, result)
+  def _reduce_81(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1830,7 +1842,7 @@ module_eval(<<'.,.,', 'parser.y', 279)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 285)
-  def _reduce_78(val, _values, result)
+  def _reduce_82(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1840,7 +1852,7 @@ module_eval(<<'.,.,', 'parser.y', 285)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 291)
-  def _reduce_79(val, _values, result)
+  def _reduce_83(val, _values, result)
                   if @prec_seen
                 on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                 @code_after_prec = true
@@ -1852,7 +1864,7 @@ module_eval(<<'.,.,', 'parser.y', 291)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 299)
-  def _reduce_80(val, _values, result)
+  def _reduce_84(val, _values, result)
                   end_c_declaration
 
     result
@@ -1860,7 +1872,7 @@ module_eval(<<'.,.,', 'parser.y', 299)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 303)
-  def _reduce_81(val, _values, result)
+  def _reduce_85(val, _values, result)
                   user_code = val[3]
               user_code.alias_name = val[6]
               builder = val[0]
@@ -1872,7 +1884,7 @@ module_eval(<<'.,.,', 'parser.y', 303)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 311)
-  def _reduce_82(val, _values, result)
+  def _reduce_86(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1883,155 +1895,126 @@ module_eval(<<'.,.,', 'parser.y', 311)
   end
 .,.,
 
-# reduce 83 omitted
+# reduce 87 omitted
 
 module_eval(<<'.,.,', 'parser.y', 319)
-  def _reduce_84(val, _values, result)
+  def _reduce_88(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 323)
-  def _reduce_85(val, _values, result)
-                               result = [{tag: nil, tokens: val[0]}]
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 327)
-  def _reduce_86(val, _values, result)
-                               result = [{tag: val[0], tokens: val[1]}]
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 331)
-  def _reduce_87(val, _values, result)
-                             result = val[0].append({tag: val[1], tokens: val[2]})
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 334)
-  def _reduce_88(val, _values, result)
-     result = [val[0]]
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 335)
+module_eval(<<'.,.,', 'parser.y', 326)
   def _reduce_89(val, _values, result)
-     result = val[0].append(val[1])
-    result
-  end
-.,.,
-
-# reduce 90 omitted
-
-# reduce 91 omitted
-
-module_eval(<<'.,.,', 'parser.y', 342)
-  def _reduce_92(val, _values, result)
-                  begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 346)
-  def _reduce_93(val, _values, result)
-                  end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 350)
-  def _reduce_94(val, _values, result)
-                  result = val[0].append(val[3])
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 354)
-  def _reduce_95(val, _values, result)
-                  begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 358)
-  def _reduce_96(val, _values, result)
-                  end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 362)
-  def _reduce_97(val, _values, result)
-                  result = [val[2]]
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 370)
-  def _reduce_98(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 370)
+module_eval(<<'.,.,', 'parser.y', 326)
+  def _reduce_90(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 321)
+  def _reduce_91(val, _values, result)
+     result = [{tag: nil, tokens: val[0]}]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 322)
+  def _reduce_92(val, _values, result)
+     result = [{tag: val[0], tokens: val[1]}]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 323)
+  def _reduce_93(val, _values, result)
+     result = val[0].append({tag: val[1], tokens: val[2]})
+    result
+  end
+.,.,
+
+# reduce 94 omitted
+
+# reduce 95 omitted
+
+module_eval(<<'.,.,', 'parser.y', 329)
+  def _reduce_96(val, _values, result)
+                   begin_c_declaration("}")
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 333)
+  def _reduce_97(val, _values, result)
+                   end_c_declaration
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 337)
+  def _reduce_98(val, _values, result)
+                   result = val[2]
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 345)
   def _reduce_99(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 365)
+module_eval(<<'.,.,', 'parser.y', 345)
   def _reduce_100(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 340)
+  def _reduce_101(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 366)
-  def _reduce_101(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 341)
+  def _reduce_102(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 367)
-  def _reduce_102(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 342)
+  def _reduce_103(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 369)
-  def _reduce_103(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 344)
+  def _reduce_104(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 370)
-  def _reduce_104(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 345)
+  def _reduce_105(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
-
-# reduce 105 omitted
 
 # reduce 106 omitted
 
@@ -2039,8 +2022,10 @@ module_eval(<<'.,.,', 'parser.y', 370)
 
 # reduce 108 omitted
 
-module_eval(<<'.,.,', 'parser.y', 378)
-  def _reduce_109(val, _values, result)
+# reduce 109 omitted
+
+module_eval(<<'.,.,', 'parser.y', 353)
+  def _reduce_110(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -2053,8 +2038,8 @@ module_eval(<<'.,.,', 'parser.y', 378)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 389)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 364)
+  def _reduce_111(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2065,8 +2050,8 @@ module_eval(<<'.,.,', 'parser.y', 389)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 397)
-  def _reduce_111(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 372)
+  def _reduce_112(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2077,16 +2062,7 @@ module_eval(<<'.,.,', 'parser.y', 397)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 406)
-  def _reduce_112(val, _values, result)
-               reset_precs
-           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 411)
+module_eval(<<'.,.,', 'parser.y', 381)
   def _reduce_113(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -2095,8 +2071,17 @@ module_eval(<<'.,.,', 'parser.y', 411)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 416)
+module_eval(<<'.,.,', 'parser.y', 386)
   def _reduce_114(val, _values, result)
+               reset_precs
+           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 391)
+  def _reduce_115(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -2107,8 +2092,8 @@ module_eval(<<'.,.,', 'parser.y', 416)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 424)
-  def _reduce_115(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 399)
+  def _reduce_116(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -2119,8 +2104,8 @@ module_eval(<<'.,.,', 'parser.y', 424)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 432)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 407)
+  def _reduce_117(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -2131,8 +2116,8 @@ module_eval(<<'.,.,', 'parser.y', 432)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 440)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 415)
+  def _reduce_118(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
              @code_after_prec = true
@@ -2143,16 +2128,16 @@ module_eval(<<'.,.,', 'parser.y', 440)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 448)
-  def _reduce_118(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 423)
+  def _reduce_119(val, _values, result)
                end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 452)
-  def _reduce_119(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 427)
+  def _reduce_120(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
            user_code.tag = val[7]
@@ -2164,8 +2149,8 @@ module_eval(<<'.,.,', 'parser.y', 452)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 461)
-  def _reduce_120(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 436)
+  def _reduce_121(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2176,66 +2161,66 @@ module_eval(<<'.,.,', 'parser.y', 461)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 468)
-  def _reduce_121(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 443)
+  def _reduce_122(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 469)
-  def _reduce_122(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 444)
+  def _reduce_123(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 470)
-  def _reduce_123(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 445)
+  def _reduce_124(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 472)
-  def _reduce_124(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 447)
+  def _reduce_125(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 473)
-  def _reduce_125(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 448)
+  def _reduce_126(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 474)
-  def _reduce_126(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 449)
+  def _reduce_127(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 475)
-  def _reduce_127(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 450)
+  def _reduce_128(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 477)
-  def _reduce_128(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 452)
+  def _reduce_129(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-# reduce 129 omitted
+# reduce 130 omitted
 
-module_eval(<<'.,.,', 'parser.y', 483)
-  def _reduce_130(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 458)
+  def _reduce_131(val, _values, result)
                     begin_c_declaration('\Z')
                 @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2243,16 +2228,14 @@ module_eval(<<'.,.,', 'parser.y', 483)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 488)
-  def _reduce_131(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 463)
+  def _reduce_132(val, _values, result)
                     end_c_declaration
                 @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
-
-# reduce 132 omitted
 
 # reduce 133 omitted
 
@@ -2262,26 +2245,14 @@ module_eval(<<'.,.,', 'parser.y', 488)
 
 # reduce 136 omitted
 
-module_eval(<<'.,.,', 'parser.y', 499)
-  def _reduce_137(val, _values, result)
-     result = [val[0]]
-    result
-  end
-.,.,
+# reduce 137 omitted
 
-module_eval(<<'.,.,', 'parser.y', 500)
-  def _reduce_138(val, _values, result)
-     result = val[0].append(val[1])
-    result
-  end
-.,.,
+# reduce 138 omitted
 
 # reduce 139 omitted
 
-# reduce 140 omitted
-
-module_eval(<<'.,.,', 'parser.y', 505)
-  def _reduce_141(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 477)
+  def _reduce_140(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 529)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 526)
 
 include Lrama::Report::Duration
 
@@ -729,7 +729,7 @@ end
 
 racc_action_table = [
     95,    48,    96,   184,    85,    76,    48,    48,   189,   184,
-    76,    76,    48,    48,   189,    47,    76,   185,    67,    48,
+    76,    76,    48,    48,   189,    47,    76,   185,    68,    48,
      6,    47,   191,   185,    79,    48,    40,    47,   191,    76,
     72,    48,   160,    47,    41,   161,    79,    93,    44,    48,
     48,    47,    47,    86,    79,    79,   186,   187,    45,    97,
@@ -751,16 +751,16 @@ racc_action_table = [
     47,    76,    76,    48,    48,    47,   221,    76,    76,    48,
     48,   221,    47,    76,    76,    48,    48,   221,    47,    76,
    205,   206,   207,   130,   233,   242,    55,   229,   229,    48,
-    48,    47,    47,    48,    48,    47,    47,    48,    48,    47,
-    47,    48,    56,    47,   205,   206,   207,    57,    58,    59,
-    60,    61,    62,    63,    64,    87,    98,    98,    98,   100,
-   106,   109,   111,   114,   114,   114,   114,   117,   125,   127,
-   130,   132,   134,   135,   136,   137,   138,    76,   145,   146,
-   147,   148,   150,   151,   152,   154,   164,   145,   166,   169,
-   170,   172,   174,   175,   176,   177,   178,   179,   181,   182,
-   188,   193,   194,   201,   164,   208,   211,   169,   213,   164,
-   223,   164,   130,   227,   182,   230,   182,   179,   179,   239,
-   130,   241,   130,   179,   130,   179 ]
+    48,    47,    47,    48,    48,    47,    47,    48,    56,    47,
+   205,   206,   207,    57,    58,    59,    60,    61,    62,    63,
+    64,    87,    98,    98,    98,   100,   106,   109,   111,   114,
+   114,   114,   114,   117,   125,   127,   130,   132,   134,   135,
+   136,   137,   138,    76,   145,   146,   147,   148,   150,   151,
+   152,   154,   164,   145,   166,   169,   170,   172,   174,   175,
+   176,   177,   178,   179,   181,   182,   188,   193,   194,   201,
+   164,   208,   211,   169,   213,   164,   223,   164,   130,   227,
+   182,   230,   182,   179,   179,   239,   130,   241,   130,   179,
+   130,   179 ]
 
 racc_action_check = [
     46,   163,    46,   163,    38,   163,   168,   202,   168,   202,
@@ -781,48 +781,48 @@ racc_action_check = [
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,   195,    12,   195,
     12,   195,   195,   199,    66,   199,    66,   199,   199,   200,
-    67,   200,    67,   200,   200,    71,    72,    71,    72,    71,
+    68,   200,    68,   200,   200,    71,    72,    71,    72,    71,
     72,   111,   113,   111,   113,   111,   113,   142,   186,   142,
    186,   142,   186,   192,   208,   192,   208,   192,   208,   213,
    229,   213,   229,   213,   229,   230,    78,   230,    78,   230,
    190,   190,   190,   190,   225,   238,    17,   225,   238,    79,
-   106,    79,   106,   108,   114,   108,   114,   116,   139,   116,
-   139,   143,    20,   143,   222,   222,   222,    24,    25,    26,
-    27,    28,    29,    30,    31,    39,    50,    52,    53,    54,
-    65,    69,    70,    77,    82,    83,    84,    85,    90,    91,
-    92,    99,   101,   102,   103,   104,   105,   110,   117,   118,
-   119,   120,   129,   130,   131,   133,   146,   147,   149,   150,
-   151,   153,   155,   156,   157,   158,   159,   160,   161,   162,
-   167,   171,   173,   180,   182,   184,   187,   188,   189,   201,
-   209,   211,   215,   216,   219,   221,   224,   226,   228,   232,
-   233,   235,   239,   240,   241,   245 ]
+   106,    79,   106,   114,   116,   114,   116,   143,    20,   143,
+   222,   222,   222,    24,    25,    26,    27,    28,    29,    30,
+    31,    39,    50,    52,    53,    54,    65,    69,    70,    77,
+    82,    83,    84,    85,    90,    91,    92,    99,   101,   102,
+   103,   104,   105,   110,   117,   118,   119,   120,   129,   130,
+   131,   133,   146,   147,   149,   150,   151,   153,   155,   156,
+   157,   158,   159,   160,   161,   162,   167,   171,   173,   180,
+   182,   184,   187,   188,   189,   201,   209,   211,   215,   216,
+   219,   221,   224,   226,   228,   232,   233,   235,   239,   240,
+   241,   245 ]
 
 racc_action_pointer = [
     65,    20,    73,    98,   nil,    19,    34,   nil,   126,    29,
    nil,    42,   165,    70,   103,   126,   141,   207,   nil,   nil,
-   223,   nil,   nil,   nil,   228,   229,   230,   245,   246,   247,
-   248,   249,    10,    22,    16,    28,    36,    37,    -1,   253,
+   219,   nil,   nil,   nil,   224,   225,   226,   241,   242,   243,
+   244,   245,    10,    22,    16,    28,    36,    37,    -1,   249,
    nil,   nil,   nil,   nil,    33,   nil,    -5,   nil,   nil,   nil,
-   237,   nil,   238,   239,   240,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   252,   171,   177,   nil,   255,
-   254,   182,   183,   nil,   nil,   nil,   nil,   255,   213,   226,
-   nil,   nil,   256,   257,   258,   226,   113,   nil,    70,   nil,
-   244,   245,   218,   nil,   nil,   nil,   nil,   nil,   nil,   269,
-   nil,   270,   271,   272,   273,   274,   227,   nil,   230,   nil,
-   270,   188,   nil,   189,   231,   nil,   234,   273,   236,   239,
-   270,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   239,
-   278,   282,   nil,   283,   nil,   nil,   nil,   nil,   nil,   235,
-   nil,   nil,   194,   238,   -10,   nil,   239,   282,   nil,   286,
-   242,   237,   nil,   271,   nil,   272,   273,   274,   275,   276,
-   289,   293,   253,    -2,   nil,     5,   nil,   254,     3,   nil,
-   nil,   281,   nil,   282,   nil,   nil,    73,    79,    85,   nil,
-   260,   nil,   257,     4,   264,   nil,   195,   263,   260,   267,
+   233,   nil,   234,   235,   236,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   248,   171,   nil,   177,   251,
+   250,   182,   183,   nil,   nil,   nil,   nil,   251,   213,   226,
+   nil,   nil,   252,   253,   254,   222,   113,   nil,    70,   nil,
+   240,   241,   214,   nil,   nil,   nil,   nil,   nil,   nil,   265,
+   nil,   266,   267,   268,   269,   270,   227,   nil,   nil,   nil,
+   266,   188,   nil,   189,   230,   nil,   231,   269,   232,   235,
+   266,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   235,
+   274,   278,   nil,   279,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   194,   234,   -10,   nil,   235,   278,   nil,   282,
+   238,   233,   nil,   267,   nil,   268,   269,   270,   271,   272,
+   285,   289,   249,    -2,   nil,     5,   nil,   250,     3,   nil,
+   nil,   277,   nil,   278,   nil,   nil,    73,    79,    85,   nil,
+   256,   nil,   253,     4,   260,   nil,   195,   259,   256,   263,
    171,   nil,   200,   nil,   nil,   164,   nil,   nil,   nil,   170,
-   176,   262,     4,   nil,   nil,   nil,   nil,   nil,   201,   308,
-   nil,   264,     9,   206,   nil,   260,   311,   nil,   nil,   268,
-    49,   274,   195,   nil,   270,   182,   309,   nil,   310,   207,
-   212,   nil,   299,   268,   nil,   301,   nil,   nil,   183,   270,
-   315,   272,   nil,   nil,   nil,   317,   nil ]
+   176,   258,     4,   nil,   nil,   nil,   nil,   nil,   201,   304,
+   nil,   260,     9,   206,   nil,   256,   307,   nil,   nil,   264,
+    49,   270,   191,   nil,   266,   182,   305,   nil,   306,   207,
+   212,   nil,   295,   264,   nil,   297,   nil,   nil,   183,   266,
+   311,   268,   nil,   nil,   nil,   313,   nil ]
 
 racc_action_default = [
     -1,  -143,    -1,    -3,    -8,  -143,  -143,    -2,    -3,  -143,
@@ -831,14 +831,14 @@ racc_action_default = [
   -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,  -143,
    -11,   247,    -4,   -26,  -143,   -13,  -134,  -102,  -103,  -133,
    -15,   -93,   -16,   -17,  -143,   -21,   -27,   -33,   -36,   -39,
-   -42,   -43,   -44,   -45,   -46,   -47,   -53,  -143,   -56,   -58,
+   -42,   -43,   -44,   -45,   -46,   -47,   -53,   -55,  -143,   -58,
    -48,   -83,  -143,   -86,   -88,   -89,  -142,   -49,   -96,  -143,
    -99,  -101,   -50,   -51,   -52,  -143,  -143,    -9,    -5,  -104,
   -106,  -143,   -70,  -130,   -14,  -135,  -136,  -137,   -90,  -143,
-   -18,  -143,  -143,  -143,  -143,  -143,  -143,   -57,   -54,   -59,
+   -18,  -143,  -143,  -143,  -143,  -143,  -143,   -54,   -56,   -59,
    -81,  -143,   -87,   -84,  -143,  -100,   -97,  -143,  -143,  -143,
   -143,    -6,    -7,  -105,  -131,  -107,  -108,  -109,   -71,  -143,
-  -143,  -143,   -94,  -143,   -22,   -28,   -34,   -37,   -40,   -55,
+  -143,  -143,   -94,  -143,   -22,   -28,   -34,   -37,   -40,   -57,
    -60,   -82,   -85,   -98,  -143,   -66,   -72,  -143,   -10,  -143,
   -113,  -143,   -91,  -143,   -19,  -143,  -143,  -143,  -143,  -143,
    -61,  -143,   -64,   -68,   -73,  -143,  -132,  -110,  -111,  -114,
@@ -852,19 +852,19 @@ racc_action_default = [
    -61,   -70,  -128,   -79,  -117,   -61,  -120 ]
 
 racc_goto_table = [
-    73,   129,    49,    71,   180,    66,   162,   168,   115,   107,
-    91,    89,   116,   204,   144,     3,     9,     7,     1,    88,
-   215,    42,    69,   121,    81,    81,    81,    81,   220,   122,
-   218,    39,   120,   225,   218,   218,    46,    94,   112,    73,
-   108,   133,   113,   173,   165,   212,   115,   143,   101,   155,
-   238,   107,   231,   102,    91,   123,    69,    69,    50,    52,
-    53,   219,    77,    82,    83,    84,   156,   103,    81,    81,
-   234,   224,   236,   115,   195,   199,   200,   157,    73,   139,
-   112,   142,   107,   104,   244,   158,   105,   159,    65,   246,
-    70,   140,   203,   110,   118,   202,    69,   209,    69,   214,
-   232,   141,   131,   171,    81,    99,    81,   153,   126,   112,
-   167,   216,   235,   149,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   226,   nil,   nil,   nil,   nil,    69,
+    73,   129,    49,    71,   180,    91,   162,    89,   115,    67,
+   168,   204,   116,     1,   144,   220,     9,     3,   215,     7,
+   225,    42,    69,    88,    81,    81,    81,    81,   218,    50,
+    52,    53,   218,   218,   195,   199,   200,   238,   112,    73,
+   121,   122,   113,   107,   165,   108,   115,   143,   212,    91,
+   231,   123,    77,    82,    83,    84,    69,    39,    69,   120,
+    46,   219,    94,   133,   173,   101,   155,   102,    81,    81,
+   234,   224,   236,   115,   156,   103,   157,   104,    73,   158,
+   112,   142,   105,   139,   244,   159,    65,    70,   140,   246,
+   110,   118,   203,   202,   209,   232,    69,   141,   131,   214,
+   171,    99,   153,   126,    81,   167,    81,   216,   235,   112,
+   149,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   226,   nil,   nil,   nil,   nil,   nil,
    183,   nil,   nil,    81,   nil,   190,   nil,   nil,   nil,   nil,
    nil,   nil,   240,   nil,   nil,   nil,   nil,   nil,   243,   nil,
    245,   nil,   nil,   210,   nil,   nil,   nil,   nil,   nil,   217,
@@ -874,19 +874,19 @@ racc_goto_table = [
    nil,   nil,   nil,   nil,   nil,   nil,   237,   222 ]
 
 racc_goto_check = [
-    44,    48,    36,    52,    41,    34,    40,    63,    58,    35,
-    11,    59,    57,    46,    39,     6,     7,     6,     1,     4,
-    46,     7,    36,     5,    36,    36,    36,    36,    47,     8,
-    67,     9,    10,    47,    67,    67,    12,    13,    44,    44,
-    34,    15,    52,    16,    39,    63,    58,    57,    17,    18,
-    47,    35,    46,    23,    11,    59,    36,    36,    14,    14,
-    14,    40,    33,    33,    33,    33,    24,    25,    36,    36,
-    41,    40,    41,    58,    22,    22,    22,    26,    44,    34,
-    44,    52,    35,    27,    41,    28,    29,    30,    31,    41,
-    32,    37,    48,    38,    42,    43,    36,    49,    36,    48,
-    50,    51,    53,    54,    36,    55,    36,    56,    61,    44,
-    62,    64,    65,    66,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,    48,   nil,   nil,   nil,   nil,    36,
+    44,    48,    36,    52,    41,    11,    40,    59,    58,    35,
+    63,    46,    57,     1,    39,    47,     7,     6,    46,     6,
+    47,     7,    36,     4,    36,    36,    36,    36,    67,    14,
+    14,    14,    67,    67,    22,    22,    22,    47,    44,    44,
+     5,     8,    52,    35,    39,    35,    58,    57,    63,    11,
+    46,    59,    33,    33,    33,    33,    36,     9,    36,    10,
+    12,    40,    13,    15,    16,    17,    18,    23,    36,    36,
+    41,    40,    41,    58,    24,    25,    26,    27,    44,    28,
+    44,    52,    29,    35,    41,    30,    31,    32,    37,    41,
+    38,    42,    48,    43,    49,    50,    36,    51,    53,    48,
+    54,    55,    56,    61,    36,    62,    36,    64,    65,    44,
+    66,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,    48,   nil,   nil,   nil,   nil,   nil,
     44,   nil,   nil,    36,   nil,    44,   nil,   nil,   nil,   nil,
    nil,   nil,    48,   nil,   nil,   nil,   nil,   nil,    48,   nil,
     48,   nil,   nil,    44,   nil,   nil,   nil,   nil,   nil,    44,
@@ -896,19 +896,19 @@ racc_goto_check = [
    nil,   nil,   nil,   nil,   nil,   nil,    44,    44 ]
 
 racc_goto_pointer = [
-   nil,    18,   nil,   nil,   -25,   -65,    15,    13,   -59,    27,
-   -55,   -34,    24,    -9,    45,   -59,  -111,    -7,   -85,   nil,
-   nil,   nil,  -102,    -3,   -69,    10,   -59,    25,   -52,    27,
-   -51,    56,    57,    28,   -27,   -57,   -10,   -19,    24,  -103,
-  -140,  -156,     8,   -87,   -33,   nil,  -170,  -180,   -91,   -88,
-  -123,    -9,   -30,     4,   -49,    54,   -25,   -67,   -70,   -33,
-   nil,    18,   -40,  -143,   -80,  -115,   -11,  -165 ]
+   nil,    13,   nil,   nil,   -21,   -48,    17,    13,   -47,    53,
+   -28,   -39,    48,    16,    16,   -37,   -90,    10,   -68,   nil,
+   nil,   nil,  -142,    11,   -61,    18,   -60,    19,   -58,    23,
+   -53,    54,    54,    18,   nil,   -23,   -10,   -22,    21,  -103,
+  -140,  -156,     5,   -89,   -33,   nil,  -172,  -193,   -91,   -91,
+  -128,   -13,   -30,     0,   -52,    50,   -30,   -67,   -70,   -37,
+   nil,    13,   -45,  -140,   -84,  -119,   -14,  -167 ]
 
 racc_goto_default = [
    nil,   nil,     2,     8,   nil,   nil,   nil,   nil,   nil,   nil,
    nil,    10,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    21,
     22,    23,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    68,    74,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,    66,   nil,    74,   nil,   nil,   nil,
    nil,   nil,    92,   163,   197,   128,   nil,   nil,   nil,   nil,
    nil,    75,   nil,   nil,   nil,   nil,   nil,    78,    80,   nil,
     90,   nil,   nil,   nil,   nil,   nil,   nil,   196 ]
@@ -967,14 +967,14 @@ racc_reduce_table = [
   2, 74, :_reduce_50,
   2, 74, :_reduce_51,
   2, 74, :_reduce_52,
-  1, 86, :_reduce_53,
-  2, 86, :_reduce_54,
-  3, 86, :_reduce_55,
-  1, 89, :_reduce_56,
-  2, 89, :_reduce_57,
+  1, 90, :_reduce_53,
+  2, 90, :_reduce_54,
+  1, 86, :_reduce_55,
+  2, 86, :_reduce_56,
+  3, 86, :_reduce_57,
   0, 93, :_reduce_none,
   1, 93, :_reduce_none,
-  3, 90, :_reduce_60,
+  3, 89, :_reduce_60,
   0, 96, :_reduce_none,
   1, 96, :_reduce_none,
   8, 75, :_reduce_63,
@@ -1230,8 +1230,8 @@ Racc_token_to_s_table = [
   "token_declarations",
   "symbol_declarations",
   "token_declarations_for_precedence",
-  "token_declaration_list",
   "token_declaration",
+  "\"-many1@token_declaration\"",
   "id",
   "alias",
   "\"-option@INTEGER\"",
@@ -1657,8 +1657,22 @@ module_eval(<<'.,.,', 'parser.y', 198)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 209)
+module_eval(<<'.,.,', 'parser.y', 227)
   def _reduce_53(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 227)
+  def _reduce_54(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 209)
+  def _reduce_55(val, _values, result)
                               val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
                           }
@@ -1668,7 +1682,7 @@ module_eval(<<'.,.,', 'parser.y', 209)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 215)
-  def _reduce_54(val, _values, result)
+  def _reduce_56(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
@@ -1678,7 +1692,7 @@ module_eval(<<'.,.,', 'parser.y', 215)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 221)
-  def _reduce_55(val, _values, result)
+  def _reduce_57(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
@@ -1687,25 +1701,11 @@ module_eval(<<'.,.,', 'parser.y', 221)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 226)
-  def _reduce_56(val, _values, result)
-     result = [val[0]]
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 227)
-  def _reduce_57(val, _values, result)
-     result = val[0].append(val[1])
-    result
-  end
-.,.,
-
 # reduce 58 omitted
 
 # reduce 59 omitted
 
-module_eval(<<'.,.,', 'parser.y', 229)
+module_eval(<<'.,.,', 'parser.y', 226)
   def _reduce_60(val, _values, result)
      result = val
     result
@@ -1716,7 +1716,7 @@ module_eval(<<'.,.,', 'parser.y', 229)
 
 # reduce 62 omitted
 
-module_eval(<<'.,.,', 'parser.y', 233)
+module_eval(<<'.,.,', 'parser.y', 230)
   def _reduce_63(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
@@ -1725,7 +1725,7 @@ module_eval(<<'.,.,', 'parser.y', 233)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 239)
+module_eval(<<'.,.,', 'parser.y', 236)
   def _reduce_64(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
@@ -1734,7 +1734,7 @@ module_eval(<<'.,.,', 'parser.y', 239)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 244)
+module_eval(<<'.,.,', 'parser.y', 241)
   def _reduce_65(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
@@ -1743,21 +1743,21 @@ module_eval(<<'.,.,', 'parser.y', 244)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 248)
+module_eval(<<'.,.,', 'parser.y', 245)
   def _reduce_66(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 249)
+module_eval(<<'.,.,', 'parser.y', 246)
   def _reduce_67(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 253)
+module_eval(<<'.,.,', 'parser.y', 250)
   def _reduce_68(val, _values, result)
                       builder = val[0]
                   result = [builder]
@@ -1766,7 +1766,7 @@ module_eval(<<'.,.,', 'parser.y', 253)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 258)
+module_eval(<<'.,.,', 'parser.y', 255)
   def _reduce_69(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
@@ -1779,7 +1779,7 @@ module_eval(<<'.,.,', 'parser.y', 258)
 
 # reduce 71 omitted
 
-module_eval(<<'.,.,', 'parser.y', 264)
+module_eval(<<'.,.,', 'parser.y', 261)
   def _reduce_72(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
@@ -1788,7 +1788,7 @@ module_eval(<<'.,.,', 'parser.y', 264)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 269)
+module_eval(<<'.,.,', 'parser.y', 266)
   def _reduce_73(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
@@ -1797,7 +1797,7 @@ module_eval(<<'.,.,', 'parser.y', 269)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 274)
+module_eval(<<'.,.,', 'parser.y', 271)
   def _reduce_74(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
@@ -1809,7 +1809,7 @@ module_eval(<<'.,.,', 'parser.y', 274)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 282)
+module_eval(<<'.,.,', 'parser.y', 279)
   def _reduce_75(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
@@ -1819,7 +1819,7 @@ module_eval(<<'.,.,', 'parser.y', 282)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 288)
+module_eval(<<'.,.,', 'parser.y', 285)
   def _reduce_76(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
@@ -1829,7 +1829,7 @@ module_eval(<<'.,.,', 'parser.y', 288)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 294)
+module_eval(<<'.,.,', 'parser.y', 291)
   def _reduce_77(val, _values, result)
                   if @prec_seen
                 on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
@@ -1841,7 +1841,7 @@ module_eval(<<'.,.,', 'parser.y', 294)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 302)
+module_eval(<<'.,.,', 'parser.y', 299)
   def _reduce_78(val, _values, result)
                   end_c_declaration
 
@@ -1849,7 +1849,7 @@ module_eval(<<'.,.,', 'parser.y', 302)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 306)
+module_eval(<<'.,.,', 'parser.y', 303)
   def _reduce_79(val, _values, result)
                   user_code = val[3]
               user_code.alias_name = val[6]
@@ -1861,7 +1861,7 @@ module_eval(<<'.,.,', 'parser.y', 306)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 314)
+module_eval(<<'.,.,', 'parser.y', 311)
   def _reduce_80(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
@@ -1875,14 +1875,14 @@ module_eval(<<'.,.,', 'parser.y', 314)
 
 # reduce 81 omitted
 
-module_eval(<<'.,.,', 'parser.y', 322)
+module_eval(<<'.,.,', 'parser.y', 319)
   def _reduce_82(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 326)
+module_eval(<<'.,.,', 'parser.y', 323)
   def _reduce_83(val, _values, result)
                                result = [{tag: nil, tokens: val[0]}]
 
@@ -1890,7 +1890,7 @@ module_eval(<<'.,.,', 'parser.y', 326)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 330)
+module_eval(<<'.,.,', 'parser.y', 327)
   def _reduce_84(val, _values, result)
                                result = [{tag: val[0], tokens: val[1]}]
 
@@ -1898,7 +1898,7 @@ module_eval(<<'.,.,', 'parser.y', 330)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 334)
+module_eval(<<'.,.,', 'parser.y', 331)
   def _reduce_85(val, _values, result)
                              result = val[0].append({tag: val[1], tokens: val[2]})
 
@@ -1906,14 +1906,14 @@ module_eval(<<'.,.,', 'parser.y', 334)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 337)
+module_eval(<<'.,.,', 'parser.y', 334)
   def _reduce_86(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 338)
+module_eval(<<'.,.,', 'parser.y', 335)
   def _reduce_87(val, _values, result)
      result = val[0].append(val[1])
     result
@@ -1924,7 +1924,7 @@ module_eval(<<'.,.,', 'parser.y', 338)
 
 # reduce 89 omitted
 
-module_eval(<<'.,.,', 'parser.y', 345)
+module_eval(<<'.,.,', 'parser.y', 342)
   def _reduce_90(val, _values, result)
                   begin_c_declaration("}")
 
@@ -1932,7 +1932,7 @@ module_eval(<<'.,.,', 'parser.y', 345)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 349)
+module_eval(<<'.,.,', 'parser.y', 346)
   def _reduce_91(val, _values, result)
                   end_c_declaration
 
@@ -1940,7 +1940,7 @@ module_eval(<<'.,.,', 'parser.y', 349)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 353)
+module_eval(<<'.,.,', 'parser.y', 350)
   def _reduce_92(val, _values, result)
                   result = val[0].append(val[3])
 
@@ -1948,7 +1948,7 @@ module_eval(<<'.,.,', 'parser.y', 353)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 357)
+module_eval(<<'.,.,', 'parser.y', 354)
   def _reduce_93(val, _values, result)
                   begin_c_declaration("}")
 
@@ -1956,7 +1956,7 @@ module_eval(<<'.,.,', 'parser.y', 357)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 361)
+module_eval(<<'.,.,', 'parser.y', 358)
   def _reduce_94(val, _values, result)
                   end_c_declaration
 
@@ -1964,7 +1964,7 @@ module_eval(<<'.,.,', 'parser.y', 361)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 365)
+module_eval(<<'.,.,', 'parser.y', 362)
   def _reduce_95(val, _values, result)
                   result = [val[2]]
 
@@ -1972,7 +1972,7 @@ module_eval(<<'.,.,', 'parser.y', 365)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 370)
+module_eval(<<'.,.,', 'parser.y', 367)
   def _reduce_96(val, _values, result)
                                              result = [{tag: nil, tokens: val[0]}]
 
@@ -1980,7 +1980,7 @@ module_eval(<<'.,.,', 'parser.y', 370)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 374)
+module_eval(<<'.,.,', 'parser.y', 371)
   def _reduce_97(val, _values, result)
                                              result = [{tag: val[0], tokens: val[1]}]
 
@@ -1988,7 +1988,7 @@ module_eval(<<'.,.,', 'parser.y', 374)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 378)
+module_eval(<<'.,.,', 'parser.y', 375)
   def _reduce_98(val, _values, result)
                                              result = val[0].append({tag: val[1], tokens: val[2]})
 
@@ -1996,14 +1996,14 @@ module_eval(<<'.,.,', 'parser.y', 378)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 381)
+module_eval(<<'.,.,', 'parser.y', 378)
   def _reduce_99(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 382)
+module_eval(<<'.,.,', 'parser.y', 379)
   def _reduce_100(val, _values, result)
      result = val[0].append(val[1])
     result
@@ -2012,14 +2012,14 @@ module_eval(<<'.,.,', 'parser.y', 382)
 
 # reduce 101 omitted
 
-module_eval(<<'.,.,', 'parser.y', 386)
+module_eval(<<'.,.,', 'parser.y', 383)
   def _reduce_102(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 387)
+module_eval(<<'.,.,', 'parser.y', 384)
   def _reduce_103(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
@@ -2038,7 +2038,7 @@ module_eval(<<'.,.,', 'parser.y', 387)
 
 # reduce 109 omitted
 
-module_eval(<<'.,.,', 'parser.y', 397)
+module_eval(<<'.,.,', 'parser.y', 394)
   def _reduce_110(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
@@ -2052,7 +2052,7 @@ module_eval(<<'.,.,', 'parser.y', 397)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 408)
+module_eval(<<'.,.,', 'parser.y', 405)
   def _reduce_111(val, _values, result)
                     builder = val[0]
                 if !builder.line
@@ -2064,7 +2064,7 @@ module_eval(<<'.,.,', 'parser.y', 408)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 416)
+module_eval(<<'.,.,', 'parser.y', 413)
   def _reduce_112(val, _values, result)
                     builder = val[2]
                 if !builder.line
@@ -2076,7 +2076,7 @@ module_eval(<<'.,.,', 'parser.y', 416)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 425)
+module_eval(<<'.,.,', 'parser.y', 422)
   def _reduce_113(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -2085,7 +2085,7 @@ module_eval(<<'.,.,', 'parser.y', 425)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 430)
+module_eval(<<'.,.,', 'parser.y', 427)
   def _reduce_114(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -2094,7 +2094,7 @@ module_eval(<<'.,.,', 'parser.y', 430)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 435)
+module_eval(<<'.,.,', 'parser.y', 432)
   def _reduce_115(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
@@ -2106,7 +2106,7 @@ module_eval(<<'.,.,', 'parser.y', 435)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 443)
+module_eval(<<'.,.,', 'parser.y', 440)
   def _reduce_116(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
@@ -2118,7 +2118,7 @@ module_eval(<<'.,.,', 'parser.y', 443)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 451)
+module_eval(<<'.,.,', 'parser.y', 448)
   def _reduce_117(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
@@ -2130,7 +2130,7 @@ module_eval(<<'.,.,', 'parser.y', 451)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 459)
+module_eval(<<'.,.,', 'parser.y', 456)
   def _reduce_118(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
@@ -2142,7 +2142,7 @@ module_eval(<<'.,.,', 'parser.y', 459)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 467)
+module_eval(<<'.,.,', 'parser.y', 464)
   def _reduce_119(val, _values, result)
                end_c_declaration
 
@@ -2150,7 +2150,7 @@ module_eval(<<'.,.,', 'parser.y', 467)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 471)
+module_eval(<<'.,.,', 'parser.y', 468)
   def _reduce_120(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
@@ -2163,7 +2163,7 @@ module_eval(<<'.,.,', 'parser.y', 471)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 480)
+module_eval(<<'.,.,', 'parser.y', 477)
   def _reduce_121(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
@@ -2175,56 +2175,56 @@ module_eval(<<'.,.,', 'parser.y', 480)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 487)
+module_eval(<<'.,.,', 'parser.y', 484)
   def _reduce_122(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 488)
+module_eval(<<'.,.,', 'parser.y', 485)
   def _reduce_123(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 489)
+module_eval(<<'.,.,', 'parser.y', 486)
   def _reduce_124(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 491)
+module_eval(<<'.,.,', 'parser.y', 488)
   def _reduce_125(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 492)
+module_eval(<<'.,.,', 'parser.y', 489)
   def _reduce_126(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 493)
+module_eval(<<'.,.,', 'parser.y', 490)
   def _reduce_127(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 494)
+module_eval(<<'.,.,', 'parser.y', 491)
   def _reduce_128(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 496)
+module_eval(<<'.,.,', 'parser.y', 493)
   def _reduce_129(val, _values, result)
      result = val[1].s_value
     result
@@ -2233,7 +2233,7 @@ module_eval(<<'.,.,', 'parser.y', 496)
 
 # reduce 130 omitted
 
-module_eval(<<'.,.,', 'parser.y', 502)
+module_eval(<<'.,.,', 'parser.y', 499)
   def _reduce_131(val, _values, result)
                     begin_c_declaration('\Z')
                 @grammar.epilogue_first_lineno = @lexer.line + 1
@@ -2242,7 +2242,7 @@ module_eval(<<'.,.,', 'parser.y', 502)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 507)
+module_eval(<<'.,.,', 'parser.y', 504)
   def _reduce_132(val, _values, result)
                     end_c_declaration
                 @grammar.epilogue = val[2].s_value
@@ -2261,14 +2261,14 @@ module_eval(<<'.,.,', 'parser.y', 507)
 
 # reduce 137 omitted
 
-module_eval(<<'.,.,', 'parser.y', 518)
+module_eval(<<'.,.,', 'parser.y', 515)
   def _reduce_138(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 519)
+module_eval(<<'.,.,', 'parser.y', 516)
   def _reduce_139(val, _values, result)
      result = val[0].append(val[1])
     result
@@ -2279,7 +2279,7 @@ module_eval(<<'.,.,', 'parser.y', 519)
 
 # reduce 141 omitted
 
-module_eval(<<'.,.,', 'parser.y', 524)
+module_eval(<<'.,.,', 'parser.y', 521)
   def _reduce_142(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 425)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 418)
 
 include Lrama::Report::Duration
 
@@ -728,15 +728,15 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    94,    48,    95,   165,    48,    77,   171,    48,    77,   165,
-    48,    77,   171,     6,    77,    85,    48,     4,    47,     5,
-    48,    69,    47,    40,    77,    74,    48,    48,    47,    47,
-    41,    81,    81,    48,    44,    47,    92,    48,    81,    47,
-    45,    48,    81,    47,   167,   168,   116,   174,   168,    96,
-   167,   168,    86,   174,   168,    20,    24,    25,    26,    27,
+    94,    48,    95,   166,    48,    77,   172,    48,    77,   166,
+    48,    77,   172,    48,    77,    47,     6,    85,    69,    48,
+    48,    47,    47,    77,    74,    81,    48,    48,    47,    47,
+    40,    81,    81,    48,    41,    47,    92,    48,    81,    47,
+    44,    77,   103,   168,   169,    45,   175,   169,    96,   168,
+   169,    52,   175,   169,    86,    20,    24,    25,    26,    27,
     28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
     38,    92,    48,     4,    47,     5,    77,   103,    48,    48,
-    47,    47,    77,   103,    48,    48,    47,    47,    77,   103,
+    47,    47,    77,   103,   116,    48,     4,    47,     5,    77,
     20,    24,    25,    26,    27,    28,    29,    30,    31,    32,
     33,    34,    35,    36,    37,    38,    11,    12,    13,    14,
     15,    16,    17,    18,    19,    52,    20,    24,    25,    26,
@@ -745,147 +745,147 @@ racc_action_table = [
     19,    43,    20,    24,    25,    26,    27,    28,    29,    30,
     31,    32,    33,    34,    35,    36,    37,    38,    48,    48,
     47,    47,    77,   103,    48,    48,    47,    47,    77,    77,
-    48,    48,    47,    47,    77,    77,    48,    48,    47,   195,
-    77,    77,    48,    48,   195,    47,    77,    77,    48,    52,
-   195,   148,    77,   169,   149,    52,   149,   179,   180,   181,
-   131,   179,   180,   181,   131,   202,   207,   214,   203,   203,
-   203,    48,    48,    47,    47,    48,    48,    47,    47,   179,
-   180,   181,   119,   120,    55,    52,    52,    52,    52,    52,
+    48,    48,    47,    47,    77,    77,    48,    48,   196,   196,
+    77,    77,    48,    48,    47,   196,    77,    77,   148,   170,
+    52,   149,   149,   180,   181,   182,   131,   180,   181,   182,
+   131,   203,   208,   215,   204,   204,   204,    48,    48,    47,
+    47,    48,    48,    47,    47,    48,    48,    47,    47,   180,
+   181,   182,   119,   120,    55,    52,    52,    52,    52,    52,
     61,    62,    63,    64,    65,    87,    52,    52,   106,   109,
    111,   118,   125,   126,   128,   131,   132,    77,   140,   141,
-   142,   143,   145,   146,   152,   140,   154,   157,   158,   159,
-   160,   162,   163,   170,   175,   152,   182,   131,   186,   157,
-   188,   131,   152,   197,   152,   131,   160,   163,   204,   163,
-   160,   160,   212,   131,   160 ]
+   142,   143,   145,   146,   153,   140,   155,   153,   159,   160,
+   161,   163,   164,   171,   176,   153,   183,   131,   187,   153,
+   189,   131,   153,   198,   153,   131,   161,   164,   205,   164,
+   161,   161,   213,   131,   161 ]
 
 racc_action_check = [
-    46,   151,    46,   151,   156,   151,   156,   176,   156,   176,
-   187,   176,   187,     1,   187,    38,    32,     0,    32,     0,
-    33,    32,    33,     5,    33,    33,    34,    35,    34,    35,
-     6,    34,    35,    36,     9,    36,    44,    37,    36,    37,
-    11,    79,    37,    79,   151,   151,    79,   156,   156,    46,
-   176,   176,    38,   187,   187,    44,    44,    44,    44,    44,
+    46,   151,    46,   151,   157,   151,   157,   177,   157,   177,
+   188,   177,   188,    32,   188,    32,     1,    38,    32,    33,
+    34,    33,    34,    33,    33,    34,    35,    36,    35,    36,
+     5,    35,    36,    37,     6,    37,    44,    58,    37,    58,
+     9,    58,    58,   151,   151,    11,   157,   157,    46,   177,
+   177,    13,   188,   188,    38,    44,    44,    44,    44,    44,
     44,    44,    44,    44,    44,    44,    44,    44,    44,    44,
-    44,    88,    58,     2,    58,     2,    58,    58,    59,    12,
-    59,    12,    59,    59,    60,    67,    60,    67,    60,    60,
+    44,    88,    59,     0,    59,     0,    59,    59,    60,    79,
+    60,    79,    60,    60,    79,    72,     2,    72,     2,    72,
     88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
     88,    88,    88,    88,    88,    88,     3,     3,     3,     3,
-     3,     3,     3,     3,     3,    13,     3,     3,     3,     3,
+     3,     3,     3,     3,     3,    14,     3,     3,     3,     3,
      3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
      3,     3,     8,     8,     8,     8,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
-     8,     8,     8,     8,     8,     8,     8,     8,   100,    69,
-   100,    69,   100,   100,    72,    74,    72,    74,    72,    74,
-   111,   167,   111,   167,   111,   167,   174,   182,   174,   182,
-   174,   182,   188,   203,   188,   203,   188,   203,   204,    14,
-   204,   139,   204,   153,   139,    15,   153,   164,   164,   164,
-   164,   172,   172,   172,   172,   194,   199,   211,   194,   199,
-   211,    81,   106,    81,   106,   114,   116,   114,   116,   196,
-   196,   196,    86,    86,    16,    17,    20,    24,    25,    26,
+     8,     8,     8,     8,     8,     8,     8,     8,   100,    12,
+   100,    12,   100,   100,    74,   111,    74,   111,    74,   111,
+   168,   175,   168,   175,   168,   175,   183,   189,   183,   189,
+   183,   189,   204,   205,   204,   205,   204,   205,   139,   154,
+    15,   139,   154,   165,   165,   165,   165,   173,   173,   173,
+   173,   195,   200,   212,   195,   200,   212,    67,    69,    67,
+    69,    81,   106,    81,   106,   114,   116,   114,   116,   197,
+   197,   197,    86,    86,    16,    17,    20,    24,    25,    26,
     27,    28,    29,    30,    31,    39,    50,    55,    66,    70,
     71,    85,    89,    90,    91,    92,    98,   110,   118,   119,
    120,   121,   130,   131,   141,   142,   144,   145,   146,   147,
-   148,   149,   150,   155,   161,   163,   165,   166,   169,   170,
-   171,   173,   175,   185,   186,   190,   191,   193,   195,   198,
-   200,   202,   206,   207,   213 ]
+   148,   149,   150,   156,   162,   164,   166,   167,   170,   171,
+   172,   174,   176,   186,   187,   191,   192,   194,   196,   199,
+   201,   203,   207,   208,   214 ]
 
 racc_action_pointer = [
-     7,    13,    63,    93,   nil,    16,    30,   nil,   119,    25,
-   nil,    34,    76,    68,   142,   148,   219,   178,   nil,   nil,
-   179,   nil,   nil,   nil,   180,   181,   182,   225,   226,   227,
-   228,   229,    13,    17,    23,    24,    30,    34,    10,   233,
+    63,    16,    76,    93,   nil,    23,    34,   nil,   119,    31,
+   nil,    39,   156,     5,    69,   144,   219,   179,   nil,   nil,
+   180,   nil,   nil,   nil,   181,   182,   183,   225,   226,   227,
+   228,   229,    10,    16,    17,    23,    24,    30,    12,   233,
    nil,   nil,   nil,   nil,    32,   nil,    -5,   nil,   nil,   nil,
-   189,   nil,   nil,   nil,   nil,   190,   nil,   nil,    69,    75,
-    81,   nil,   nil,   nil,   nil,   nil,   230,    82,   nil,   156,
-   233,   232,   161,   nil,   162,   nil,   nil,   nil,   nil,    38,
+   190,   nil,   nil,   nil,   nil,   191,   nil,   nil,    34,    69,
+    75,   nil,   nil,   nil,   nil,   nil,   230,   204,   nil,   205,
+   233,   232,    82,   nil,   161,   nil,   nil,   nil,   nil,    76,
    nil,   208,   nil,   nil,   nil,   202,   218,   nil,    67,   233,
-   221,   222,   193,   nil,   nil,   nil,   nil,   nil,   244,   nil,
+   221,   222,   194,   nil,   nil,   nil,   nil,   nil,   244,   nil,
    155,   nil,   nil,   nil,   nil,   nil,   209,   nil,   nil,   nil,
-   240,   167,   nil,   nil,   212,   nil,   213,   nil,   243,   208,
+   240,   162,   nil,   nil,   212,   nil,   213,   nil,   243,   208,
    211,   240,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   211,   248,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   151,
-   nil,   209,   250,   nil,   254,   212,   205,   211,   252,   256,
-   218,    -2,   nil,   153,   nil,   219,     1,   nil,   nil,   nil,
-   nil,   223,   nil,   220,   148,   227,   215,   168,   nil,   227,
-   224,   231,   152,   219,   173,   227,     4,   nil,   nil,   nil,
-   nil,   nil,   174,   nil,   nil,   271,   229,     7,   179,   nil,
-   223,   268,   nil,   233,   165,   239,   170,   nil,   235,   166,
-   272,   nil,   273,   180,   185,   nil,   234,   231,   nil,   nil,
-   nil,   167,   nil,   276,   nil,   nil ]
+   211,   248,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   148,
+   nil,   200,   250,   nil,   254,   203,   206,   212,   252,   256,
+   218,    -2,   nil,   nil,   149,   nil,   219,     1,   nil,   nil,
+   nil,   nil,   223,   nil,   211,   145,   227,   216,   167,   nil,
+   227,   215,   231,   149,   220,   168,   218,     4,   nil,   nil,
+   nil,   nil,   nil,   173,   nil,   nil,   271,   220,     7,   174,
+   nil,   224,   268,   nil,   233,   161,   239,   171,   nil,   235,
+   162,   272,   nil,   273,   179,   180,   nil,   235,   232,   nil,
+   nil,   nil,   163,   nil,   276,   nil,   nil ]
 
 racc_action_default = [
     -1,  -127,    -1,    -3,   -10,  -127,  -127,    -2,    -3,  -127,
    -16,  -127,  -127,  -127,  -127,  -127,  -127,  -127,   -24,   -25,
   -127,   -30,   -31,   -32,  -127,  -127,  -127,  -127,  -127,  -127,
   -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
-   -13,   216,    -4,   -26,  -127,   -17,  -120,   -90,   -91,  -119,
-   -14,   -19,   -82,   -20,   -21,  -127,   -23,   -29,  -127,  -127,
+   -13,   217,    -4,   -26,  -127,   -17,  -118,   -89,   -90,  -117,
+   -14,   -19,   -81,   -20,   -21,  -127,   -23,   -29,  -127,  -127,
   -127,   -36,   -37,   -38,   -39,   -40,   -41,   -47,   -49,  -127,
-   -52,   -42,   -75,   -77,  -127,   -80,   -81,  -126,   -43,   -85,
-   -87,  -127,   -44,   -45,   -46,  -127,  -127,   -11,    -5,    -7,
-   -92,  -127,   -64,   -18,  -121,  -122,  -123,   -15,  -127,   -22,
-   -27,   -33,  -124,  -125,   -34,   -35,  -127,   -48,   -50,   -53,
-   -73,  -127,   -76,   -78,   -85,   -86,  -127,   -88,  -127,  -127,
-  -127,  -127,    -6,    -8,    -9,  -117,   -93,   -94,   -95,   -65,
-  -127,  -127,   -83,   -28,   -51,   -54,   -74,   -79,   -89,  -127,
-   -60,   -66,  -127,   -12,  -127,   -99,  -127,  -127,   -55,  -127,
-   -58,   -62,   -67,  -127,  -118,   -96,   -97,  -100,  -116,   -84,
-   -56,  -127,   -61,   -66,   -64,   -90,   -64,  -127,  -113,  -127,
-   -99,   -90,   -64,   -64,  -127,   -66,   -63,   -68,   -69,  -106,
-  -107,  -108,  -127,   -71,   -72,  -127,   -66,   -98,  -127,  -101,
-   -64,   -55,  -105,   -57,  -127,   -90,  -109,  -114,   -59,  -127,
-   -55,  -104,   -55,  -127,  -127,  -111,  -127,   -64,  -102,   -70,
-  -110,  -127,  -115,   -55,  -112,  -103 ]
+   -52,   -42,   -74,   -76,  -127,   -79,   -80,  -126,   -43,   -84,
+   -86,  -127,   -44,   -45,   -46,  -127,  -127,   -11,    -5,    -7,
+   -91,  -127,   -64,   -18,  -119,  -120,  -121,   -15,  -127,   -22,
+   -27,   -33,  -122,  -123,   -34,   -35,  -127,   -48,   -50,   -53,
+   -72,  -127,   -75,   -77,   -84,   -85,  -127,   -87,  -127,  -127,
+  -127,  -127,    -6,    -8,    -9,  -115,   -92,   -93,   -94,   -65,
+  -127,  -127,   -82,   -28,   -51,   -54,   -73,   -78,   -88,  -127,
+   -60,  -124,  -127,   -12,  -127,  -124,  -127,  -127,   -55,  -127,
+   -58,   -62,   -66,  -125,  -127,  -116,   -95,   -96,   -98,  -114,
+   -83,   -56,  -127,   -61,  -124,   -64,   -89,   -64,  -127,  -111,
+  -127,  -124,   -89,   -64,   -64,  -127,  -124,   -63,   -67,   -68,
+  -104,  -105,  -106,  -127,   -70,   -71,  -127,  -124,   -97,  -127,
+   -99,   -64,   -55,  -103,   -57,  -127,   -89,  -107,  -112,   -59,
+  -127,   -55,  -102,   -55,  -127,  -127,  -109,  -127,   -64,  -100,
+   -69,  -108,  -127,  -113,   -55,  -110,  -101 ]
 
 racc_goto_table = [
-   102,   102,   102,    49,   130,    73,    68,    89,   156,   161,
-    91,   150,     1,   101,   104,   105,    51,    53,    54,   173,
-   123,   124,   115,    70,   117,    79,    79,    79,    79,    56,
-     9,    39,    57,   187,   121,    42,    58,    59,    60,   178,
-   139,   107,   102,   108,   112,   193,   113,   190,    46,    93,
-   173,   122,   201,    97,    91,   133,   198,   115,    70,   138,
-    70,   208,    66,   209,   153,    71,     3,    99,     7,   194,
-   114,   205,   114,   135,   215,   199,   177,   110,   183,   176,
-   134,   136,    98,   137,   189,   191,    78,    82,    83,    84,
-   147,   211,   127,   164,   155,   185,   206,    70,   172,   144,
-   nil,   nil,   200,   nil,   nil,   114,   nil,   114,   nil,   184,
-   nil,   nil,   nil,   nil,   nil,   nil,   192,   nil,   164,   213,
-   nil,   nil,   nil,   nil,   196,   nil,   nil,   nil,   nil,   172,
-   196,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   210,   196 ]
+   102,   102,   102,    49,   130,    73,    68,    89,   162,    91,
+   150,   139,   101,   104,   105,     1,     9,   174,    51,    53,
+    54,    42,   115,    70,   117,    79,    79,    79,    79,    56,
+   123,     3,    57,     7,   124,   154,    58,    59,    60,   179,
+   158,   107,   102,   108,   112,   194,   113,   191,   174,   157,
+    39,   122,   202,    91,   133,    97,   199,   115,    70,   138,
+    70,   209,   195,   210,   121,    46,   158,    99,   200,    93,
+   114,   206,   114,    66,   216,   188,    71,   178,   135,   184,
+   134,   110,   177,   137,   212,   190,   192,    78,    82,    83,
+    84,   136,    98,   165,   147,   127,   156,    70,   186,   173,
+   207,   144,   nil,   201,   nil,   114,   nil,   114,   nil,   nil,
+   185,   nil,   nil,   nil,   nil,   nil,   nil,   193,   nil,   165,
+   214,   nil,   nil,   nil,   nil,   197,   nil,   nil,   nil,   nil,
+   173,   197,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   211,   197 ]
 
 racc_goto_check = [
-    34,    34,    34,    27,    39,    41,    26,     8,    48,    32,
-    12,    31,     1,    21,    21,    21,    16,    16,    16,    38,
-     5,     9,    44,    27,    44,    27,    27,    27,    27,    15,
-     7,    10,    15,    48,    11,     7,    15,    15,    15,    36,
-    30,    26,    34,    26,    41,    31,    41,    36,    13,    14,
-    38,     8,    32,    16,    12,    21,    31,    44,    27,    44,
-    27,    32,    22,    32,    30,    23,     6,    15,     6,    37,
-    27,    36,    27,    28,    32,    37,    39,    29,    39,    33,
-    26,    40,    42,    41,    39,    39,    24,    24,    24,    24,
-    43,    37,    46,    34,    47,    49,    50,    27,    34,    51,
-   nil,   nil,    39,   nil,   nil,    27,   nil,    27,   nil,    34,
-   nil,   nil,   nil,   nil,   nil,   nil,    34,   nil,    34,    39,
-   nil,   nil,   nil,   nil,    34,   nil,   nil,   nil,   nil,    34,
-    34,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    34,    34 ]
+    35,    35,    35,    27,    40,    42,    26,     8,    32,    12,
+    31,    30,    21,    21,    21,     1,     7,    39,    16,    16,
+    16,     7,    45,    27,    45,    27,    27,    27,    27,    15,
+     5,     6,    15,     6,     9,    30,    15,    15,    15,    37,
+    34,    26,    35,    26,    42,    31,    42,    37,    39,    49,
+    10,     8,    32,    12,    21,    16,    31,    45,    27,    45,
+    27,    32,    38,    32,    11,    13,    34,    15,    38,    14,
+    27,    37,    27,    22,    32,    49,    23,    40,    28,    40,
+    26,    29,    33,    42,    38,    40,    40,    24,    24,    24,
+    24,    41,    43,    35,    44,    47,    48,    27,    50,    35,
+    51,    52,   nil,    40,   nil,    27,   nil,    27,   nil,   nil,
+    35,   nil,   nil,   nil,   nil,   nil,   nil,    35,   nil,    35,
+    40,   nil,   nil,   nil,   nil,    35,   nil,   nil,   nil,   nil,
+    35,    35,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    35,    35 ]
 
 racc_goto_pointer = [
-   nil,    12,   nil,   nil,   nil,   -69,    66,    27,   -37,   -68,
-    27,   -53,   -34,    36,     3,    12,     3,   nil,   nil,   nil,
-   nil,   -45,    30,    32,    52,   nil,   -26,    -9,   -37,     7,
-   -78,  -130,  -139,   -84,   -58,   nil,  -125,  -113,  -137,   -88,
-   -29,   -28,    30,   -42,   -57,   nil,     2,   -51,  -137,   -73,
-  -101,   -26 ]
+   nil,    15,   nil,   nil,   nil,   -59,    31,    13,   -37,   -55,
+    46,   -23,   -35,    53,    23,    12,     5,   nil,   nil,   nil,
+   nil,   -46,    41,    43,    53,   nil,   -26,    -9,   -32,    11,
+  -107,  -131,  -140,   -82,  -105,   -58,   nil,  -126,  -121,  -140,
+   -88,   -19,   -28,    40,   -38,   -57,   nil,     5,   -49,   -96,
+   -71,   -98,   -24 ]
 
 racc_goto_default = [
    nil,   nil,     2,     8,    88,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,    10,   nil,   nil,    50,   nil,    21,    22,    23,
    100,   nil,   nil,   nil,   nil,    67,   nil,    75,   nil,   nil,
-   nil,   nil,   nil,   151,    72,   129,   nil,   nil,   166,   nil,
-    76,   nil,   nil,   nil,    80,    90,   nil,   nil,   nil,   nil,
-   nil,   nil ]
+   nil,   nil,   nil,   151,   152,    72,   129,   nil,   nil,   167,
+   nil,    76,   nil,   nil,   nil,    80,    90,   nil,   nil,   nil,
+   nil,   nil,   nil ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -952,61 +952,59 @@ racc_reduce_table = [
   3, 85, :_reduce_61,
   1, 86, :_reduce_62,
   3, 86, :_reduce_63,
-  0, 94, :_reduce_none,
-  1, 94, :_reduce_none,
-  0, 88, :_reduce_66,
-  1, 88, :_reduce_67,
+  0, 95, :_reduce_none,
+  1, 95, :_reduce_none,
+  1, 88, :_reduce_66,
+  3, 88, :_reduce_67,
   3, 88, :_reduce_68,
-  3, 88, :_reduce_69,
-  6, 88, :_reduce_70,
+  6, 88, :_reduce_69,
+  3, 88, :_reduce_70,
   3, 88, :_reduce_71,
-  3, 88, :_reduce_72,
   0, 83, :_reduce_none,
-  1, 83, :_reduce_74,
-  1, 96, :_reduce_75,
-  2, 96, :_reduce_76,
-  1, 78, :_reduce_77,
-  2, 78, :_reduce_78,
-  3, 78, :_reduce_79,
-  1, 89, :_reduce_none,
-  1, 89, :_reduce_none,
-  0, 97, :_reduce_82,
-  0, 98, :_reduce_83,
-  5, 70, :_reduce_84,
-  1, 99, :_reduce_85,
-  2, 99, :_reduce_86,
-  1, 79, :_reduce_87,
-  2, 79, :_reduce_88,
-  3, 79, :_reduce_89,
+  1, 83, :_reduce_73,
+  1, 97, :_reduce_74,
+  2, 97, :_reduce_75,
+  1, 78, :_reduce_76,
+  2, 78, :_reduce_77,
+  3, 78, :_reduce_78,
+  1, 90, :_reduce_none,
+  1, 90, :_reduce_none,
+  0, 98, :_reduce_81,
+  0, 99, :_reduce_82,
+  5, 70, :_reduce_83,
+  1, 100, :_reduce_84,
+  2, 100, :_reduce_85,
+  1, 79, :_reduce_86,
+  2, 79, :_reduce_87,
+  3, 79, :_reduce_88,
+  1, 82, :_reduce_89,
   1, 82, :_reduce_90,
-  1, 82, :_reduce_91,
-  0, 101, :_reduce_none,
-  1, 101, :_reduce_none,
+  0, 102, :_reduce_none,
+  1, 102, :_reduce_none,
   2, 59, :_reduce_none,
   2, 59, :_reduce_none,
-  4, 100, :_reduce_96,
-  1, 102, :_reduce_97,
-  3, 102, :_reduce_98,
-  0, 103, :_reduce_99,
-  1, 103, :_reduce_100,
-  3, 103, :_reduce_101,
-  5, 103, :_reduce_102,
-  7, 103, :_reduce_103,
-  4, 103, :_reduce_104,
-  3, 103, :_reduce_105,
-  1, 91, :_reduce_106,
-  1, 91, :_reduce_107,
-  1, 91, :_reduce_108,
-  1, 92, :_reduce_109,
-  3, 92, :_reduce_110,
-  2, 92, :_reduce_111,
-  4, 92, :_reduce_112,
-  0, 104, :_reduce_113,
-  0, 105, :_reduce_114,
-  5, 93, :_reduce_115,
-  3, 90, :_reduce_116,
-  0, 106, :_reduce_117,
-  3, 60, :_reduce_118,
+  4, 101, :_reduce_95,
+  1, 103, :_reduce_96,
+  3, 103, :_reduce_97,
+  1, 104, :_reduce_98,
+  3, 104, :_reduce_99,
+  5, 104, :_reduce_100,
+  7, 104, :_reduce_101,
+  4, 104, :_reduce_102,
+  3, 104, :_reduce_103,
+  1, 92, :_reduce_104,
+  1, 92, :_reduce_105,
+  1, 92, :_reduce_106,
+  1, 93, :_reduce_107,
+  3, 93, :_reduce_108,
+  2, 93, :_reduce_109,
+  4, 93, :_reduce_110,
+  0, 105, :_reduce_111,
+  0, 106, :_reduce_112,
+  5, 94, :_reduce_113,
+  3, 91, :_reduce_114,
+  0, 107, :_reduce_115,
+  3, 60, :_reduce_116,
   1, 68, :_reduce_none,
   0, 69, :_reduce_none,
   1, 69, :_reduce_none,
@@ -1014,11 +1012,13 @@ racc_reduce_table = [
   1, 69, :_reduce_none,
   1, 75, :_reduce_none,
   1, 75, :_reduce_none,
-  1, 95, :_reduce_126 ]
+  0, 89, :_reduce_none,
+  1, 89, :_reduce_none,
+  1, 96, :_reduce_126 ]
 
 racc_reduce_n = 127
 
-racc_shift_n = 216
+racc_shift_n = 217
 
 racc_token_table = {
   false => 0,
@@ -1066,16 +1066,16 @@ racc_token_table = {
   "%inline" => 42,
   "," => 43,
   "|" => 44,
-  "%empty" => 45,
-  "%prec" => 46,
-  "{" => 47,
-  "}" => 48,
-  "?" => 49,
-  "+" => 50,
-  "*" => 51,
-  "[" => 52,
-  "]" => 53,
-  "{...}" => 54 }
+  "%prec" => 45,
+  "{" => 46,
+  "}" => 47,
+  "?" => 48,
+  "+" => 49,
+  "*" => 50,
+  "[" => 51,
+  "]" => 52,
+  "{...}" => 53,
+  "%empty" => 54 }
 
 racc_nt_base = 55
 
@@ -1144,7 +1144,6 @@ Racc_token_to_s_table = [
   "\"%inline\"",
   "\",\"",
   "\"|\"",
-  "\"%empty\"",
   "\"%prec\"",
   "\"{\"",
   "\"}\"",
@@ -1154,6 +1153,7 @@ Racc_token_to_s_table = [
   "\"[\"",
   "\"]\"",
   "\"{...}\"",
+  "\"%empty\"",
   "$start",
   "input",
   "prologue_declaration",
@@ -1188,6 +1188,7 @@ Racc_token_to_s_table = [
   "rule_rhs_list",
   "\"-option@TAG\"",
   "rule_rhs",
+  "empty",
   "symbol",
   "named_ref",
   "parameterizing_suffix",
@@ -1678,15 +1679,6 @@ module_eval(<<'.,.,', 'parser.y', 213)
 
 module_eval(<<'.,.,', 'parser.y', 218)
   def _reduce_67(val, _values, result)
-                  reset_precs
-              result = Grammar::ParameterizingRule::Rhs.new
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 223)
-  def _reduce_68(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1697,8 +1689,8 @@ module_eval(<<'.,.,', 'parser.y', 223)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 231)
-  def _reduce_69(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 226)
+  def _reduce_68(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1707,8 +1699,8 @@ module_eval(<<'.,.,', 'parser.y', 231)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 237)
-  def _reduce_70(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 232)
+  def _reduce_69(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1717,8 +1709,8 @@ module_eval(<<'.,.,', 'parser.y', 237)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 243)
-  def _reduce_71(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 238)
+  def _reduce_70(val, _values, result)
                   user_code = val[1]
               user_code.alias_name = val[2]
               builder = val[0]
@@ -1729,8 +1721,8 @@ module_eval(<<'.,.,', 'parser.y', 243)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 251)
-  def _reduce_72(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 246)
+  def _reduce_71(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1741,126 +1733,128 @@ module_eval(<<'.,.,', 'parser.y', 251)
   end
 .,.,
 
-# reduce 73 omitted
+# reduce 72 omitted
 
-module_eval(<<'.,.,', 'parser.y', 259)
-  def _reduce_74(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 254)
+  def _reduce_73(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 266)
-  def _reduce_75(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 266)
-  def _reduce_76(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 261)
+  def _reduce_74(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 261)
-  def _reduce_77(val, _values, result)
+  def _reduce_75(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 256)
+  def _reduce_76(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 262)
-  def _reduce_78(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 257)
+  def _reduce_77(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 263)
-  def _reduce_79(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 258)
+  def _reduce_78(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
+# reduce 79 omitted
+
 # reduce 80 omitted
 
-# reduce 81 omitted
-
-module_eval(<<'.,.,', 'parser.y', 269)
-  def _reduce_82(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 264)
+  def _reduce_81(val, _values, result)
                    begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 273)
-  def _reduce_83(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 268)
+  def _reduce_82(val, _values, result)
                    end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 277)
-  def _reduce_84(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 272)
+  def _reduce_83(val, _values, result)
                    result = val[2]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 285)
-  def _reduce_85(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 285)
-  def _reduce_86(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 280)
+  def _reduce_84(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 280)
-  def _reduce_87(val, _values, result)
+  def _reduce_85(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 275)
+  def _reduce_86(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 281)
-  def _reduce_88(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 276)
+  def _reduce_87(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 282)
-  def _reduce_89(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 277)
+  def _reduce_88(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 284)
-  def _reduce_90(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 279)
+  def _reduce_89(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 285)
-  def _reduce_91(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 280)
+  def _reduce_90(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
+
+# reduce 91 omitted
 
 # reduce 92 omitted
 
@@ -1868,10 +1862,8 @@ module_eval(<<'.,.,', 'parser.y', 285)
 
 # reduce 94 omitted
 
-# reduce 95 omitted
-
-module_eval(<<'.,.,', 'parser.y', 293)
-  def _reduce_96(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 288)
+  def _reduce_95(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -1884,8 +1876,8 @@ module_eval(<<'.,.,', 'parser.y', 293)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 304)
-  def _reduce_97(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 299)
+  def _reduce_96(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -1896,8 +1888,8 @@ module_eval(<<'.,.,', 'parser.y', 304)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 312)
-  def _reduce_98(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 307)
+  def _reduce_97(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -1908,26 +1900,17 @@ module_eval(<<'.,.,', 'parser.y', 312)
   end
 .,.,
 
+module_eval(<<'.,.,', 'parser.y', 316)
+  def _reduce_98(val, _values, result)
+               reset_precs
+           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
+
+    result
+  end
+.,.,
+
 module_eval(<<'.,.,', 'parser.y', 321)
   def _reduce_99(val, _values, result)
-               reset_precs
-           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 326)
-  def _reduce_100(val, _values, result)
-               reset_precs
-           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 331)
-  def _reduce_101(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -1938,8 +1921,8 @@ module_eval(<<'.,.,', 'parser.y', 331)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 339)
-  def _reduce_102(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 329)
+  def _reduce_100(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -1950,8 +1933,8 @@ module_eval(<<'.,.,', 'parser.y', 339)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 347)
-  def _reduce_103(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 337)
+  def _reduce_101(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -1962,8 +1945,8 @@ module_eval(<<'.,.,', 'parser.y', 347)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 355)
-  def _reduce_104(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 345)
+  def _reduce_102(val, _values, result)
                user_code = val[1]
            user_code.alias_name = val[2]
            user_code.tag = val[3]
@@ -1975,8 +1958,8 @@ module_eval(<<'.,.,', 'parser.y', 355)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 364)
-  def _reduce_105(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 354)
+  def _reduce_103(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -1987,57 +1970,57 @@ module_eval(<<'.,.,', 'parser.y', 364)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 371)
-  def _reduce_106(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 361)
+  def _reduce_104(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 372)
-  def _reduce_107(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 362)
+  def _reduce_105(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 373)
-  def _reduce_108(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 363)
+  def _reduce_106(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 375)
-  def _reduce_109(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 365)
+  def _reduce_107(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 376)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 366)
+  def _reduce_108(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 377)
-  def _reduce_111(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 367)
+  def _reduce_109(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 378)
-  def _reduce_112(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 368)
+  def _reduce_110(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 382)
-  def _reduce_113(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 372)
+  def _reduce_111(val, _values, result)
                           if @prec_seen
                         on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                         @code_after_prec = true
@@ -2048,31 +2031,31 @@ module_eval(<<'.,.,', 'parser.y', 382)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 390)
-  def _reduce_114(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 380)
+  def _reduce_112(val, _values, result)
                           end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 394)
-  def _reduce_115(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 384)
+  def _reduce_113(val, _values, result)
                           result = val[2]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 397)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 387)
+  def _reduce_114(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 401)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 391)
+  def _reduce_115(val, _values, result)
                     begin_c_declaration('\Z')
                 @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2080,14 +2063,18 @@ module_eval(<<'.,.,', 'parser.y', 401)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 406)
-  def _reduce_118(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 396)
+  def _reduce_116(val, _values, result)
                     end_c_declaration
                 @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
+
+# reduce 117 omitted
+
+# reduce 118 omitted
 
 # reduce 119 omitted
 
@@ -2103,7 +2090,7 @@ module_eval(<<'.,.,', 'parser.y', 406)
 
 # reduce 125 omitted
 
-module_eval(<<'.,.,', 'parser.y', 420)
+module_eval(<<'.,.,', 'parser.y', 413)
   def _reduce_126(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 418)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 417)
 
 include Lrama::Report::Duration
 
@@ -1290,14 +1290,14 @@ module_eval(<<'.,.,', 'parser.y', 21)
 
 # reduce 13 omitted
 
-module_eval(<<'.,.,', 'parser.y', 55)
+module_eval(<<'.,.,', 'parser.y', 54)
   def _reduce_14(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 55)
+module_eval(<<'.,.,', 'parser.y', 54)
   def _reduce_15(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
@@ -1306,7 +1306,7 @@ module_eval(<<'.,.,', 'parser.y', 55)
 
 # reduce 16 omitted
 
-module_eval(<<'.,.,', 'parser.y', 27)
+module_eval(<<'.,.,', 'parser.y', 26)
   def _reduce_17(val, _values, result)
      @grammar.expect = val[1]
     result
@@ -1317,7 +1317,7 @@ module_eval(<<'.,.,', 'parser.y', 27)
 
 # reduce 19 omitted
 
-module_eval(<<'.,.,', 'parser.y', 32)
+module_eval(<<'.,.,', 'parser.y', 31)
   def _reduce_20(val, _values, result)
                              val[1].each {|token|
                            @grammar.lex_param = Grammar::Code::NoReferenceCode.new(type: :lex_param, token_code: token).token_code.s_value
@@ -1327,7 +1327,7 @@ module_eval(<<'.,.,', 'parser.y', 32)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 38)
+module_eval(<<'.,.,', 'parser.y', 37)
   def _reduce_21(val, _values, result)
                              val[1].each {|token|
                            @grammar.parse_param = Grammar::Code::NoReferenceCode.new(type: :parse_param, token_code: token).token_code.s_value
@@ -1337,7 +1337,7 @@ module_eval(<<'.,.,', 'parser.y', 38)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 44)
+module_eval(<<'.,.,', 'parser.y', 43)
   def _reduce_22(val, _values, result)
                              @grammar.add_percent_code(id: val[1], code: val[2])
 
@@ -1345,7 +1345,7 @@ module_eval(<<'.,.,', 'parser.y', 44)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 48)
+module_eval(<<'.,.,', 'parser.y', 47)
   def _reduce_23(val, _values, result)
                              @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[1])
 
@@ -1353,14 +1353,14 @@ module_eval(<<'.,.,', 'parser.y', 48)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 50)
+module_eval(<<'.,.,', 'parser.y', 49)
   def _reduce_24(val, _values, result)
      @grammar.no_stdlib = true
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 51)
+module_eval(<<'.,.,', 'parser.y', 50)
   def _reduce_25(val, _values, result)
      @grammar.locations = true
     result
@@ -1369,21 +1369,21 @@ module_eval(<<'.,.,', 'parser.y', 51)
 
 # reduce 26 omitted
 
-module_eval(<<'.,.,', 'parser.y', 110)
+module_eval(<<'.,.,', 'parser.y', 109)
   def _reduce_27(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 110)
+module_eval(<<'.,.,', 'parser.y', 109)
   def _reduce_28(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 56)
+module_eval(<<'.,.,', 'parser.y', 55)
   def _reduce_29(val, _values, result)
                                @grammar.set_union(
                              Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[1]),
@@ -1400,7 +1400,7 @@ module_eval(<<'.,.,', 'parser.y', 56)
 
 # reduce 32 omitted
 
-module_eval(<<'.,.,', 'parser.y', 66)
+module_eval(<<'.,.,', 'parser.y', 65)
   def _reduce_33(val, _values, result)
                                @grammar.add_destructor(
                              ident_or_tags: val[2],
@@ -1412,7 +1412,7 @@ module_eval(<<'.,.,', 'parser.y', 66)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 74)
+module_eval(<<'.,.,', 'parser.y', 73)
   def _reduce_34(val, _values, result)
                                @grammar.add_printer(
                              ident_or_tags: val[2],
@@ -1424,7 +1424,7 @@ module_eval(<<'.,.,', 'parser.y', 74)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 82)
+module_eval(<<'.,.,', 'parser.y', 81)
   def _reduce_35(val, _values, result)
                                @grammar.add_error_token(
                              ident_or_tags: val[2],
@@ -1436,7 +1436,7 @@ module_eval(<<'.,.,', 'parser.y', 82)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 90)
+module_eval(<<'.,.,', 'parser.y', 89)
   def _reduce_36(val, _values, result)
                                @grammar.after_shift = val[1]
 
@@ -1444,7 +1444,7 @@ module_eval(<<'.,.,', 'parser.y', 90)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 94)
+module_eval(<<'.,.,', 'parser.y', 93)
   def _reduce_37(val, _values, result)
                                @grammar.before_reduce = val[1]
 
@@ -1452,7 +1452,7 @@ module_eval(<<'.,.,', 'parser.y', 94)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 98)
+module_eval(<<'.,.,', 'parser.y', 97)
   def _reduce_38(val, _values, result)
                                @grammar.after_reduce = val[1]
 
@@ -1460,7 +1460,7 @@ module_eval(<<'.,.,', 'parser.y', 98)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 102)
+module_eval(<<'.,.,', 'parser.y', 101)
   def _reduce_39(val, _values, result)
                                @grammar.after_shift_error_token = val[1]
 
@@ -1468,7 +1468,7 @@ module_eval(<<'.,.,', 'parser.y', 102)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 106)
+module_eval(<<'.,.,', 'parser.y', 105)
   def _reduce_40(val, _values, result)
                                @grammar.after_pop_stack = val[1]
 
@@ -1478,7 +1478,7 @@ module_eval(<<'.,.,', 'parser.y', 106)
 
 # reduce 41 omitted
 
-module_eval(<<'.,.,', 'parser.y', 112)
+module_eval(<<'.,.,', 'parser.y', 111)
   def _reduce_42(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1490,7 +1490,7 @@ module_eval(<<'.,.,', 'parser.y', 112)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 120)
+module_eval(<<'.,.,', 'parser.y', 119)
   def _reduce_43(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1504,7 +1504,7 @@ module_eval(<<'.,.,', 'parser.y', 120)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 130)
+module_eval(<<'.,.,', 'parser.y', 129)
   def _reduce_44(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1518,7 +1518,7 @@ module_eval(<<'.,.,', 'parser.y', 130)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 140)
+module_eval(<<'.,.,', 'parser.y', 139)
   def _reduce_45(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1532,7 +1532,7 @@ module_eval(<<'.,.,', 'parser.y', 140)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 150)
+module_eval(<<'.,.,', 'parser.y', 149)
   def _reduce_46(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1546,21 +1546,21 @@ module_eval(<<'.,.,', 'parser.y', 150)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 179)
+module_eval(<<'.,.,', 'parser.y', 178)
   def _reduce_47(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 179)
+module_eval(<<'.,.,', 'parser.y', 178)
   def _reduce_48(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 161)
+module_eval(<<'.,.,', 'parser.y', 160)
   def _reduce_49(val, _values, result)
                               val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
@@ -1570,7 +1570,7 @@ module_eval(<<'.,.,', 'parser.y', 161)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 167)
+module_eval(<<'.,.,', 'parser.y', 166)
   def _reduce_50(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
@@ -1580,7 +1580,7 @@ module_eval(<<'.,.,', 'parser.y', 167)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 173)
+module_eval(<<'.,.,', 'parser.y', 172)
   def _reduce_51(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
@@ -1594,7 +1594,7 @@ module_eval(<<'.,.,', 'parser.y', 173)
 
 # reduce 53 omitted
 
-module_eval(<<'.,.,', 'parser.y', 178)
+module_eval(<<'.,.,', 'parser.y', 177)
   def _reduce_54(val, _values, result)
      result = val
     result
@@ -1605,7 +1605,7 @@ module_eval(<<'.,.,', 'parser.y', 178)
 
 # reduce 56 omitted
 
-module_eval(<<'.,.,', 'parser.y', 182)
+module_eval(<<'.,.,', 'parser.y', 181)
   def _reduce_57(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
@@ -1614,7 +1614,7 @@ module_eval(<<'.,.,', 'parser.y', 182)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 188)
+module_eval(<<'.,.,', 'parser.y', 187)
   def _reduce_58(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
@@ -1623,7 +1623,7 @@ module_eval(<<'.,.,', 'parser.y', 188)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 193)
+module_eval(<<'.,.,', 'parser.y', 192)
   def _reduce_59(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
@@ -1632,21 +1632,21 @@ module_eval(<<'.,.,', 'parser.y', 193)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 197)
+module_eval(<<'.,.,', 'parser.y', 196)
   def _reduce_60(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 198)
+module_eval(<<'.,.,', 'parser.y', 197)
   def _reduce_61(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 202)
+module_eval(<<'.,.,', 'parser.y', 201)
   def _reduce_62(val, _values, result)
                       builder = val[0]
                   result = [builder]
@@ -1655,7 +1655,7 @@ module_eval(<<'.,.,', 'parser.y', 202)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 207)
+module_eval(<<'.,.,', 'parser.y', 206)
   def _reduce_63(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
@@ -1668,7 +1668,7 @@ module_eval(<<'.,.,', 'parser.y', 207)
 
 # reduce 65 omitted
 
-module_eval(<<'.,.,', 'parser.y', 213)
+module_eval(<<'.,.,', 'parser.y', 212)
   def _reduce_66(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
@@ -1677,7 +1677,7 @@ module_eval(<<'.,.,', 'parser.y', 213)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 218)
+module_eval(<<'.,.,', 'parser.y', 217)
   def _reduce_67(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
@@ -1689,7 +1689,7 @@ module_eval(<<'.,.,', 'parser.y', 218)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 226)
+module_eval(<<'.,.,', 'parser.y', 225)
   def _reduce_68(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
@@ -1699,7 +1699,7 @@ module_eval(<<'.,.,', 'parser.y', 226)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 232)
+module_eval(<<'.,.,', 'parser.y', 231)
   def _reduce_69(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
@@ -1709,7 +1709,7 @@ module_eval(<<'.,.,', 'parser.y', 232)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 238)
+module_eval(<<'.,.,', 'parser.y', 237)
   def _reduce_70(val, _values, result)
                   user_code = val[1]
               user_code.alias_name = val[2]
@@ -1721,7 +1721,7 @@ module_eval(<<'.,.,', 'parser.y', 238)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 246)
+module_eval(<<'.,.,', 'parser.y', 245)
   def _reduce_71(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
@@ -1735,42 +1735,42 @@ module_eval(<<'.,.,', 'parser.y', 246)
 
 # reduce 72 omitted
 
-module_eval(<<'.,.,', 'parser.y', 254)
+module_eval(<<'.,.,', 'parser.y', 253)
   def _reduce_73(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 261)
+module_eval(<<'.,.,', 'parser.y', 260)
   def _reduce_74(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 261)
+module_eval(<<'.,.,', 'parser.y', 260)
   def _reduce_75(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 256)
+module_eval(<<'.,.,', 'parser.y', 255)
   def _reduce_76(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 257)
+module_eval(<<'.,.,', 'parser.y', 256)
   def _reduce_77(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 258)
+module_eval(<<'.,.,', 'parser.y', 257)
   def _reduce_78(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
@@ -1781,7 +1781,7 @@ module_eval(<<'.,.,', 'parser.y', 258)
 
 # reduce 80 omitted
 
-module_eval(<<'.,.,', 'parser.y', 264)
+module_eval(<<'.,.,', 'parser.y', 263)
   def _reduce_81(val, _values, result)
                    begin_c_declaration("}")
 
@@ -1789,7 +1789,7 @@ module_eval(<<'.,.,', 'parser.y', 264)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 268)
+module_eval(<<'.,.,', 'parser.y', 267)
   def _reduce_82(val, _values, result)
                    end_c_declaration
 
@@ -1797,7 +1797,7 @@ module_eval(<<'.,.,', 'parser.y', 268)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 272)
+module_eval(<<'.,.,', 'parser.y', 271)
   def _reduce_83(val, _values, result)
                    result = val[2]
 
@@ -1805,49 +1805,49 @@ module_eval(<<'.,.,', 'parser.y', 272)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 280)
+module_eval(<<'.,.,', 'parser.y', 279)
   def _reduce_84(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 280)
+module_eval(<<'.,.,', 'parser.y', 279)
   def _reduce_85(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 275)
+module_eval(<<'.,.,', 'parser.y', 274)
   def _reduce_86(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 276)
+module_eval(<<'.,.,', 'parser.y', 275)
   def _reduce_87(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 277)
+module_eval(<<'.,.,', 'parser.y', 276)
   def _reduce_88(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 279)
+module_eval(<<'.,.,', 'parser.y', 278)
   def _reduce_89(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 280)
+module_eval(<<'.,.,', 'parser.y', 279)
   def _reduce_90(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
@@ -1862,7 +1862,7 @@ module_eval(<<'.,.,', 'parser.y', 280)
 
 # reduce 94 omitted
 
-module_eval(<<'.,.,', 'parser.y', 288)
+module_eval(<<'.,.,', 'parser.y', 287)
   def _reduce_95(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
@@ -1876,7 +1876,7 @@ module_eval(<<'.,.,', 'parser.y', 288)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 299)
+module_eval(<<'.,.,', 'parser.y', 298)
   def _reduce_96(val, _values, result)
                     builder = val[0]
                 if !builder.line
@@ -1888,7 +1888,7 @@ module_eval(<<'.,.,', 'parser.y', 299)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 307)
+module_eval(<<'.,.,', 'parser.y', 306)
   def _reduce_97(val, _values, result)
                     builder = val[2]
                 if !builder.line
@@ -1900,7 +1900,7 @@ module_eval(<<'.,.,', 'parser.y', 307)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 316)
+module_eval(<<'.,.,', 'parser.y', 315)
   def _reduce_98(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -1909,7 +1909,7 @@ module_eval(<<'.,.,', 'parser.y', 316)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 321)
+module_eval(<<'.,.,', 'parser.y', 320)
   def _reduce_99(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
@@ -1921,7 +1921,7 @@ module_eval(<<'.,.,', 'parser.y', 321)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 329)
+module_eval(<<'.,.,', 'parser.y', 328)
   def _reduce_100(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
@@ -1933,7 +1933,7 @@ module_eval(<<'.,.,', 'parser.y', 329)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 337)
+module_eval(<<'.,.,', 'parser.y', 336)
   def _reduce_101(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
@@ -1945,7 +1945,7 @@ module_eval(<<'.,.,', 'parser.y', 337)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 345)
+module_eval(<<'.,.,', 'parser.y', 344)
   def _reduce_102(val, _values, result)
                user_code = val[1]
            user_code.alias_name = val[2]
@@ -1958,7 +1958,7 @@ module_eval(<<'.,.,', 'parser.y', 345)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 354)
+module_eval(<<'.,.,', 'parser.y', 353)
   def _reduce_103(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
@@ -1970,56 +1970,56 @@ module_eval(<<'.,.,', 'parser.y', 354)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 361)
+module_eval(<<'.,.,', 'parser.y', 360)
   def _reduce_104(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 362)
+module_eval(<<'.,.,', 'parser.y', 361)
   def _reduce_105(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 363)
+module_eval(<<'.,.,', 'parser.y', 362)
   def _reduce_106(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 365)
+module_eval(<<'.,.,', 'parser.y', 364)
   def _reduce_107(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 366)
+module_eval(<<'.,.,', 'parser.y', 365)
   def _reduce_108(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 367)
+module_eval(<<'.,.,', 'parser.y', 366)
   def _reduce_109(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 368)
+module_eval(<<'.,.,', 'parser.y', 367)
   def _reduce_110(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 372)
+module_eval(<<'.,.,', 'parser.y', 371)
   def _reduce_111(val, _values, result)
                           if @prec_seen
                         on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
@@ -2031,7 +2031,7 @@ module_eval(<<'.,.,', 'parser.y', 372)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 380)
+module_eval(<<'.,.,', 'parser.y', 379)
   def _reduce_112(val, _values, result)
                           end_c_declaration
 
@@ -2039,7 +2039,7 @@ module_eval(<<'.,.,', 'parser.y', 380)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 384)
+module_eval(<<'.,.,', 'parser.y', 383)
   def _reduce_113(val, _values, result)
                           result = val[2]
 
@@ -2047,14 +2047,14 @@ module_eval(<<'.,.,', 'parser.y', 384)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 387)
+module_eval(<<'.,.,', 'parser.y', 386)
   def _reduce_114(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 391)
+module_eval(<<'.,.,', 'parser.y', 390)
   def _reduce_115(val, _values, result)
                                 begin_c_declaration('\Z')
                             @grammar.epilogue_first_lineno = @lexer.line + 1
@@ -2063,7 +2063,7 @@ module_eval(<<'.,.,', 'parser.y', 391)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 396)
+module_eval(<<'.,.,', 'parser.y', 395)
   def _reduce_116(val, _values, result)
                                 end_c_declaration
                             @grammar.epilogue = val[2].s_value
@@ -2090,7 +2090,7 @@ module_eval(<<'.,.,', 'parser.y', 396)
 
 # reduce 125 omitted
 
-module_eval(<<'.,.,', 'parser.y', 413)
+module_eval(<<'.,.,', 'parser.y', 412)
   def _reduce_126(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 533)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 530)
 
 include Lrama::Report::Duration
 
@@ -728,196 +728,198 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-   103,    53,   104,   170,    90,    81,    53,    53,   187,   170,
-    81,    81,    53,     3,   187,    53,    81,    52,   172,   163,
-    72,     8,   164,   188,   172,     6,    53,     7,    52,   188,
-    81,    77,    41,    53,    53,    52,    52,    47,    84,    84,
-    53,   190,    52,    91,   164,    84,   173,    48,    53,   105,
-    52,   189,   173,    84,    53,    50,    52,   189,    21,    25,
-    26,    27,    28,    29,    30,    31,    32,    33,    34,    35,
-    36,    37,    38,    39,    47,    53,    53,    52,    52,    96,
-    81,   205,    53,    53,    52,    52,    81,   205,    53,    56,
-    52,   227,    81,   205,   228,    21,    25,    26,    27,    28,
+   105,    55,   106,   171,    92,    83,    55,    55,   188,   171,
+    83,    83,    55,     6,   188,    55,    83,    54,   173,   164,
+    74,    10,   165,   189,   173,     4,    55,     5,    54,   189,
+    83,    79,    11,    55,    55,    54,    54,    49,    86,    86,
+    55,   191,    54,    93,   165,    86,   174,    43,    55,   107,
+    54,   190,   174,    86,     4,    50,     5,   190,    24,    28,
     29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-    39,     9,   195,   196,   197,   101,    12,    13,    14,    15,
-    16,    17,    47,   127,    18,    19,    20,    21,    25,    26,
-    27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
-    37,    38,    39,    53,    53,    52,    52,    81,   205,    53,
-    53,    52,    52,    81,   205,    53,    53,    52,    52,    81,
-   205,    53,    53,    52,    52,    81,    81,    53,    53,    52,
-    52,    81,    81,    53,    53,    52,    52,    81,    81,    53,
-    53,    52,   216,    81,    81,    53,    53,   216,   216,    81,
-    81,    53,    53,    52,    52,    81,   195,   196,   197,   101,
-   232,   240,    56,   228,   228,    53,    53,    52,    52,    53,
-    53,    52,    52,   195,   196,   197,    56,    59,    60,    61,
-    62,    63,    64,    65,    66,    67,    68,    69,    92,    48,
-    98,   101,   106,   106,   106,   108,   114,   117,   119,   122,
-   122,   122,   122,   125,   130,   131,   133,   135,   136,   137,
-   138,   139,    81,   146,   147,   148,   149,   150,   153,   154,
-   155,   157,   167,   146,   169,   175,   177,   178,   179,   180,
-   181,   182,   184,   185,   153,   192,   200,   201,   208,   167,
-   212,   215,   101,   220,   167,   224,   167,   226,   182,   185,
-   185,   101,   237,   182,   239,   182,   101,   101,   182 ]
+    39,    40,    41,    42,    49,    55,    55,    54,    54,    98,
+    83,   206,    55,    55,    54,    54,    83,   206,    55,    52,
+    54,   228,    83,   206,   229,    24,    28,    29,    30,    31,
+    32,    33,    34,    35,    36,    37,    38,    39,    40,    41,
+    42,    12,   196,   197,   198,   103,    15,    16,    17,    18,
+    19,    20,    49,   129,    21,    22,    23,    24,    28,    29,
+    30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
+    40,    41,    42,    55,    55,    54,    54,    83,   206,    55,
+    55,    54,    54,    83,   206,    55,    55,    54,    54,    83,
+   206,    55,    55,    54,    54,    83,    83,    55,    55,    54,
+    54,    83,    83,    55,    55,    54,    54,    83,    83,    55,
+    55,    54,   217,    83,    83,    55,    55,   217,   217,    83,
+    83,    55,    55,    54,    54,    83,   196,   197,   198,   103,
+   233,   241,    58,   229,   229,    55,    55,    54,    54,    55,
+    55,    54,    54,    55,    58,    54,   196,   197,   198,    58,
+    61,    62,    63,    64,    65,    66,    67,    68,    69,    70,
+    71,    50,   100,   103,   108,   108,   108,   110,   116,   119,
+   121,   124,   124,   124,   124,   127,   130,   132,   133,   135,
+   137,   138,   139,   140,   141,    83,   148,   149,   150,   151,
+   154,   155,   156,   158,   168,   148,   170,   176,   178,   179,
+   180,   181,   182,   183,   185,   186,   154,   193,   201,   202,
+   209,   168,   213,   216,   103,   221,   168,   225,   168,   227,
+   183,   186,   186,   103,   238,   183,   240,   183,   103,   103,
+   183 ]
 
 racc_action_check = [
-    51,   152,    51,   152,    39,   152,   166,   191,   166,   191,
-   166,   191,   209,     1,   209,    33,   209,    33,   152,   145,
-    33,     3,   145,   166,   191,     2,    34,     2,    34,   209,
-    34,    34,     7,    35,    36,    35,    36,     9,    35,    36,
-    37,   168,    37,    39,   168,    37,   152,    10,    38,    51,
-    38,   166,   191,    38,    13,    12,    13,   209,     9,     9,
-     9,     9,     9,     9,     9,     9,     9,     9,     9,     9,
-     9,     9,     9,     9,    42,    71,   179,    71,   179,    42,
-   179,   179,   180,    72,   180,    72,   180,   180,   181,    14,
-   181,   217,   181,   181,   217,    42,    42,    42,    42,    42,
-    42,    42,    42,    42,    42,    42,    42,    42,    42,    42,
-    42,     4,   171,   171,   171,   171,     4,     4,     4,     4,
-     4,     4,    91,    91,     4,     4,     4,     4,     4,     4,
-     4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-     4,     4,     4,   202,    83,   202,    83,   202,   202,   206,
-    84,   206,    84,   206,   206,   207,   114,   207,   114,   207,
-   207,    76,    77,    76,    77,    76,    77,   119,   121,   119,
-   121,   119,   121,   143,   173,   143,   173,   143,   173,   189,
-   192,   189,   192,   189,   192,   212,   226,   212,   226,   212,
-   226,   228,   116,   228,   116,   228,   186,   186,   186,   186,
-   223,   234,    15,   223,   234,   122,   124,   122,   124,   140,
-   144,   140,   144,   218,   218,   218,    16,    17,    18,    21,
-    25,    26,    27,    28,    29,    30,    31,    32,    40,    44,
-    45,    46,    55,    57,    58,    59,    70,    74,    75,    82,
-    87,    88,    89,    90,   100,   101,   107,   109,   110,   111,
-   112,   113,   118,   125,   126,   127,   128,   129,   130,   131,
-   132,   134,   147,   148,   151,   156,   158,   159,   160,   161,
-   162,   163,   164,   165,   169,   170,   174,   176,   183,   185,
-   187,   190,   194,   198,   208,   213,   215,   216,   219,   222,
-   225,   227,   231,   232,   233,   235,   237,   239,   242 ]
+    53,   153,    53,   153,    42,   153,   167,   192,   167,   192,
+   167,   192,   210,     1,   210,    36,   210,    36,   153,   147,
+    36,     5,   147,   167,   192,     0,    37,     0,    37,   210,
+    37,    37,     6,    38,    39,    38,    39,    12,    38,    39,
+    40,   169,    40,    42,   169,    40,   153,     9,    41,    53,
+    41,   167,   192,    41,     2,    13,     2,   210,    12,    12,
+    12,    12,    12,    12,    12,    12,    12,    12,    12,    12,
+    12,    12,    12,    12,    44,    16,   180,    16,   180,    44,
+   180,   180,   181,    73,   181,    73,   181,   181,   182,    15,
+   182,   218,   182,   182,   218,    44,    44,    44,    44,    44,
+    44,    44,    44,    44,    44,    44,    44,    44,    44,    44,
+    44,     8,   172,   172,   172,   172,     8,     8,     8,     8,
+     8,     8,    93,    93,     8,     8,     8,     8,     8,     8,
+     8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
+     8,     8,     8,   203,    74,   203,    74,   203,   203,   207,
+    85,   207,    85,   207,   207,   208,    86,   208,    86,   208,
+   208,    78,    79,    78,    79,    78,    79,   121,   123,   121,
+   123,   121,   123,   145,   174,   145,   174,   145,   174,   190,
+   193,   190,   193,   190,   193,   213,   227,   213,   227,   213,
+   227,   229,   116,   229,   116,   229,   187,   187,   187,   187,
+   224,   235,    17,   224,   235,   118,   124,   118,   124,   126,
+   142,   126,   142,   146,    18,   146,   219,   219,   219,    19,
+    20,    21,    24,    28,    29,    30,    31,    32,    33,    34,
+    35,    46,    47,    48,    57,    59,    60,    61,    72,    76,
+    77,    84,    89,    90,    91,    92,    94,   102,   103,   109,
+   111,   112,   113,   114,   115,   120,   127,   128,   129,   131,
+   132,   133,   134,   136,   149,   150,   152,   157,   159,   160,
+   161,   162,   163,   164,   165,   166,   170,   171,   175,   177,
+   184,   186,   188,   191,   195,   199,   209,   214,   216,   217,
+   220,   223,   226,   228,   232,   233,   234,   236,   238,   240,
+   243 ]
 
 racc_action_pointer = [
-   nil,    13,    15,    21,   102,   nil,   nil,    25,   nil,    33,
-    34,   nil,    49,    51,    69,   182,   196,   212,   198,   nil,
-   nil,   199,   nil,   nil,   nil,   200,   201,   202,   218,   219,
-   220,   221,   222,    12,    23,    30,    31,    37,    45,    -1,
-   226,   nil,    70,   nil,   216,   217,   179,   nil,   nil,   nil,
-   nil,    -5,   nil,   nil,   nil,   212,   nil,   213,   214,   215,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   228,    72,    80,   nil,   231,   230,   158,   159,   nil,   nil,
-   nil,   nil,   231,   141,   147,   nil,   nil,   232,   233,   234,
-   202,   118,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   201,   240,   nil,   nil,   nil,   nil,   nil,   244,   nil,   245,
-   246,   247,   248,   249,   153,   nil,   189,   nil,   245,   164,
-   nil,   165,   202,   nil,   203,   248,   211,   214,   245,   255,
-   211,   206,   258,   nil,   259,   nil,   nil,   nil,   nil,   nil,
-   206,   nil,   nil,   170,   207,   -23,   nil,   215,   258,   nil,
-   nil,   218,    -2,   nil,   nil,   nil,   244,   nil,   245,   246,
-   247,   248,   249,   263,   267,   227,     3,   nil,    -1,   227,
-   234,    63,   nil,   171,   255,   nil,   256,   nil,   nil,    73,
-    79,    85,   nil,   235,   nil,   232,   147,   239,   nil,   176,
-   238,     4,   177,   nil,   230,   nil,   nil,   nil,   281,   nil,
-   nil,   nil,   140,   nil,   nil,   nil,   146,   152,   237,     9,
-   nil,   nil,   182,   283,   nil,   239,   246,    49,   164,   280,
-   nil,   nil,   243,   158,   nil,   244,   183,   239,   188,   nil,
-   nil,   271,   285,   273,   159,   287,   nil,   244,   nil,   245,
-   nil,   nil,   290,   nil,   nil ]
+    15,    13,    44,   nil,   nil,    14,    32,   nil,   102,    45,
+   nil,   nil,    33,    42,   nil,    83,    72,   182,   194,   199,
+   215,   201,   nil,   nil,   202,   nil,   nil,   nil,   203,   204,
+   205,   221,   222,   223,   224,   225,    12,    23,    30,    31,
+    37,    45,    -1,   nil,    70,   nil,   218,   219,   181,   nil,
+   nil,   nil,   nil,    -5,   nil,   nil,   nil,   214,   nil,   215,
+   216,   217,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   230,    80,   141,   nil,   233,   232,   158,   159,
+   nil,   nil,   nil,   nil,   233,   147,   153,   nil,   nil,   234,
+   235,   236,   204,   118,   235,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   204,   243,   nil,   nil,   nil,   nil,   nil,   247,
+   nil,   248,   249,   250,   251,   252,   189,   nil,   202,   nil,
+   248,   164,   nil,   165,   203,   nil,   206,   251,   214,   217,
+   nil,   257,   213,   208,   260,   nil,   261,   nil,   nil,   nil,
+   nil,   nil,   207,   nil,   nil,   170,   210,   -23,   nil,   217,
+   260,   nil,   220,    -2,   nil,   nil,   nil,   246,   nil,   247,
+   248,   249,   250,   251,   265,   269,   229,     3,   nil,    -1,
+   229,   236,    63,   nil,   171,   257,   nil,   258,   nil,   nil,
+    73,    79,    85,   nil,   237,   nil,   234,   147,   241,   nil,
+   176,   240,     4,   177,   nil,   232,   nil,   nil,   nil,   283,
+   nil,   nil,   nil,   140,   nil,   nil,   nil,   146,   152,   239,
+     9,   nil,   nil,   182,   285,   nil,   241,   248,    49,   167,
+   282,   nil,   nil,   245,   158,   nil,   246,   183,   241,   188,
+   nil,   nil,   273,   287,   275,   159,   289,   nil,   246,   nil,
+   247,   nil,   nil,   292,   nil,   nil ]
 
 racc_action_default = [
-    -4,  -142,   -12,  -142,  -142,    -5,    -6,  -142,   245,  -142,
-   -10,   -14,  -142,  -142,  -142,  -142,  -142,  -142,  -142,   -26,
-   -27,  -142,   -31,   -32,   -33,  -142,  -142,  -142,  -142,  -142,
+    -1,  -142,    -1,   -12,    -6,  -142,  -142,    -2,  -142,  -142,
+    -9,   246,  -142,   -10,   -14,  -142,  -142,  -142,  -142,  -142,
+  -142,  -142,   -26,   -27,  -142,   -31,   -32,   -33,  -142,  -142,
   -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,  -142,
-  -142,    -9,    -1,  -105,   -10,  -142,   -71,  -129,   -11,   -13,
-   -15,  -133,  -103,  -104,  -132,   -17,   -94,   -18,   -19,  -142,
-   -23,   -28,   -34,   -37,   -40,   -43,   -44,   -45,   -46,   -47,
-   -48,   -54,  -142,   -57,   -59,   -49,   -84,  -142,   -87,   -89,
-   -90,  -141,   -50,   -97,  -142,  -100,  -102,   -51,   -52,   -53,
-  -142,  -142,    -7,    -2,    -3,  -106,  -130,  -107,  -108,   -72,
-  -142,  -142,   -16,  -134,  -135,  -136,   -91,  -142,   -20,  -142,
-  -142,  -142,  -142,  -142,  -142,   -58,   -55,   -60,   -82,  -142,
-   -88,   -85,  -142,  -101,   -98,  -142,  -142,  -142,  -142,  -142,
-  -112,  -142,  -142,   -95,  -142,   -24,   -29,   -35,   -38,   -41,
-   -56,   -61,   -83,   -86,   -99,  -142,   -67,   -73,  -142,    -8,
-  -131,  -109,  -110,  -113,  -128,   -92,  -142,   -21,  -142,  -142,
-  -142,  -142,  -142,   -62,  -142,   -65,   -69,   -74,  -142,  -112,
-  -103,   -71,  -117,  -142,  -142,   -96,  -142,   -25,   -30,  -142,
-  -142,  -142,   -63,  -142,   -68,   -73,   -71,  -103,   -78,  -142,
-  -142,  -111,  -142,  -114,   -71,  -121,  -122,  -123,  -142,  -120,
-   -93,   -22,   -36,  -137,  -139,  -140,   -39,   -42,   -73,   -70,
-   -75,   -76,  -142,  -142,   -81,   -73,  -103,  -142,  -124,   -62,
-  -118,  -138,   -64,  -142,   -79,   -66,  -142,   -71,  -142,  -126,
-  -115,  -142,   -62,  -142,  -142,   -62,  -125,   -71,   -77,   -71,
-  -127,  -116,   -62,   -80,  -119 ]
+  -142,  -142,  -142,    -7,    -3,  -105,   -10,  -142,   -71,  -129,
+   -11,   -13,   -15,  -133,  -103,  -104,  -132,   -17,   -94,   -18,
+   -19,  -142,   -23,   -28,   -34,   -37,   -40,   -43,   -44,   -45,
+   -46,   -47,   -48,   -54,  -142,   -57,   -59,   -49,   -84,  -142,
+   -87,   -89,   -90,  -141,   -50,   -97,  -142,  -100,  -102,   -51,
+   -52,   -53,  -142,  -142,  -142,    -4,    -5,  -106,  -130,  -107,
+  -108,   -72,  -142,  -142,   -16,  -134,  -135,  -136,   -91,  -142,
+   -20,  -142,  -142,  -142,  -142,  -142,  -142,   -58,   -55,   -60,
+   -82,  -142,   -88,   -85,  -142,  -101,   -98,  -142,  -142,  -142,
+    -8,  -142,  -112,  -142,  -142,   -95,  -142,   -24,   -29,   -35,
+   -38,   -41,   -56,   -61,   -83,   -86,   -99,  -142,   -67,   -73,
+  -142,  -131,  -109,  -110,  -113,  -128,   -92,  -142,   -21,  -142,
+  -142,  -142,  -142,  -142,   -62,  -142,   -65,   -69,   -74,  -142,
+  -112,  -103,   -71,  -117,  -142,  -142,   -96,  -142,   -25,   -30,
+  -142,  -142,  -142,   -63,  -142,   -68,   -73,   -71,  -103,   -78,
+  -142,  -142,  -111,  -142,  -114,   -71,  -121,  -122,  -123,  -142,
+  -120,   -93,   -22,   -36,  -137,  -139,  -140,   -39,   -42,   -73,
+   -70,   -75,   -76,  -142,  -142,   -81,   -73,  -103,  -142,  -124,
+   -62,  -118,  -138,   -64,  -142,   -79,   -66,  -142,   -71,  -142,
+  -126,  -115,  -142,   -62,  -142,  -142,   -62,  -125,   -71,   -77,
+   -71,  -127,  -116,   -62,   -80,  -119 ]
 
 racc_goto_table = [
-    78,    76,   100,    54,   165,   194,   115,    71,   123,   152,
-   183,    49,   124,   217,   145,    82,    87,    88,    89,     1,
-   211,    43,     2,    74,     4,    86,    86,    86,    86,    42,
-   221,    93,    94,   223,   221,   221,     5,   168,    55,    57,
-    58,    40,   120,    78,   121,    97,   116,   234,   191,   123,
-   144,   115,   229,   128,    95,   202,   206,   207,    10,    11,
-    51,    74,    74,   102,   134,   222,   230,   176,   109,   123,
-   158,   110,   225,    86,    86,   115,   159,   111,   160,   238,
-   112,   161,   241,   113,   162,    78,   143,   120,   140,   244,
-    70,    75,   141,   118,   126,   209,   213,   233,   142,   132,
-   174,   107,   156,   151,    74,   198,    74,   231,   129,   120,
-   nil,   nil,    86,   nil,    86,   nil,   nil,   nil,   171,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   193,   nil,   nil,
-    74,   nil,   186,   nil,    86,   nil,   nil,   nil,   nil,   199,
-   nil,   nil,   210,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   219,   nil,   nil,   nil,   nil,   214,   nil,   171,   218,   nil,
+    80,   102,    56,    78,   117,    73,   195,   166,   126,   184,
+   153,    51,   147,   218,   125,   222,     1,     8,    45,   222,
+   222,   212,    76,    44,    88,    88,    88,    88,    84,    89,
+    90,    91,     3,   224,     7,   169,    57,    59,    60,    95,
+    96,   122,    80,   118,    99,   123,   146,   235,   192,   117,
+    97,     9,    94,   230,    13,   125,   203,   207,   208,    76,
+    76,    14,    53,   104,   136,   231,   177,   223,   111,   159,
+   112,    88,    88,   117,   226,   125,   160,   113,   239,   161,
+   114,   242,   162,   115,    80,   142,   122,   145,   245,   163,
+    72,    77,   143,   120,   128,   210,   214,   234,   144,   134,
+   175,   109,    76,   157,    76,   152,   199,   232,   122,   131,
+    88,   nil,    88,   nil,   nil,   nil,   172,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   194,   nil,   nil,    76,   nil,
+   187,   nil,    88,   nil,   nil,   nil,   nil,   200,   nil,   nil,
+   211,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   220,   nil,
+   nil,   nil,   nil,   215,   nil,   172,   219,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   186,   nil,   nil,   218,   nil,
-   nil,   nil,   nil,   235,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   218,   242,   236,   243 ]
+   nil,   nil,   nil,   187,   nil,   nil,   219,   nil,   nil,   nil,
+   nil,   236,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   219,   243,   237,   244 ]
 
 racc_goto_check = [
-    45,    53,    49,    37,    41,    47,    36,    35,    59,    63,
-    42,    11,    58,    48,    40,    34,    34,    34,    34,     1,
-    47,    60,     2,    37,     3,    37,    37,    37,    37,     4,
-    67,     5,     6,    48,    67,    67,     7,    40,    15,    15,
-    15,     8,    45,    45,    53,    11,    35,    48,    63,    59,
-    58,    36,    47,     9,    60,    23,    23,    23,    10,    12,
-    13,    37,    37,    14,    16,    41,    42,    17,    18,    59,
-    19,    24,    41,    37,    37,    36,    25,    26,    27,    42,
-    28,    29,    42,    30,    31,    45,    53,    45,    35,    42,
+    45,    49,    37,    53,    36,    35,    47,    41,    58,    42,
+    63,    11,    40,    48,    59,    67,     1,     3,    60,    67,
+    67,    47,    37,     4,    37,    37,    37,    37,    34,    34,
+    34,    34,     6,    48,     6,    40,    15,    15,    15,     5,
+     7,    45,    45,    35,    11,    53,    58,    48,    63,    36,
+    60,     8,     9,    47,    10,    59,    23,    23,    23,    37,
+    37,    12,    13,    14,    16,    42,    17,    41,    18,    19,
+    24,    37,    37,    36,    41,    59,    25,    26,    42,    27,
+    28,    42,    29,    30,    45,    35,    45,    53,    42,    31,
     32,    33,    38,    39,    43,    44,    50,    51,    52,    54,
-    55,    56,    57,    62,    37,    64,    37,    65,    66,    45,
-   nil,   nil,    37,   nil,    37,   nil,   nil,   nil,    45,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,    49,   nil,   nil,
-    37,   nil,    45,   nil,    37,   nil,   nil,   nil,   nil,    45,
-   nil,   nil,    49,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    49,   nil,   nil,   nil,   nil,    45,   nil,    45,    45,   nil,
+    55,    56,    37,    57,    37,    62,    64,    65,    45,    66,
+    37,   nil,    37,   nil,   nil,   nil,    45,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,    49,   nil,   nil,    37,   nil,
+    45,   nil,    37,   nil,   nil,   nil,   nil,    45,   nil,   nil,
+    49,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    49,   nil,
+   nil,   nil,   nil,    45,   nil,    45,    45,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    45,   nil,   nil,    45,   nil,
-   nil,   nil,   nil,    49,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    45,    49,    45,    49 ]
+   nil,   nil,   nil,    45,   nil,   nil,    45,   nil,   nil,   nil,
+   nil,    49,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+    45,    49,    45,    49 ]
 
 racc_goto_pointer = [
-   nil,    19,    22,    22,    20,   -11,   -10,    34,    35,   -39,
-    54,     1,    55,    47,    12,    24,   -44,   -90,     8,   -65,
-   nil,   nil,   nil,  -124,    10,   -60,    15,   -59,    17,   -57,
-    19,   -55,    57,    57,   -20,   -26,   -65,   -10,   -26,    19,
-  -111,  -143,  -153,     3,   -90,   -34,   nil,  -166,  -179,   -44,
-   -92,  -127,   -20,   -33,    -7,   -55,    45,   -31,   -72,   -75,
-    12,   nil,   -27,  -121,   -67,  -113,    12,  -172 ]
+   nil,    16,   nil,    14,    11,    -5,    32,    -4,    47,     9,
+    46,    -2,    53,    46,    10,    19,   -46,   -92,     6,   -68,
+   nil,   nil,   nil,  -124,     7,   -62,    13,   -60,    15,   -58,
+    17,   -52,    54,    54,   -10,   -31,   -69,   -14,   -28,    17,
+  -115,  -142,  -155,     1,   -91,   -37,   nil,  -166,  -180,   -47,
+   -93,  -128,   -22,   -34,    -9,   -56,    43,   -32,   -78,   -71,
+     6,   nil,   -27,  -122,   -67,  -114,    11,  -188 ]
 
 racc_goto_default = [
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    45,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    22,    23,    24,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,    73,    79,   nil,   nil,
-   nil,   nil,   nil,    46,   166,   204,    99,   nil,   nil,   nil,
-   nil,   nil,    80,   nil,   nil,   nil,   nil,   nil,    83,    85,
-   nil,    44,   nil,   nil,   nil,   nil,   nil,   203 ]
+   nil,   nil,     2,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    47,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+    25,    26,    27,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    75,    81,   nil,   nil,
+   nil,   nil,   nil,    48,   167,   205,   101,   nil,   nil,   nil,
+   nil,   nil,    82,   nil,   nil,   nil,   nil,   nil,    85,    87,
+   nil,    46,   nil,   nil,   nil,   nil,   nil,   204 ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
-  0, 61, :_reduce_none,
-  1, 61, :_reduce_none,
+  0, 61, :_reduce_1,
+  2, 61, :_reduce_2,
+  0, 62, :_reduce_none,
+  1, 62, :_reduce_none,
   5, 56, :_reduce_none,
-  0, 57, :_reduce_none,
-  2, 57, :_reduce_none,
   0, 63, :_reduce_6,
   0, 64, :_reduce_7,
-  5, 62, :_reduce_8,
-  2, 62, :_reduce_none,
+  5, 57, :_reduce_8,
+  2, 57, :_reduce_none,
   0, 66, :_reduce_none,
   1, 66, :_reduce_none,
   0, 58, :_reduce_12,
@@ -1053,7 +1055,7 @@ racc_reduce_table = [
 
 racc_reduce_n = 142
 
-racc_shift_n = 245
+racc_shift_n = 246
 
 racc_token_table = {
   false => 0,
@@ -1191,12 +1193,12 @@ Racc_token_to_s_table = [
   "\"{...}\"",
   "$start",
   "input",
-  "prologue_declarations",
+  "prologue_declaration",
   "bison_declarations",
   "grammar",
   "epilogue",
+  "\"-many@prologue_declaration\"",
   "\"-option@epilogue\"",
-  "prologue_declaration",
   "@1",
   "@2",
   "bison_declaration",
@@ -1265,9 +1267,19 @@ Racc_debug_parser = true
 
 # reduce 0 omitted
 
-# reduce 1 omitted
+module_eval(<<'.,.,', 'parser.y', 11)
+  def _reduce_1(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
-# reduce 2 omitted
+module_eval(<<'.,.,', 'parser.y', 11)
+  def _reduce_2(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
 # reduce 3 omitted
 
@@ -1275,7 +1287,7 @@ Racc_debug_parser = true
 
 # reduce 5 omitted
 
-module_eval(<<'.,.,', 'parser.y', 15)
+module_eval(<<'.,.,', 'parser.y', 12)
   def _reduce_6(val, _values, result)
                                 begin_c_declaration("%}")
                             @grammar.prologue_first_lineno = @lexer.line
@@ -1284,7 +1296,7 @@ module_eval(<<'.,.,', 'parser.y', 15)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 20)
+module_eval(<<'.,.,', 'parser.y', 17)
   def _reduce_7(val, _values, result)
                                 end_c_declaration
 
@@ -1292,7 +1304,7 @@ module_eval(<<'.,.,', 'parser.y', 20)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 24)
+module_eval(<<'.,.,', 'parser.y', 21)
   def _reduce_8(val, _values, result)
                                 @grammar.prologue = val[2].s_value
 
@@ -1306,7 +1318,7 @@ module_eval(<<'.,.,', 'parser.y', 24)
 
 # reduce 11 omitted
 
-module_eval(<<'.,.,', 'parser.y', 28)
+module_eval(<<'.,.,', 'parser.y', 25)
   def _reduce_12(val, _values, result)
      result = ""
     result
@@ -1317,7 +1329,7 @@ module_eval(<<'.,.,', 'parser.y', 28)
 
 # reduce 14 omitted
 
-module_eval(<<'.,.,', 'parser.y', 32)
+module_eval(<<'.,.,', 'parser.y', 29)
   def _reduce_15(val, _values, result)
      @grammar.expect = val[1]
     result
@@ -1328,7 +1340,7 @@ module_eval(<<'.,.,', 'parser.y', 32)
 
 # reduce 17 omitted
 
-module_eval(<<'.,.,', 'parser.y', 37)
+module_eval(<<'.,.,', 'parser.y', 34)
   def _reduce_18(val, _values, result)
                              val[1].each {|token|
                            @grammar.lex_param = Grammar::Code::NoReferenceCode.new(type: :lex_param, token_code: token).token_code.s_value
@@ -1338,7 +1350,7 @@ module_eval(<<'.,.,', 'parser.y', 37)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 43)
+module_eval(<<'.,.,', 'parser.y', 40)
   def _reduce_19(val, _values, result)
                              val[1].each {|token|
                            @grammar.parse_param = Grammar::Code::NoReferenceCode.new(type: :parse_param, token_code: token).token_code.s_value
@@ -1348,7 +1360,7 @@ module_eval(<<'.,.,', 'parser.y', 43)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 49)
+module_eval(<<'.,.,', 'parser.y', 46)
   def _reduce_20(val, _values, result)
                              begin_c_declaration("}")
 
@@ -1356,7 +1368,7 @@ module_eval(<<'.,.,', 'parser.y', 49)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 53)
+module_eval(<<'.,.,', 'parser.y', 50)
   def _reduce_21(val, _values, result)
                              end_c_declaration
 
@@ -1364,7 +1376,7 @@ module_eval(<<'.,.,', 'parser.y', 53)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 57)
+module_eval(<<'.,.,', 'parser.y', 54)
   def _reduce_22(val, _values, result)
                              @grammar.add_percent_code(id: val[1], code: val[4])
 
@@ -1372,7 +1384,7 @@ module_eval(<<'.,.,', 'parser.y', 57)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 61)
+module_eval(<<'.,.,', 'parser.y', 58)
   def _reduce_23(val, _values, result)
                              begin_c_declaration("}")
 
@@ -1380,7 +1392,7 @@ module_eval(<<'.,.,', 'parser.y', 61)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 65)
+module_eval(<<'.,.,', 'parser.y', 62)
   def _reduce_24(val, _values, result)
                              end_c_declaration
 
@@ -1388,7 +1400,7 @@ module_eval(<<'.,.,', 'parser.y', 65)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 69)
+module_eval(<<'.,.,', 'parser.y', 66)
   def _reduce_25(val, _values, result)
                              @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[3])
 
@@ -1396,21 +1408,21 @@ module_eval(<<'.,.,', 'parser.y', 69)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 71)
+module_eval(<<'.,.,', 'parser.y', 68)
   def _reduce_26(val, _values, result)
      @grammar.no_stdlib = true
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 72)
+module_eval(<<'.,.,', 'parser.y', 69)
   def _reduce_27(val, _values, result)
      @grammar.locations = true
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 76)
+module_eval(<<'.,.,', 'parser.y', 73)
   def _reduce_28(val, _values, result)
                                begin_c_declaration("}")
 
@@ -1418,7 +1430,7 @@ module_eval(<<'.,.,', 'parser.y', 76)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 80)
+module_eval(<<'.,.,', 'parser.y', 77)
   def _reduce_29(val, _values, result)
                                end_c_declaration
 
@@ -1426,7 +1438,7 @@ module_eval(<<'.,.,', 'parser.y', 80)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 84)
+module_eval(<<'.,.,', 'parser.y', 81)
   def _reduce_30(val, _values, result)
                                @grammar.set_union(
                              Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[3]),
@@ -1443,7 +1455,7 @@ module_eval(<<'.,.,', 'parser.y', 84)
 
 # reduce 33 omitted
 
-module_eval(<<'.,.,', 'parser.y', 94)
+module_eval(<<'.,.,', 'parser.y', 91)
   def _reduce_34(val, _values, result)
                                begin_c_declaration("}")
 
@@ -1451,7 +1463,7 @@ module_eval(<<'.,.,', 'parser.y', 94)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 98)
+module_eval(<<'.,.,', 'parser.y', 95)
   def _reduce_35(val, _values, result)
                                end_c_declaration
 
@@ -1459,7 +1471,7 @@ module_eval(<<'.,.,', 'parser.y', 98)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 102)
+module_eval(<<'.,.,', 'parser.y', 99)
   def _reduce_36(val, _values, result)
                                @grammar.add_destructor(
                              ident_or_tags: val[6],
@@ -1471,7 +1483,7 @@ module_eval(<<'.,.,', 'parser.y', 102)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 110)
+module_eval(<<'.,.,', 'parser.y', 107)
   def _reduce_37(val, _values, result)
                                begin_c_declaration("}")
 
@@ -1479,7 +1491,7 @@ module_eval(<<'.,.,', 'parser.y', 110)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 114)
+module_eval(<<'.,.,', 'parser.y', 111)
   def _reduce_38(val, _values, result)
                                end_c_declaration
 
@@ -1487,7 +1499,7 @@ module_eval(<<'.,.,', 'parser.y', 114)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 118)
+module_eval(<<'.,.,', 'parser.y', 115)
   def _reduce_39(val, _values, result)
                                @grammar.add_printer(
                              ident_or_tags: val[6],
@@ -1499,7 +1511,7 @@ module_eval(<<'.,.,', 'parser.y', 118)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 126)
+module_eval(<<'.,.,', 'parser.y', 123)
   def _reduce_40(val, _values, result)
                                begin_c_declaration("}")
 
@@ -1507,7 +1519,7 @@ module_eval(<<'.,.,', 'parser.y', 126)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 130)
+module_eval(<<'.,.,', 'parser.y', 127)
   def _reduce_41(val, _values, result)
                                end_c_declaration
 
@@ -1515,7 +1527,7 @@ module_eval(<<'.,.,', 'parser.y', 130)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 134)
+module_eval(<<'.,.,', 'parser.y', 131)
   def _reduce_42(val, _values, result)
                                @grammar.add_error_token(
                              ident_or_tags: val[6],
@@ -1527,7 +1539,7 @@ module_eval(<<'.,.,', 'parser.y', 134)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 142)
+module_eval(<<'.,.,', 'parser.y', 139)
   def _reduce_43(val, _values, result)
                                @grammar.after_shift = val[1]
 
@@ -1535,7 +1547,7 @@ module_eval(<<'.,.,', 'parser.y', 142)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 146)
+module_eval(<<'.,.,', 'parser.y', 143)
   def _reduce_44(val, _values, result)
                                @grammar.before_reduce = val[1]
 
@@ -1543,7 +1555,7 @@ module_eval(<<'.,.,', 'parser.y', 146)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 150)
+module_eval(<<'.,.,', 'parser.y', 147)
   def _reduce_45(val, _values, result)
                                @grammar.after_reduce = val[1]
 
@@ -1551,7 +1563,7 @@ module_eval(<<'.,.,', 'parser.y', 150)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 154)
+module_eval(<<'.,.,', 'parser.y', 151)
   def _reduce_46(val, _values, result)
                                @grammar.after_shift_error_token = val[1]
 
@@ -1559,7 +1571,7 @@ module_eval(<<'.,.,', 'parser.y', 154)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 158)
+module_eval(<<'.,.,', 'parser.y', 155)
   def _reduce_47(val, _values, result)
                                @grammar.after_pop_stack = val[1]
 
@@ -1569,7 +1581,7 @@ module_eval(<<'.,.,', 'parser.y', 158)
 
 # reduce 48 omitted
 
-module_eval(<<'.,.,', 'parser.y', 164)
+module_eval(<<'.,.,', 'parser.y', 161)
   def _reduce_49(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1581,7 +1593,7 @@ module_eval(<<'.,.,', 'parser.y', 164)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 172)
+module_eval(<<'.,.,', 'parser.y', 169)
   def _reduce_50(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1595,7 +1607,7 @@ module_eval(<<'.,.,', 'parser.y', 172)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 182)
+module_eval(<<'.,.,', 'parser.y', 179)
   def _reduce_51(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1609,7 +1621,7 @@ module_eval(<<'.,.,', 'parser.y', 182)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 192)
+module_eval(<<'.,.,', 'parser.y', 189)
   def _reduce_52(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1623,7 +1635,7 @@ module_eval(<<'.,.,', 'parser.y', 192)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 202)
+module_eval(<<'.,.,', 'parser.y', 199)
   def _reduce_53(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
@@ -1637,7 +1649,7 @@ module_eval(<<'.,.,', 'parser.y', 202)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 213)
+module_eval(<<'.,.,', 'parser.y', 210)
   def _reduce_54(val, _values, result)
                               val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
@@ -1647,7 +1659,7 @@ module_eval(<<'.,.,', 'parser.y', 213)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 219)
+module_eval(<<'.,.,', 'parser.y', 216)
   def _reduce_55(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
@@ -1657,7 +1669,7 @@ module_eval(<<'.,.,', 'parser.y', 219)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 225)
+module_eval(<<'.,.,', 'parser.y', 222)
   def _reduce_56(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
@@ -1667,14 +1679,14 @@ module_eval(<<'.,.,', 'parser.y', 225)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 230)
+module_eval(<<'.,.,', 'parser.y', 227)
   def _reduce_57(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 231)
+module_eval(<<'.,.,', 'parser.y', 228)
   def _reduce_58(val, _values, result)
      result = val[0].append(val[1])
     result
@@ -1685,7 +1697,7 @@ module_eval(<<'.,.,', 'parser.y', 231)
 
 # reduce 60 omitted
 
-module_eval(<<'.,.,', 'parser.y', 233)
+module_eval(<<'.,.,', 'parser.y', 230)
   def _reduce_61(val, _values, result)
      result = val
     result
@@ -1696,7 +1708,7 @@ module_eval(<<'.,.,', 'parser.y', 233)
 
 # reduce 63 omitted
 
-module_eval(<<'.,.,', 'parser.y', 237)
+module_eval(<<'.,.,', 'parser.y', 234)
   def _reduce_64(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
@@ -1705,7 +1717,7 @@ module_eval(<<'.,.,', 'parser.y', 237)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 243)
+module_eval(<<'.,.,', 'parser.y', 240)
   def _reduce_65(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
@@ -1714,7 +1726,7 @@ module_eval(<<'.,.,', 'parser.y', 243)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 248)
+module_eval(<<'.,.,', 'parser.y', 245)
   def _reduce_66(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
@@ -1723,21 +1735,21 @@ module_eval(<<'.,.,', 'parser.y', 248)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 252)
+module_eval(<<'.,.,', 'parser.y', 249)
   def _reduce_67(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 253)
+module_eval(<<'.,.,', 'parser.y', 250)
   def _reduce_68(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 257)
+module_eval(<<'.,.,', 'parser.y', 254)
   def _reduce_69(val, _values, result)
                       builder = val[0]
                   result = [builder]
@@ -1746,7 +1758,7 @@ module_eval(<<'.,.,', 'parser.y', 257)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 262)
+module_eval(<<'.,.,', 'parser.y', 259)
   def _reduce_70(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
@@ -1759,7 +1771,7 @@ module_eval(<<'.,.,', 'parser.y', 262)
 
 # reduce 72 omitted
 
-module_eval(<<'.,.,', 'parser.y', 268)
+module_eval(<<'.,.,', 'parser.y', 265)
   def _reduce_73(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
@@ -1768,7 +1780,7 @@ module_eval(<<'.,.,', 'parser.y', 268)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 273)
+module_eval(<<'.,.,', 'parser.y', 270)
   def _reduce_74(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
@@ -1777,7 +1789,7 @@ module_eval(<<'.,.,', 'parser.y', 273)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 278)
+module_eval(<<'.,.,', 'parser.y', 275)
   def _reduce_75(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
@@ -1789,7 +1801,7 @@ module_eval(<<'.,.,', 'parser.y', 278)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 286)
+module_eval(<<'.,.,', 'parser.y', 283)
   def _reduce_76(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
@@ -1799,7 +1811,7 @@ module_eval(<<'.,.,', 'parser.y', 286)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 292)
+module_eval(<<'.,.,', 'parser.y', 289)
   def _reduce_77(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
@@ -1809,7 +1821,7 @@ module_eval(<<'.,.,', 'parser.y', 292)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 298)
+module_eval(<<'.,.,', 'parser.y', 295)
   def _reduce_78(val, _values, result)
                   if @prec_seen
                 on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
@@ -1821,7 +1833,7 @@ module_eval(<<'.,.,', 'parser.y', 298)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 306)
+module_eval(<<'.,.,', 'parser.y', 303)
   def _reduce_79(val, _values, result)
                   end_c_declaration
 
@@ -1829,7 +1841,7 @@ module_eval(<<'.,.,', 'parser.y', 306)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 310)
+module_eval(<<'.,.,', 'parser.y', 307)
   def _reduce_80(val, _values, result)
                   user_code = val[3]
               user_code.alias_name = val[6]
@@ -1841,7 +1853,7 @@ module_eval(<<'.,.,', 'parser.y', 310)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 318)
+module_eval(<<'.,.,', 'parser.y', 315)
   def _reduce_81(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
@@ -1855,14 +1867,14 @@ module_eval(<<'.,.,', 'parser.y', 318)
 
 # reduce 82 omitted
 
-module_eval(<<'.,.,', 'parser.y', 326)
+module_eval(<<'.,.,', 'parser.y', 323)
   def _reduce_83(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 330)
+module_eval(<<'.,.,', 'parser.y', 327)
   def _reduce_84(val, _values, result)
                                result = [{tag: nil, tokens: val[0]}]
 
@@ -1870,7 +1882,7 @@ module_eval(<<'.,.,', 'parser.y', 330)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 334)
+module_eval(<<'.,.,', 'parser.y', 331)
   def _reduce_85(val, _values, result)
                                result = [{tag: val[0], tokens: val[1]}]
 
@@ -1878,7 +1890,7 @@ module_eval(<<'.,.,', 'parser.y', 334)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 338)
+module_eval(<<'.,.,', 'parser.y', 335)
   def _reduce_86(val, _values, result)
                              result = val[0].append({tag: val[1], tokens: val[2]})
 
@@ -1886,14 +1898,14 @@ module_eval(<<'.,.,', 'parser.y', 338)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 341)
+module_eval(<<'.,.,', 'parser.y', 338)
   def _reduce_87(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 342)
+module_eval(<<'.,.,', 'parser.y', 339)
   def _reduce_88(val, _values, result)
      result = val[0].append(val[1])
     result
@@ -1904,7 +1916,7 @@ module_eval(<<'.,.,', 'parser.y', 342)
 
 # reduce 90 omitted
 
-module_eval(<<'.,.,', 'parser.y', 349)
+module_eval(<<'.,.,', 'parser.y', 346)
   def _reduce_91(val, _values, result)
                   begin_c_declaration("}")
 
@@ -1912,7 +1924,7 @@ module_eval(<<'.,.,', 'parser.y', 349)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 353)
+module_eval(<<'.,.,', 'parser.y', 350)
   def _reduce_92(val, _values, result)
                   end_c_declaration
 
@@ -1920,7 +1932,7 @@ module_eval(<<'.,.,', 'parser.y', 353)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 357)
+module_eval(<<'.,.,', 'parser.y', 354)
   def _reduce_93(val, _values, result)
                   result = val[0].append(val[3])
 
@@ -1928,7 +1940,7 @@ module_eval(<<'.,.,', 'parser.y', 357)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 361)
+module_eval(<<'.,.,', 'parser.y', 358)
   def _reduce_94(val, _values, result)
                   begin_c_declaration("}")
 
@@ -1936,7 +1948,7 @@ module_eval(<<'.,.,', 'parser.y', 361)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 365)
+module_eval(<<'.,.,', 'parser.y', 362)
   def _reduce_95(val, _values, result)
                   end_c_declaration
 
@@ -1944,7 +1956,7 @@ module_eval(<<'.,.,', 'parser.y', 365)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 369)
+module_eval(<<'.,.,', 'parser.y', 366)
   def _reduce_96(val, _values, result)
                   result = [val[2]]
 
@@ -1952,7 +1964,7 @@ module_eval(<<'.,.,', 'parser.y', 369)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 374)
+module_eval(<<'.,.,', 'parser.y', 371)
   def _reduce_97(val, _values, result)
                                              result = [{tag: nil, tokens: val[0]}]
 
@@ -1960,7 +1972,7 @@ module_eval(<<'.,.,', 'parser.y', 374)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 378)
+module_eval(<<'.,.,', 'parser.y', 375)
   def _reduce_98(val, _values, result)
                                              result = [{tag: val[0], tokens: val[1]}]
 
@@ -1968,7 +1980,7 @@ module_eval(<<'.,.,', 'parser.y', 378)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 382)
+module_eval(<<'.,.,', 'parser.y', 379)
   def _reduce_99(val, _values, result)
                                              result = val[0].append({tag: val[1], tokens: val[2]})
 
@@ -1976,14 +1988,14 @@ module_eval(<<'.,.,', 'parser.y', 382)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 385)
+module_eval(<<'.,.,', 'parser.y', 382)
   def _reduce_100(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 386)
+module_eval(<<'.,.,', 'parser.y', 383)
   def _reduce_101(val, _values, result)
      result = val[0].append(val[1])
     result
@@ -1992,14 +2004,14 @@ module_eval(<<'.,.,', 'parser.y', 386)
 
 # reduce 102 omitted
 
-module_eval(<<'.,.,', 'parser.y', 390)
+module_eval(<<'.,.,', 'parser.y', 387)
   def _reduce_103(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 391)
+module_eval(<<'.,.,', 'parser.y', 388)
   def _reduce_104(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
@@ -2014,7 +2026,7 @@ module_eval(<<'.,.,', 'parser.y', 391)
 
 # reduce 108 omitted
 
-module_eval(<<'.,.,', 'parser.y', 401)
+module_eval(<<'.,.,', 'parser.y', 398)
   def _reduce_109(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
@@ -2028,7 +2040,7 @@ module_eval(<<'.,.,', 'parser.y', 401)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 412)
+module_eval(<<'.,.,', 'parser.y', 409)
   def _reduce_110(val, _values, result)
                     builder = val[0]
                 if !builder.line
@@ -2040,7 +2052,7 @@ module_eval(<<'.,.,', 'parser.y', 412)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 420)
+module_eval(<<'.,.,', 'parser.y', 417)
   def _reduce_111(val, _values, result)
                     builder = val[2]
                 if !builder.line
@@ -2052,7 +2064,7 @@ module_eval(<<'.,.,', 'parser.y', 420)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 429)
+module_eval(<<'.,.,', 'parser.y', 426)
   def _reduce_112(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -2061,7 +2073,7 @@ module_eval(<<'.,.,', 'parser.y', 429)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 434)
+module_eval(<<'.,.,', 'parser.y', 431)
   def _reduce_113(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -2070,7 +2082,7 @@ module_eval(<<'.,.,', 'parser.y', 434)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 439)
+module_eval(<<'.,.,', 'parser.y', 436)
   def _reduce_114(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
@@ -2082,7 +2094,7 @@ module_eval(<<'.,.,', 'parser.y', 439)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 447)
+module_eval(<<'.,.,', 'parser.y', 444)
   def _reduce_115(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
@@ -2094,7 +2106,7 @@ module_eval(<<'.,.,', 'parser.y', 447)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 455)
+module_eval(<<'.,.,', 'parser.y', 452)
   def _reduce_116(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
@@ -2106,7 +2118,7 @@ module_eval(<<'.,.,', 'parser.y', 455)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 463)
+module_eval(<<'.,.,', 'parser.y', 460)
   def _reduce_117(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
@@ -2118,7 +2130,7 @@ module_eval(<<'.,.,', 'parser.y', 463)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 471)
+module_eval(<<'.,.,', 'parser.y', 468)
   def _reduce_118(val, _values, result)
                end_c_declaration
 
@@ -2126,7 +2138,7 @@ module_eval(<<'.,.,', 'parser.y', 471)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 475)
+module_eval(<<'.,.,', 'parser.y', 472)
   def _reduce_119(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
@@ -2139,7 +2151,7 @@ module_eval(<<'.,.,', 'parser.y', 475)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 484)
+module_eval(<<'.,.,', 'parser.y', 481)
   def _reduce_120(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
@@ -2151,56 +2163,56 @@ module_eval(<<'.,.,', 'parser.y', 484)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 491)
+module_eval(<<'.,.,', 'parser.y', 488)
   def _reduce_121(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 492)
+module_eval(<<'.,.,', 'parser.y', 489)
   def _reduce_122(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 493)
+module_eval(<<'.,.,', 'parser.y', 490)
   def _reduce_123(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 495)
+module_eval(<<'.,.,', 'parser.y', 492)
   def _reduce_124(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 496)
+module_eval(<<'.,.,', 'parser.y', 493)
   def _reduce_125(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 497)
+module_eval(<<'.,.,', 'parser.y', 494)
   def _reduce_126(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 498)
+module_eval(<<'.,.,', 'parser.y', 495)
   def _reduce_127(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 500)
+module_eval(<<'.,.,', 'parser.y', 497)
   def _reduce_128(val, _values, result)
      result = val[1].s_value
     result
@@ -2209,7 +2221,7 @@ module_eval(<<'.,.,', 'parser.y', 500)
 
 # reduce 129 omitted
 
-module_eval(<<'.,.,', 'parser.y', 506)
+module_eval(<<'.,.,', 'parser.y', 503)
   def _reduce_130(val, _values, result)
                     begin_c_declaration('\Z')
                 @grammar.epilogue_first_lineno = @lexer.line + 1
@@ -2218,7 +2230,7 @@ module_eval(<<'.,.,', 'parser.y', 506)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 511)
+module_eval(<<'.,.,', 'parser.y', 508)
   def _reduce_131(val, _values, result)
                     end_c_declaration
                 @grammar.epilogue = val[2].s_value
@@ -2237,14 +2249,14 @@ module_eval(<<'.,.,', 'parser.y', 511)
 
 # reduce 136 omitted
 
-module_eval(<<'.,.,', 'parser.y', 522)
+module_eval(<<'.,.,', 'parser.y', 519)
   def _reduce_137(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 523)
+module_eval(<<'.,.,', 'parser.y', 520)
   def _reduce_138(val, _values, result)
      result = val[0].append(val[1])
     result
@@ -2255,7 +2267,7 @@ module_eval(<<'.,.,', 'parser.y', 523)
 
 # reduce 140 omitted
 
-module_eval(<<'.,.,', 'parser.y', 528)
+module_eval(<<'.,.,', 'parser.y', 525)
   def _reduce_141(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -1159,11 +1159,11 @@ Racc_token_to_s_table = [
   "prologue_declaration",
   "bison_declaration",
   "rules_or_grammar_declaration",
-  "epilogue",
+  "epilogue_declaration",
   "\"-many@prologue_declaration\"",
   "\"-many@bison_declaration\"",
   "\"-many1@rules_or_grammar_declaration\"",
-  "\"-option@epilogue\"",
+  "\"-option@epilogue_declaration\"",
   "@1",
   "@2",
   "grammar_declaration",
@@ -2056,8 +2056,8 @@ module_eval(<<'.,.,', 'parser.y', 387)
 
 module_eval(<<'.,.,', 'parser.y', 391)
   def _reduce_115(val, _values, result)
-                    begin_c_declaration('\Z')
-                @grammar.epilogue_first_lineno = @lexer.line + 1
+                                begin_c_declaration('\Z')
+                            @grammar.epilogue_first_lineno = @lexer.line + 1
 
     result
   end
@@ -2065,8 +2065,8 @@ module_eval(<<'.,.,', 'parser.y', 391)
 
 module_eval(<<'.,.,', 'parser.y', 396)
   def _reduce_116(val, _values, result)
-                    end_c_declaration
-                @grammar.epilogue = val[2].s_value
+                                end_c_declaration
+                            @grammar.epilogue = val[2].s_value
 
     result
   end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 482)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 473)
 
 include Lrama::Report::Duration
 
@@ -728,44 +728,44 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    95,    48,    96,   182,    85,    77,    48,    48,   187,   182,
-    77,    77,    48,    48,   187,    47,    77,   183,    69,    48,
-     6,    47,   189,   183,    81,    48,    40,    47,   189,    77,
-    74,    48,   159,    47,    41,   160,    81,    93,    44,    48,
-    48,    47,    47,    86,    81,    81,   184,   185,    45,    97,
-   160,   190,   184,    93,     4,    52,     5,   190,    20,    24,
+    94,    48,    95,   181,    85,    77,    48,    48,   187,   181,
+    77,    77,    48,    48,   187,    47,    77,   184,    69,    48,
+     6,    47,   184,   184,    81,    48,    40,    47,   184,    77,
+    74,    48,   158,    47,    41,   159,    81,    92,    44,    48,
+    48,    47,    47,    86,    81,    81,   183,   185,    45,    96,
+   159,   190,   183,    92,     4,    52,     5,   190,    20,    24,
     25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
     35,    36,    37,    38,    20,    24,    25,    26,    27,    28,
     29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-    11,    12,    13,    14,    15,    16,    93,   120,    17,    18,
+    11,    12,    13,    14,    15,    16,   118,   119,    17,    18,
     19,    52,    20,    24,    25,    26,    27,    28,    29,    30,
     31,    32,    33,    34,    35,    36,    37,    38,    11,    12,
     13,    14,    15,    16,    52,    55,    17,    18,    19,    43,
     20,    24,    25,    26,    27,    28,    29,    30,    31,    32,
     33,    34,    35,    36,    37,    38,    48,     4,    47,     5,
-    48,   116,    47,    56,    77,   195,    48,    48,    47,    47,
+    48,   115,    47,    56,    77,   195,    48,    48,    47,    47,
     77,   195,    48,    48,    47,    47,    77,   195,    48,    48,
     47,    47,    77,   195,    48,    48,    47,    47,    77,    77,
-    48,    48,    47,    47,    77,    77,    48,    48,    47,   218,
-    77,    77,    48,    48,   218,    47,    77,    77,    48,    48,
-   218,    47,    77,   202,   203,   204,   131,   202,   203,   204,
-   131,   225,   230,   239,   226,   226,   226,    48,    48,    47,
+    48,    48,    47,    47,    77,    77,    48,    48,    47,   219,
+    77,    77,    48,    48,   219,    47,    77,    77,    48,    48,
+   219,    47,    77,   202,   203,   204,   130,   202,   203,   204,
+   130,   226,   231,   238,   227,   227,   227,    48,    48,    47,
     47,    48,    57,    47,   202,   203,   204,    58,    59,    60,
-    61,    62,    63,    64,    65,    87,    52,   100,   106,   109,
-   111,   118,   125,   126,   128,   131,   132,   134,   135,   136,
-   137,   138,    77,   145,   146,   147,   148,   150,   151,   153,
-   163,   145,   165,   168,   169,   170,   172,   173,   174,   175,
-   176,   177,   179,   180,   186,   191,   198,   163,   205,   208,
-   168,   210,   163,   220,   163,   131,   224,   180,   227,   180,
-   177,   177,   236,   131,   238,   131,   177,   131,   177 ]
+    61,    62,    63,    64,    65,    87,    52,    99,   105,   108,
+   110,   117,   124,   125,   127,   130,   131,   133,   134,   135,
+   136,   137,    77,   144,   145,   146,   147,   149,   150,   152,
+   162,   144,   164,   167,   168,   169,   171,   172,   173,   174,
+   175,   176,   178,   179,   186,   191,   198,   162,   205,   130,
+   209,   167,   211,   130,   162,   221,   162,   130,   176,   179,
+   228,   179,   176,   176,   236,   130,   176 ]
 
 racc_action_check = [
-    46,   162,    46,   162,    38,   162,   167,   199,   167,   199,
-   167,   199,   209,    32,   209,    32,   209,   162,    32,    34,
-     1,    34,   167,   199,    34,    33,     5,    33,   209,    33,
-    33,    35,   144,    35,     6,   144,    35,    44,     9,    36,
-    37,    36,    37,    38,    36,    37,   162,   164,    11,    46,
-   164,   167,   199,    88,     0,    13,     0,   209,    44,    44,
+    46,   161,    46,   161,    38,   161,   166,   199,   166,   199,
+   166,   199,   210,    32,   210,    32,   210,   161,    32,    34,
+     1,    34,   166,   199,    34,    33,     5,    33,   210,    33,
+    33,    35,   143,    35,     6,   143,    35,    44,     9,    36,
+    37,    36,    37,    38,    36,    37,   161,   163,    11,    46,
+   163,   166,   199,    88,     0,    13,     0,   210,    44,    44,
     44,    44,    44,    44,    44,    44,    44,    44,    44,    44,
     44,    44,    44,    44,    88,    88,    88,    88,    88,    88,
     88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
@@ -775,21 +775,21 @@ racc_action_check = [
      8,     8,     8,     8,    15,    16,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,    79,     2,    79,     2,
-   174,    79,   174,    17,   174,   174,   175,    12,   175,    12,
-   175,   175,   176,    67,   176,    67,   176,   176,   192,    69,
+   173,    79,   173,    17,   173,   173,   174,    12,   174,    12,
+   174,   174,   175,    67,   175,    67,   175,   175,   192,    69,
    192,    69,   192,   192,    72,    74,    72,    74,    72,    74,
-   111,   184,   111,   184,   111,   184,   190,   205,   190,   205,
-   190,   205,   210,   226,   210,   226,   210,   226,   227,    81,
-   227,    81,   227,   181,   181,   181,   181,   188,   188,   188,
-   188,   217,   222,   235,   217,   222,   235,   106,   114,   106,
-   114,   116,    20,   116,   219,   219,   219,    24,    25,    26,
+   110,   183,   110,   183,   110,   183,   190,   205,   190,   205,
+   190,   205,   211,   227,   211,   227,   211,   227,   228,    81,
+   228,    81,   228,   180,   180,   180,   180,   188,   188,   188,
+   188,   218,   223,   235,   218,   223,   235,   105,   113,   105,
+   113,   115,    20,   115,   220,   220,   220,    24,    25,    26,
     27,    28,    29,    30,    31,    39,    50,    55,    66,    70,
-    71,    85,    89,    90,    91,    92,    99,   101,   102,   103,
-   104,   105,   110,   118,   119,   120,   121,   130,   131,   133,
-   146,   147,   149,   150,   151,   152,   154,   155,   156,   157,
-   158,   159,   160,   161,   166,   171,   178,   180,   182,   185,
-   186,   187,   198,   206,   208,   212,   213,   216,   218,   221,
-   223,   225,   229,   230,   232,   236,   237,   238,   242 ]
+    71,    85,    89,    90,    91,    92,    98,   100,   101,   102,
+   103,   104,   109,   117,   118,   119,   120,   129,   130,   132,
+   145,   146,   148,   149,   150,   151,   153,   154,   155,   156,
+   157,   158,   159,   160,   165,   170,   177,   179,   181,   182,
+   185,   186,   187,   189,   198,   208,   209,   213,   214,   217,
+   219,   222,   224,   226,   230,   231,   237 ]
 
 racc_action_pointer = [
     44,    20,   137,    77,   nil,    19,    34,   nil,   105,    29,
@@ -801,101 +801,97 @@ racc_action_pointer = [
    nil,   nil,   nil,   nil,   nil,   nil,   230,   160,   nil,   166,
    233,   232,   171,   nil,   172,   nil,   nil,   nil,   nil,   143,
    nil,   196,   nil,   nil,   nil,   200,    92,   nil,    49,   233,
-   219,   220,   193,   nil,   nil,   nil,   nil,   nil,   nil,   244,
-   nil,   245,   246,   247,   248,   249,   214,   nil,   nil,   nil,
-   245,   177,   nil,   nil,   215,   nil,   218,   nil,   248,   211,
-   214,   245,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   214,   253,   nil,   257,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   -10,   nil,   213,   256,   nil,   260,
-   216,   211,   245,   nil,   246,   247,   248,   249,   250,   263,
-   267,   227,    -2,   nil,     5,   nil,   228,     3,   nil,   nil,
-   nil,   255,   nil,   nil,   147,   153,   159,   nil,   233,   nil,
-   230,   154,   237,   nil,   178,   236,   233,   240,   158,   nil,
-   183,   nil,   165,   nil,   nil,   nil,   nil,   nil,   235,     4,
-   nil,   nil,   nil,   nil,   nil,   184,   281,   nil,   237,     9,
-   189,   nil,   233,   284,   nil,   nil,   241,   169,   247,   175,
-   nil,   243,   170,   282,   nil,   283,   190,   195,   nil,   272,
-   241,   nil,   274,   nil,   nil,   171,   243,   288,   245,   nil,
-   nil,   nil,   290,   nil ]
+   219,   220,   193,   nil,   nil,   nil,   nil,   nil,   244,   nil,
+   245,   246,   247,   248,   249,   214,   nil,   nil,   nil,   245,
+   177,   nil,   nil,   215,   nil,   218,   nil,   248,   211,   214,
+   245,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   214,
+   253,   nil,   257,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   -10,   nil,   213,   256,   nil,   260,   216,
+   211,   245,   nil,   246,   247,   248,   249,   250,   263,   267,
+   227,    -2,   nil,     5,   nil,   228,     3,   nil,   nil,   nil,
+   255,   nil,   nil,   147,   153,   159,   nil,   233,   nil,   230,
+   154,   237,   227,   178,   nil,   237,   234,   241,   158,   231,
+   183,   nil,   165,   nil,   nil,   nil,   nil,   nil,   237,     4,
+   nil,   nil,   nil,   nil,   nil,   184,   nil,   nil,   283,   239,
+     9,   189,   nil,   235,   280,   nil,   nil,   243,   169,   249,
+   175,   nil,   245,   170,   284,   nil,   285,   190,   195,   nil,
+   274,   243,   nil,   nil,   nil,   171,   nil,   288,   nil,   nil ]
 
 racc_action_default = [
-    -1,  -141,    -1,    -3,   -10,  -141,  -141,    -2,    -3,  -141,
-   -16,  -141,  -141,  -141,  -141,  -141,  -141,  -141,   -28,   -29,
-  -141,   -36,   -37,   -38,  -141,  -141,  -141,  -141,  -141,  -141,
-  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,
-   -13,   244,    -4,   -30,  -141,   -17,  -134,  -104,  -105,  -133,
-   -14,   -19,   -96,   -20,   -21,  -141,   -25,   -33,   -39,   -42,
-   -45,   -48,   -49,   -50,   -51,   -52,   -53,   -59,   -61,  -141,
-   -64,   -54,   -89,   -91,  -141,   -94,   -95,  -140,   -55,   -99,
-  -101,  -141,   -56,   -57,   -58,  -141,  -141,   -11,    -5,    -7,
-  -106,  -141,   -76,  -130,   -18,  -135,  -136,  -137,   -15,  -141,
-   -22,  -141,  -141,  -141,  -141,  -141,  -141,   -60,   -62,   -65,
-   -87,  -141,   -90,   -92,   -99,  -100,  -141,  -102,  -141,  -141,
-  -141,  -141,    -6,    -8,    -9,  -131,  -107,  -108,  -109,   -77,
-  -141,  -141,   -97,  -141,   -26,   -34,   -40,   -43,   -46,   -63,
-   -66,   -88,   -93,  -103,  -141,   -72,   -78,  -141,   -12,  -141,
-  -113,  -141,  -141,   -23,  -141,  -141,  -141,  -141,  -141,   -67,
-  -141,   -70,   -74,   -79,  -141,  -132,  -110,  -111,  -114,  -129,
-   -98,  -141,   -27,   -35,  -141,  -141,  -141,   -68,  -141,   -73,
-   -78,   -76,  -104,   -83,  -141,  -141,  -113,  -104,   -76,  -118,
-  -141,   -24,   -31,   -41,  -138,  -139,   -44,   -47,   -78,   -75,
-   -80,   -81,  -122,  -123,  -124,  -141,  -141,   -86,   -78,  -112,
-  -141,  -115,   -76,  -141,  -121,   -32,   -69,  -141,  -104,  -125,
-   -84,   -71,  -141,   -67,  -119,   -67,  -141,  -141,  -127,  -141,
-   -76,  -116,  -141,   -82,  -126,  -141,   -76,   -67,   -76,  -128,
-   -85,  -117,   -67,  -120 ]
+    -1,  -139,    -1,    -3,   -10,  -139,  -139,    -2,    -3,  -139,
+   -16,  -139,  -139,  -139,  -139,  -139,  -139,  -139,   -28,   -29,
+  -139,   -36,   -37,   -38,  -139,  -139,  -139,  -139,  -139,  -139,
+  -139,  -139,  -139,  -139,  -139,  -139,  -139,  -139,  -139,  -139,
+   -13,   240,    -4,   -30,  -139,   -17,  -132,  -102,  -103,  -131,
+   -14,   -19,   -94,   -20,   -21,  -139,   -25,   -33,   -39,   -42,
+   -45,   -48,   -49,   -50,   -51,   -52,   -53,   -59,   -61,  -139,
+   -64,   -54,   -87,   -89,  -139,   -92,   -93,  -138,   -55,   -97,
+   -99,  -139,   -56,   -57,   -58,  -139,  -139,   -11,    -5,    -7,
+  -104,  -139,   -76,   -18,  -133,  -134,  -135,   -15,  -139,   -22,
+  -139,  -139,  -139,  -139,  -139,  -139,   -60,   -62,   -65,   -85,
+  -139,   -88,   -90,   -97,   -98,  -139,  -100,  -139,  -139,  -139,
+  -139,    -6,    -8,    -9,  -129,  -105,  -106,  -107,   -77,  -139,
+  -139,   -95,  -139,   -26,   -34,   -40,   -43,   -46,   -63,   -66,
+   -86,   -91,  -101,  -139,   -72,   -78,  -139,   -12,  -139,  -111,
+  -139,  -139,   -23,  -139,  -139,  -139,  -139,  -139,   -67,  -139,
+   -70,   -74,   -79,  -139,  -130,  -108,  -109,  -112,  -128,   -96,
+  -139,   -27,   -35,  -139,  -139,  -139,   -68,  -139,   -73,   -78,
+   -76,  -102,   -76,  -139,  -125,  -139,  -111,  -102,   -76,   -76,
+  -139,   -24,   -31,   -41,  -136,  -137,   -44,   -47,   -78,   -75,
+   -80,   -81,  -118,  -119,  -120,  -139,   -83,   -84,  -139,   -78,
+  -110,  -139,  -113,   -76,   -67,  -117,   -32,   -69,  -139,  -102,
+  -121,  -126,   -71,  -139,   -67,  -116,   -67,  -139,  -139,  -123,
+  -139,   -76,  -114,   -82,  -122,  -139,  -127,   -67,  -124,  -115 ]
 
 racc_goto_table = [
-   130,    49,    73,   178,    89,    68,    91,   201,   144,   115,
-   161,   117,     1,   167,   212,    51,    53,    54,   193,   196,
-   197,    70,     9,    79,    79,    79,    79,    42,   123,   217,
-    78,    82,    83,    84,   222,   124,   215,   164,    39,   121,
-   107,   112,   108,   113,   115,   228,   143,    46,   122,   209,
-    91,   235,    98,     3,    94,     7,    70,   133,    70,   171,
-   101,   154,   216,   102,   155,   103,   156,   231,   114,   233,
-   114,   181,   221,   104,   157,   105,   188,   158,    66,   139,
-   142,   241,    71,   194,   194,   194,   243,   140,   110,   200,
-   119,   199,   206,   207,   229,    70,   211,   141,    99,   214,
-   152,   194,   127,   114,   166,   114,   213,   232,   181,   149,
-   nil,   nil,   nil,   nil,   219,   nil,   nil,   nil,   188,   219,
-   223,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   234,   219,   nil,   237,   nil,
-   nil,   nil,   nil,   nil,   240,   nil,   242 ]
+   129,    49,    73,   177,   201,    68,    89,    91,   189,   160,
+   166,     1,   213,   193,   196,   197,   143,   180,     3,   122,
+     7,    70,   188,    79,    79,    79,    79,   123,     9,   194,
+   194,   194,   216,    42,    39,    51,    53,    54,   120,   207,
+   106,   111,   107,   112,   229,   163,   215,   210,   194,    46,
+   121,    91,   189,    93,   218,   180,    70,   132,    70,   225,
+   223,   220,   217,   170,   100,   153,   188,   220,   113,   232,
+   113,   233,    97,   222,   114,   101,   116,   235,   138,   141,
+   154,   102,   239,   234,   220,   155,   103,   156,   200,   104,
+   206,   157,    66,    71,    70,   139,   212,   214,    78,    82,
+    83,    84,   113,   109,   113,   199,   140,    98,   114,   151,
+   142,   126,   165,   208,   230,   148,   nil,   nil,   nil,   nil,
+   nil,   224,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   237 ]
 
 racc_goto_check = [
-    51,    39,    55,    44,     8,    38,    12,    49,    42,    58,
-    43,    58,     1,    62,    49,    16,    16,    16,    25,    25,
-    25,    39,     7,    39,    39,    39,    39,     7,     5,    50,
-    36,    36,    36,    36,    50,     9,    25,    42,    10,    11,
-    38,    55,    38,    55,    58,    49,    58,    13,     8,    62,
-    12,    50,    16,     6,    14,     6,    39,    17,    39,    18,
-    19,    20,    43,    26,    27,    28,    29,    44,    39,    44,
-    39,    47,    43,    30,    31,    32,    47,    33,    34,    38,
-    55,    44,    35,    47,    47,    47,    44,    40,    41,    51,
-    45,    46,    52,    47,    53,    39,    51,    54,    56,    47,
-    57,    47,    60,    39,    61,    39,    63,    64,    47,    65,
-   nil,   nil,   nil,   nil,    47,   nil,   nil,   nil,    47,    47,
-    51,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    47,    47,   nil,    51,   nil,
-   nil,   nil,   nil,   nil,    51,   nil,    51 ]
+    51,    39,    53,    44,    48,    38,     8,    12,    50,    43,
+    60,     1,    48,    25,    25,    25,    42,    46,     6,     5,
+     6,    39,    46,    39,    39,    39,    39,     9,     7,    46,
+    46,    46,    25,     7,    10,    16,    16,    16,    11,    46,
+    38,    53,    38,    53,    48,    42,    46,    60,    46,    13,
+     8,    12,    50,    14,    49,    46,    39,    17,    39,    44,
+    49,    46,    43,    18,    19,    20,    46,    46,    39,    44,
+    39,    44,    16,    43,    56,    26,    56,    49,    38,    53,
+    27,    28,    44,    46,    46,    29,    30,    31,    51,    32,
+    51,    33,    34,    35,    39,    40,    51,    51,    36,    36,
+    36,    36,    39,    41,    39,    45,    52,    54,    56,    55,
+    56,    58,    59,    61,    62,    63,   nil,   nil,   nil,   nil,
+   nil,    51,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    51 ]
 
 racc_goto_pointer = [
-   nil,    12,   nil,   nil,   nil,   -61,    53,    19,   -40,   -54,
-    34,   -48,   -38,    35,     8,   nil,     2,   -43,   -94,     4,
-   -73,   nil,   nil,   nil,   nil,  -156,     6,   -71,     7,   -70,
-    14,   -63,    15,   -61,    46,    49,    -4,   nil,   -27,   -11,
-   -23,    18,  -110,  -136,  -156,     4,   -89,   -91,   nil,  -174,
-  -176,   -92,   -91,  -126,   -13,   -31,    46,   -32,   -70,   nil,
-    12,   -46,  -137,   -83,  -117,   -16 ]
+   nil,    11,   nil,   nil,   nil,   -70,    18,    25,   -38,   -62,
+    30,   -49,   -37,    37,     7,   nil,    22,   -42,   -89,     8,
+   -68,   nil,   nil,   nil,   nil,  -160,    18,   -54,    23,   -50,
+    27,   -49,    29,   -46,    60,    60,    64,   nil,   -27,   -11,
+   -14,    33,  -101,  -136,  -155,   -74,  -144,   nil,  -176,  -151,
+  -158,   -92,    -3,   -31,    55,   -22,    -5,   nil,    21,   -37,
+  -139,   -71,  -107,    -9 ]
 
 racc_goto_default = [
    nil,   nil,     2,     8,    88,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,    10,   nil,   nil,    50,   nil,   nil,   nil,   nil,
    nil,    21,    22,    23,   192,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,    67,   nil,    75,
-   nil,   nil,   nil,   nil,   nil,    92,   162,    72,   129,   nil,
-   nil,   nil,   nil,   nil,    76,   nil,   nil,   nil,    80,    90,
-   nil,   nil,   nil,   nil,   nil,   nil ]
+   nil,   nil,   nil,   nil,   nil,   161,    72,   128,   nil,   nil,
+   182,   nil,    76,   nil,   nil,   nil,    80,    90,   nil,   nil,
+   nil,   nil,   nil,   nil ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -976,61 +972,59 @@ racc_reduce_table = [
   3, 98, :_reduce_75,
   0, 106, :_reduce_none,
   1, 106, :_reduce_none,
-  0, 101, :_reduce_78,
-  1, 101, :_reduce_79,
-  3, 101, :_reduce_80,
-  3, 101, :_reduce_81,
-  6, 101, :_reduce_82,
-  0, 107, :_reduce_83,
-  0, 108, :_reduce_84,
-  7, 101, :_reduce_85,
-  3, 101, :_reduce_86,
+  0, 100, :_reduce_78,
+  1, 100, :_reduce_79,
+  3, 100, :_reduce_80,
+  3, 100, :_reduce_81,
+  6, 100, :_reduce_82,
+  3, 100, :_reduce_83,
+  3, 100, :_reduce_84,
   0, 95, :_reduce_none,
-  1, 95, :_reduce_88,
-  1, 110, :_reduce_89,
-  2, 110, :_reduce_90,
-  1, 90, :_reduce_91,
-  2, 90, :_reduce_92,
-  3, 90, :_reduce_93,
-  1, 102, :_reduce_none,
-  1, 102, :_reduce_none,
-  0, 111, :_reduce_96,
-  0, 112, :_reduce_97,
-  5, 70, :_reduce_98,
-  1, 113, :_reduce_99,
-  2, 113, :_reduce_100,
-  1, 91, :_reduce_101,
-  2, 91, :_reduce_102,
-  3, 91, :_reduce_103,
-  1, 94, :_reduce_104,
-  1, 94, :_reduce_105,
-  0, 115, :_reduce_none,
-  1, 115, :_reduce_none,
+  1, 95, :_reduce_86,
+  1, 108, :_reduce_87,
+  2, 108, :_reduce_88,
+  1, 90, :_reduce_89,
+  2, 90, :_reduce_90,
+  3, 90, :_reduce_91,
+  1, 101, :_reduce_none,
+  1, 101, :_reduce_none,
+  0, 109, :_reduce_94,
+  0, 110, :_reduce_95,
+  5, 70, :_reduce_96,
+  1, 111, :_reduce_97,
+  2, 111, :_reduce_98,
+  1, 91, :_reduce_99,
+  2, 91, :_reduce_100,
+  3, 91, :_reduce_101,
+  1, 94, :_reduce_102,
+  1, 94, :_reduce_103,
+  0, 113, :_reduce_none,
+  1, 113, :_reduce_none,
   2, 59, :_reduce_none,
   2, 59, :_reduce_none,
-  4, 114, :_reduce_110,
-  1, 116, :_reduce_111,
-  3, 116, :_reduce_112,
-  0, 117, :_reduce_113,
-  1, 117, :_reduce_114,
-  3, 117, :_reduce_115,
-  5, 117, :_reduce_116,
-  7, 117, :_reduce_117,
-  0, 118, :_reduce_118,
-  0, 119, :_reduce_119,
-  8, 117, :_reduce_120,
-  3, 117, :_reduce_121,
-  1, 104, :_reduce_122,
-  1, 104, :_reduce_123,
-  1, 104, :_reduce_124,
-  1, 105, :_reduce_125,
-  3, 105, :_reduce_126,
-  2, 105, :_reduce_127,
-  4, 105, :_reduce_128,
-  3, 103, :_reduce_129,
-  1, 100, :_reduce_none,
-  0, 120, :_reduce_131,
-  3, 60, :_reduce_132,
+  4, 112, :_reduce_108,
+  1, 114, :_reduce_109,
+  3, 114, :_reduce_110,
+  0, 115, :_reduce_111,
+  1, 115, :_reduce_112,
+  3, 115, :_reduce_113,
+  5, 115, :_reduce_114,
+  7, 115, :_reduce_115,
+  4, 115, :_reduce_116,
+  3, 115, :_reduce_117,
+  1, 103, :_reduce_118,
+  1, 103, :_reduce_119,
+  1, 103, :_reduce_120,
+  1, 104, :_reduce_121,
+  3, 104, :_reduce_122,
+  2, 104, :_reduce_123,
+  4, 104, :_reduce_124,
+  0, 116, :_reduce_125,
+  0, 117, :_reduce_126,
+  5, 105, :_reduce_127,
+  3, 102, :_reduce_128,
+  0, 118, :_reduce_129,
+  3, 60, :_reduce_130,
   1, 68, :_reduce_none,
   0, 69, :_reduce_none,
   1, 69, :_reduce_none,
@@ -1038,11 +1032,11 @@ racc_reduce_table = [
   1, 69, :_reduce_none,
   1, 79, :_reduce_none,
   1, 79, :_reduce_none,
-  1, 109, :_reduce_140 ]
+  1, 107, :_reduce_138 ]
 
-racc_reduce_n = 141
+racc_reduce_n = 139
 
-racc_shift_n = 244
+racc_shift_n = 240
 
 racc_token_table = {
   false => 0,
@@ -1223,27 +1217,25 @@ Racc_token_to_s_table = [
   "rule_args",
   "rule_rhs_list",
   "\"-option@TAG\"",
-  "id_colon",
   "rule_rhs",
   "symbol",
   "named_ref",
   "parameterizing_suffix",
   "parameterizing_args",
+  "midrule_action",
   "\"-option@named_ref\"",
-  "@15",
-  "@16",
   "string_as_id",
   "\"-many1@symbol\"",
-  "@17",
-  "@18",
+  "@15",
+  "@16",
   "\"-many1@id\"",
   "rules",
   "\"-option@;\"",
   "rhs_list",
   "rhs",
-  "@19",
-  "@20",
-  "@21" ]
+  "@17",
+  "@18",
+  "@19" ]
 Ractor.make_shareable(Racc_token_to_s_table) if defined?(Ractor)
 
 Racc_debug_parser = true
@@ -1853,28 +1845,8 @@ module_eval(<<'.,.,', 'parser.y', 285)
 
 module_eval(<<'.,.,', 'parser.y', 291)
   def _reduce_83(val, _values, result)
-                  if @prec_seen
-                on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
-                @code_after_prec = true
-              end
-              begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 299)
-  def _reduce_84(val, _values, result)
-                  end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 303)
-  def _reduce_85(val, _values, result)
-                  user_code = val[3]
-              user_code.alias_name = val[6]
+                  user_code = val[1]
+              user_code.alias_name = val[2]
               builder = val[0]
               builder.user_code = user_code
               result = builder
@@ -1883,8 +1855,8 @@ module_eval(<<'.,.,', 'parser.y', 303)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 311)
-  def _reduce_86(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 299)
+  def _reduce_84(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1895,57 +1867,73 @@ module_eval(<<'.,.,', 'parser.y', 311)
   end
 .,.,
 
-# reduce 87 omitted
+# reduce 85 omitted
 
-module_eval(<<'.,.,', 'parser.y', 319)
-  def _reduce_88(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 307)
+  def _reduce_86(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 326)
+module_eval(<<'.,.,', 'parser.y', 314)
+  def _reduce_87(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 314)
+  def _reduce_88(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 309)
   def _reduce_89(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 326)
-  def _reduce_90(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 321)
-  def _reduce_91(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 322)
-  def _reduce_92(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 310)
+  def _reduce_90(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 323)
-  def _reduce_93(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 311)
+  def _reduce_91(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-# reduce 94 omitted
+# reduce 92 omitted
 
-# reduce 95 omitted
+# reduce 93 omitted
 
-module_eval(<<'.,.,', 'parser.y', 329)
-  def _reduce_96(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 317)
+  def _reduce_94(val, _values, result)
                    begin_c_declaration("}")
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 321)
+  def _reduce_95(val, _values, result)
+                   end_c_declaration
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 325)
+  def _reduce_96(val, _values, result)
+                   result = val[2]
 
     result
   end
@@ -1953,79 +1941,63 @@ module_eval(<<'.,.,', 'parser.y', 329)
 
 module_eval(<<'.,.,', 'parser.y', 333)
   def _reduce_97(val, _values, result)
-                   end_c_declaration
-
+    result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 337)
+module_eval(<<'.,.,', 'parser.y', 333)
   def _reduce_98(val, _values, result)
-                   result = val[2]
-
+    result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 345)
+module_eval(<<'.,.,', 'parser.y', 328)
   def _reduce_99(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 345)
-  def _reduce_100(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 340)
-  def _reduce_101(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 341)
-  def _reduce_102(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 329)
+  def _reduce_100(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 342)
-  def _reduce_103(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 330)
+  def _reduce_101(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 344)
-  def _reduce_104(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 332)
+  def _reduce_102(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 345)
-  def _reduce_105(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 333)
+  def _reduce_103(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
+# reduce 104 omitted
+
+# reduce 105 omitted
+
 # reduce 106 omitted
 
 # reduce 107 omitted
 
-# reduce 108 omitted
-
-# reduce 109 omitted
-
-module_eval(<<'.,.,', 'parser.y', 353)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 341)
+  def _reduce_108(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -2038,8 +2010,8 @@ module_eval(<<'.,.,', 'parser.y', 353)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 364)
-  def _reduce_111(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 352)
+  def _reduce_109(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2050,8 +2022,8 @@ module_eval(<<'.,.,', 'parser.y', 364)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 372)
-  def _reduce_112(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 360)
+  def _reduce_110(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2062,26 +2034,26 @@ module_eval(<<'.,.,', 'parser.y', 372)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 381)
+module_eval(<<'.,.,', 'parser.y', 369)
+  def _reduce_111(val, _values, result)
+               reset_precs
+           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 374)
+  def _reduce_112(val, _values, result)
+               reset_precs
+           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 379)
   def _reduce_113(val, _values, result)
-               reset_precs
-           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 386)
-  def _reduce_114(val, _values, result)
-               reset_precs
-           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 391)
-  def _reduce_115(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -2092,8 +2064,8 @@ module_eval(<<'.,.,', 'parser.y', 391)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 399)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 387)
+  def _reduce_114(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -2104,8 +2076,8 @@ module_eval(<<'.,.,', 'parser.y', 399)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 407)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 395)
+  def _reduce_115(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -2116,31 +2088,11 @@ module_eval(<<'.,.,', 'parser.y', 407)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 415)
-  def _reduce_118(val, _values, result)
-               if @prec_seen
-             on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
-             @code_after_prec = true
-           end
-           begin_c_declaration("}")
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 423)
-  def _reduce_119(val, _values, result)
-               end_c_declaration
-
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 427)
-  def _reduce_120(val, _values, result)
-               user_code = val[3]
-           user_code.alias_name = val[6]
-           user_code.tag = val[7]
+module_eval(<<'.,.,', 'parser.y', 403)
+  def _reduce_116(val, _values, result)
+               user_code = val[1]
+           user_code.alias_name = val[2]
+           user_code.tag = val[3]
            builder = val[0]
            builder.user_code = user_code
            result = builder
@@ -2149,8 +2101,8 @@ module_eval(<<'.,.,', 'parser.y', 427)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 436)
-  def _reduce_121(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 412)
+  def _reduce_117(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2161,66 +2113,92 @@ module_eval(<<'.,.,', 'parser.y', 436)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 443)
-  def _reduce_122(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 419)
+  def _reduce_118(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 444)
-  def _reduce_123(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 420)
+  def _reduce_119(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 445)
-  def _reduce_124(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 421)
+  def _reduce_120(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 447)
-  def _reduce_125(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 423)
+  def _reduce_121(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 448)
-  def _reduce_126(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 424)
+  def _reduce_122(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 449)
-  def _reduce_127(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 425)
+  def _reduce_123(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 450)
-  def _reduce_128(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 426)
+  def _reduce_124(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 452)
-  def _reduce_129(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 430)
+  def _reduce_125(val, _values, result)
+                          if @prec_seen
+                        on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
+                        @code_after_prec = true
+                      end
+                      begin_c_declaration("}")
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 438)
+  def _reduce_126(val, _values, result)
+                          end_c_declaration
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 442)
+  def _reduce_127(val, _values, result)
+                          result = val[2]
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 445)
+  def _reduce_128(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-# reduce 130 omitted
-
-module_eval(<<'.,.,', 'parser.y', 458)
-  def _reduce_131(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 449)
+  def _reduce_129(val, _values, result)
                     begin_c_declaration('\Z')
                 @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2228,14 +2206,18 @@ module_eval(<<'.,.,', 'parser.y', 458)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 463)
-  def _reduce_132(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 454)
+  def _reduce_130(val, _values, result)
                     end_c_declaration
                 @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
+
+# reduce 131 omitted
+
+# reduce 132 omitted
 
 # reduce 133 omitted
 
@@ -2247,12 +2229,8 @@ module_eval(<<'.,.,', 'parser.y', 463)
 
 # reduce 137 omitted
 
-# reduce 138 omitted
-
-# reduce 139 omitted
-
-module_eval(<<'.,.,', 'parser.y', 477)
-  def _reduce_140(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 468)
+  def _reduce_138(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 535)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 534)
 
 include Lrama::Report::Duration
 
@@ -728,68 +728,68 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-   101,    53,   102,   168,    90,    81,    53,    53,   185,   168,
-    81,    81,    53,     3,   185,    53,    81,    52,   170,   161,
-    72,     8,   162,   186,   170,     6,    53,     7,    52,   186,
+   102,    53,   103,   169,    90,    81,    53,    53,   186,   169,
+    81,    81,    53,     3,   186,    53,    81,    52,   171,   162,
+    72,     8,   163,   187,   171,     6,    53,     7,    52,   187,
     81,    77,    41,    53,    53,    52,    52,    47,    84,    84,
-    53,   188,    52,    91,   162,    84,   171,    48,    53,   103,
-    52,   187,   171,    84,    53,    50,    52,   187,    21,    25,
+    53,   189,    52,    91,   163,    84,   172,    48,    53,   104,
+    52,   188,   172,    84,    53,    50,    52,   188,    21,    25,
     26,    27,    28,    29,    30,    31,    32,    33,    34,    35,
     36,    37,    38,    39,    47,    53,    53,    52,    52,    95,
-    81,   203,    53,    53,    52,    52,    81,   203,    53,    56,
-    52,   225,    81,   203,   226,    21,    25,    26,    27,    28,
+    81,   204,    53,    53,    52,    52,    81,   204,    53,    56,
+    52,   226,    81,   204,   227,    21,    25,    26,    27,    28,
     29,    30,    31,    32,    33,    34,    35,    36,    37,    38,
-    39,     9,   193,   194,   195,    99,    12,    13,    14,    15,
-    16,    17,    47,   125,    18,    19,    20,    21,    25,    26,
+    39,     9,   194,   195,   196,   100,    12,    13,    14,    15,
+    16,    17,    47,   126,    18,    19,    20,    21,    25,    26,
     27,    28,    29,    30,    31,    32,    33,    34,    35,    36,
-    37,    38,    39,    53,    53,    52,    52,    81,   203,    53,
-    53,    52,    52,    81,   203,    53,    53,    52,    52,    81,
-   203,    53,    53,    52,    52,    81,    81,    53,    53,    52,
+    37,    38,    39,    53,    53,    52,    52,    81,   204,    53,
+    53,    52,    52,    81,   204,    53,    53,    52,    52,    81,
+   204,    53,    53,    52,    52,    81,    81,    53,    53,    52,
     52,    81,    81,    53,    53,    52,    52,    81,    81,    53,
-    53,    52,   214,    81,    81,    53,    53,   214,   214,    81,
-    81,    53,    53,    52,    52,    81,   193,   194,   195,    99,
-   230,   238,    56,   226,   226,    53,    53,    52,    52,    53,
-    53,    52,    52,   193,   194,   195,    56,    59,    60,    61,
+    53,    52,   215,    81,    81,    53,    53,   215,   215,    81,
+    81,    53,    53,    52,    52,    81,   194,   195,   196,   100,
+   231,   239,    56,   227,   227,    53,    53,    52,    52,    53,
+    53,    52,    52,   194,   195,   196,    56,    59,    60,    61,
     62,    63,    64,    65,    66,    67,    68,    69,    92,    48,
-    97,    99,   104,   104,   104,   106,   112,   115,   117,   120,
-   120,   120,   120,   123,   128,   129,   131,   133,   134,   135,
-   136,   137,    81,   144,   145,   146,   147,   148,   151,   152,
-   153,   155,   165,   144,   167,   173,   175,   176,   177,   178,
-   179,   180,   182,   183,   151,   190,   198,   199,   206,   165,
-   210,   213,    99,   218,   165,   222,   165,   224,   180,   183,
-   183,    99,   235,   180,   237,   180,    99,    99,   180 ]
+    97,   100,   105,   105,   105,   107,   113,   116,   118,   121,
+   121,   121,   121,   124,   129,   130,   132,   134,   135,   136,
+   137,   138,    81,   145,   146,   147,   148,   149,   152,   153,
+   154,   156,   166,   145,   168,   174,   176,   177,   178,   179,
+   180,   181,   183,   184,   152,   191,   199,   200,   207,   166,
+   211,   214,   100,   219,   166,   223,   166,   225,   181,   184,
+   184,   100,   236,   181,   238,   181,   100,   100,   181 ]
 
 racc_action_check = [
-    51,   150,    51,   150,    39,   150,   164,   189,   164,   189,
-   164,   189,   207,     1,   207,    33,   207,    33,   150,   143,
-    33,     3,   143,   164,   189,     2,    34,     2,    34,   207,
+    51,   151,    51,   151,    39,   151,   165,   190,   165,   190,
+   165,   190,   208,     1,   208,    33,   208,    33,   151,   144,
+    33,     3,   144,   165,   190,     2,    34,     2,    34,   208,
     34,    34,     7,    35,    36,    35,    36,     9,    35,    36,
-    37,   166,    37,    39,   166,    37,   150,    10,    38,    51,
-    38,   164,   189,    38,    13,    12,    13,   207,     9,     9,
+    37,   167,    37,    39,   167,    37,   151,    10,    38,    51,
+    38,   165,   190,    38,    13,    12,    13,   208,     9,     9,
      9,     9,     9,     9,     9,     9,     9,     9,     9,     9,
-     9,     9,     9,     9,    42,    71,   177,    71,   177,    42,
-   177,   177,   178,    72,   178,    72,   178,   178,   179,    14,
-   179,   215,   179,   179,   215,    42,    42,    42,    42,    42,
+     9,     9,     9,     9,    42,    71,   178,    71,   178,    42,
+   178,   178,   179,    72,   179,    72,   179,   179,   180,    14,
+   180,   216,   180,   180,   216,    42,    42,    42,    42,    42,
     42,    42,    42,    42,    42,    42,    42,    42,    42,    42,
-    42,     4,   169,   169,   169,   169,     4,     4,     4,     4,
+    42,     4,   170,   170,   170,   170,     4,     4,     4,     4,
      4,     4,    91,    91,     4,     4,     4,     4,     4,     4,
      4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-     4,     4,     4,   200,    83,   200,    83,   200,   200,   204,
-    84,   204,    84,   204,   204,   205,   112,   205,   112,   205,
-   205,    76,    77,    76,    77,    76,    77,   117,   119,   117,
-   119,   117,   119,   141,   171,   141,   171,   141,   171,   187,
-   190,   187,   190,   187,   190,   210,   224,   210,   224,   210,
-   224,   226,   114,   226,   114,   226,   184,   184,   184,   184,
-   221,   232,    15,   221,   232,   120,   122,   120,   122,   138,
-   142,   138,   142,   216,   216,   216,    16,    17,    18,    21,
+     4,     4,     4,   201,    83,   201,    83,   201,   201,   205,
+    84,   205,    84,   205,   205,   206,   113,   206,   113,   206,
+   206,    76,    77,    76,    77,    76,    77,   118,   120,   118,
+   120,   118,   120,   142,   172,   142,   172,   142,   172,   188,
+   191,   188,   191,   188,   191,   211,   225,   211,   225,   211,
+   225,   227,   115,   227,   115,   227,   185,   185,   185,   185,
+   222,   233,    15,   222,   233,   121,   123,   121,   123,   139,
+   143,   139,   143,   217,   217,   217,    16,    17,    18,    21,
     25,    26,    27,    28,    29,    30,    31,    32,    40,    44,
     45,    46,    55,    57,    58,    59,    70,    74,    75,    82,
-    87,    88,    89,    90,    98,    99,   105,   107,   108,   109,
-   110,   111,   116,   123,   124,   125,   126,   127,   128,   129,
-   130,   132,   145,   146,   149,   154,   156,   157,   158,   159,
-   160,   161,   162,   163,   167,   168,   172,   174,   181,   183,
-   185,   188,   192,   196,   206,   211,   213,   214,   217,   220,
-   223,   225,   229,   230,   231,   233,   235,   237,   240 ]
+    87,    88,    89,    90,    99,   100,   106,   108,   109,   110,
+   111,   112,   117,   124,   125,   126,   127,   128,   129,   130,
+   131,   133,   146,   147,   150,   155,   157,   158,   159,   160,
+   161,   162,   163,   164,   168,   169,   173,   175,   182,   184,
+   186,   189,   193,   197,   207,   212,   214,   215,   218,   221,
+   224,   226,   230,   231,   232,   234,   236,   238,   241 ]
 
 racc_action_pointer = [
    nil,    13,    15,    21,   102,   nil,   nil,    25,   nil,    33,
@@ -801,111 +801,111 @@ racc_action_pointer = [
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
    228,    72,    80,   nil,   231,   230,   158,   159,   nil,   nil,
    nil,   nil,   231,   141,   147,   nil,   nil,   232,   233,   234,
-   202,   118,   nil,   nil,   nil,   nil,   nil,   nil,   201,   240,
-   nil,   nil,   nil,   nil,   nil,   244,   nil,   245,   246,   247,
-   248,   249,   153,   nil,   189,   nil,   245,   164,   nil,   165,
-   202,   nil,   203,   248,   211,   214,   245,   255,   211,   206,
-   258,   nil,   259,   nil,   nil,   nil,   nil,   nil,   206,   nil,
-   nil,   170,   207,   -23,   nil,   215,   258,   nil,   nil,   218,
-    -2,   nil,   nil,   nil,   244,   nil,   245,   246,   247,   248,
-   249,   263,   267,   227,     3,   nil,    -1,   227,   234,    63,
-   nil,   171,   255,   nil,   256,   nil,   nil,    73,    79,    85,
-   nil,   235,   nil,   232,   147,   239,   nil,   176,   238,     4,
-   177,   nil,   230,   nil,   nil,   nil,   281,   nil,   nil,   nil,
-   140,   nil,   nil,   nil,   146,   152,   237,     9,   nil,   nil,
-   182,   283,   nil,   239,   246,    49,   164,   280,   nil,   nil,
-   243,   158,   nil,   244,   183,   239,   188,   nil,   nil,   271,
-   285,   273,   159,   287,   nil,   244,   nil,   245,   nil,   nil,
-   290,   nil,   nil ]
+   202,   118,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   201,
+   240,   nil,   nil,   nil,   nil,   nil,   244,   nil,   245,   246,
+   247,   248,   249,   153,   nil,   189,   nil,   245,   164,   nil,
+   165,   202,   nil,   203,   248,   211,   214,   245,   255,   211,
+   206,   258,   nil,   259,   nil,   nil,   nil,   nil,   nil,   206,
+   nil,   nil,   170,   207,   -23,   nil,   215,   258,   nil,   nil,
+   218,    -2,   nil,   nil,   nil,   244,   nil,   245,   246,   247,
+   248,   249,   263,   267,   227,     3,   nil,    -1,   227,   234,
+    63,   nil,   171,   255,   nil,   256,   nil,   nil,    73,    79,
+    85,   nil,   235,   nil,   232,   147,   239,   nil,   176,   238,
+     4,   177,   nil,   230,   nil,   nil,   nil,   281,   nil,   nil,
+   nil,   140,   nil,   nil,   nil,   146,   152,   237,     9,   nil,
+   nil,   182,   283,   nil,   239,   246,    49,   164,   280,   nil,
+   nil,   243,   158,   nil,   244,   183,   239,   188,   nil,   nil,
+   271,   285,   273,   159,   287,   nil,   244,   nil,   245,   nil,
+   nil,   290,   nil,   nil ]
 
 racc_action_default = [
-    -2,  -140,   -10,  -140,  -140,    -3,    -4,  -140,   243,  -140,
-    -8,   -12,  -140,  -140,  -140,  -140,  -140,  -140,  -140,   -24,
-   -25,  -140,   -29,   -30,   -31,  -140,  -140,  -140,  -140,  -140,
-  -140,  -140,  -140,  -140,  -140,  -140,  -140,  -140,  -140,  -140,
-  -140,    -7,  -127,  -101,    -8,  -140,  -124,  -126,    -9,   -11,
-   -13,  -131,   -99,  -100,  -130,   -15,   -90,   -16,   -17,  -140,
+    -2,  -141,   -10,  -141,  -141,    -3,    -4,  -141,   244,  -141,
+    -8,   -12,  -141,  -141,  -141,  -141,  -141,  -141,  -141,   -24,
+   -25,  -141,   -29,   -30,   -31,  -141,  -141,  -141,  -141,  -141,
+  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,  -141,
+  -141,    -7,  -128,  -103,    -8,  -141,   -69,  -127,    -9,   -11,
+   -13,  -132,  -101,  -102,  -131,   -15,   -92,   -16,   -17,  -141,
    -21,   -26,   -32,   -35,   -38,   -41,   -42,   -43,   -44,   -45,
-   -46,   -52,  -140,   -55,   -57,   -47,   -80,  -140,   -83,   -85,
-   -86,  -139,   -48,   -93,  -140,   -96,   -98,   -49,   -50,   -51,
-  -140,  -140,    -5,    -1,  -102,  -128,  -103,  -104,  -140,  -140,
-   -14,  -132,  -133,  -134,   -87,  -140,   -18,  -140,  -140,  -140,
-  -140,  -140,  -140,   -56,   -53,   -58,   -78,  -140,   -84,   -81,
-  -140,   -97,   -94,  -140,  -140,  -140,  -140,  -140,  -108,  -140,
-  -140,   -91,  -140,   -22,   -27,   -33,   -36,   -39,   -54,   -59,
-   -79,   -82,   -95,  -140,   -65,   -69,  -140,    -6,  -129,  -105,
-  -106,  -109,  -125,   -88,  -140,   -19,  -140,  -140,  -140,  -140,
-  -140,   -60,  -140,   -63,   -67,   -70,  -140,  -108,   -99,  -124,
-  -113,  -140,  -140,   -92,  -140,   -23,   -28,  -140,  -140,  -140,
-   -61,  -140,   -66,   -69,  -124,   -99,   -74,  -140,  -140,  -107,
-  -140,  -110,  -124,  -117,  -118,  -119,  -140,  -116,   -89,   -20,
-   -34,  -135,  -137,  -138,   -37,   -40,   -69,   -68,   -71,   -72,
-  -140,  -140,   -77,   -69,   -99,  -140,  -120,   -60,  -114,  -136,
-   -62,  -140,   -75,   -64,  -140,  -124,  -140,  -122,  -111,  -140,
-   -60,  -140,  -140,   -60,  -121,  -124,   -73,  -124,  -123,  -112,
-   -60,   -76,  -115 ]
+   -46,   -52,  -141,   -55,   -57,   -47,   -82,  -141,   -85,   -87,
+   -88,  -140,   -48,   -95,  -141,   -98,  -100,   -49,   -50,   -51,
+  -141,  -141,    -5,    -1,  -104,  -129,  -105,  -106,   -70,  -141,
+  -141,   -14,  -133,  -134,  -135,   -89,  -141,   -18,  -141,  -141,
+  -141,  -141,  -141,  -141,   -56,   -53,   -58,   -80,  -141,   -86,
+   -83,  -141,   -99,   -96,  -141,  -141,  -141,  -141,  -141,  -110,
+  -141,  -141,   -93,  -141,   -22,   -27,   -33,   -36,   -39,   -54,
+   -59,   -81,   -84,   -97,  -141,   -65,   -71,  -141,    -6,  -130,
+  -107,  -108,  -111,  -126,   -90,  -141,   -19,  -141,  -141,  -141,
+  -141,  -141,   -60,  -141,   -63,   -67,   -72,  -141,  -110,  -101,
+   -69,  -115,  -141,  -141,   -94,  -141,   -23,   -28,  -141,  -141,
+  -141,   -61,  -141,   -66,   -71,   -69,  -101,   -76,  -141,  -141,
+  -109,  -141,  -112,   -69,  -119,  -120,  -121,  -141,  -118,   -91,
+   -20,   -34,  -136,  -138,  -139,   -37,   -40,   -71,   -68,   -73,
+   -74,  -141,  -141,   -79,   -71,  -101,  -141,  -122,   -60,  -116,
+  -137,   -62,  -141,   -77,   -64,  -141,   -69,  -141,  -124,  -113,
+  -141,   -60,  -141,  -141,   -60,  -123,   -69,   -75,   -69,  -125,
+  -114,   -60,   -78,  -117 ]
 
 racc_goto_table = [
-    78,    76,    98,    54,   163,   122,   192,    71,   181,   113,
-   121,   150,    43,    49,   215,   143,    82,    87,    88,    89,
-     1,   209,     2,    74,     4,    86,    86,    86,    86,    42,
-    93,   219,     5,    40,   221,   219,   219,   126,   166,    10,
-    11,   142,   118,    78,   119,    94,   114,    96,   232,   121,
-   189,    51,   113,   227,    55,    57,    58,   200,   204,   205,
-   100,    74,    74,   132,   228,   220,   174,   107,   156,   121,
-   108,   157,   223,    86,    86,   109,   113,   236,   158,   110,
-   239,   159,   111,    78,   141,   118,   138,   242,   160,    70,
-    75,   139,   116,   124,   207,   211,   231,   140,   130,   172,
-   105,   154,    74,   149,    74,   196,   229,   118,   127,   nil,
-    86,   nil,    86,   nil,   nil,   nil,   169,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   191,   nil,   nil,    74,   nil,
-   184,   nil,    86,   nil,   nil,   nil,   nil,   197,   nil,   nil,
-   208,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   217,   nil,
-   nil,   nil,   nil,   212,   nil,   169,   216,   nil,   nil,   nil,
+    78,    76,    99,    54,   114,   193,   151,    71,   164,   182,
+   122,   144,   123,    49,   220,     1,     2,   216,   220,   220,
+   210,    43,     4,    74,    42,    86,    86,    86,    86,    82,
+    87,    88,    89,    93,   167,     5,    40,   222,    55,    57,
+    58,   127,   119,    78,   120,   190,   115,    96,   114,   143,
+   122,   233,   228,    10,    94,   201,   205,   206,    11,    51,
+   101,    74,    74,   133,   175,   229,   108,   157,   109,   221,
+   122,   158,   114,    86,    86,   110,   224,   159,   237,   111,
+   160,   240,   112,   161,    78,   142,   119,   139,   243,    70,
+    75,   140,   117,   125,   208,   212,   232,   141,   131,   173,
+   106,   155,   150,    74,   197,    74,   230,   128,   119,   nil,
+   nil,    86,   nil,    86,   nil,   nil,   nil,   170,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   192,   nil,   nil,    74,
+   nil,   185,   nil,    86,   nil,   nil,   nil,   nil,   198,   nil,
+   nil,   209,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   218,
+   nil,   nil,   nil,   nil,   213,   nil,   170,   217,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   184,   nil,   nil,   216,   nil,   nil,   nil,
-   nil,   233,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   216,   240,   234,   241 ]
+   nil,   nil,   nil,   nil,   185,   nil,   nil,   217,   nil,   nil,
+   nil,   nil,   234,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   217,   241,   235,   242 ]
 
 racc_goto_check = [
-    44,    51,    45,    36,    40,    56,    46,    34,    41,    35,
-    57,    61,    58,    10,    47,    39,    33,    33,    33,    33,
-     1,    46,     2,    36,     3,    36,    36,    36,    36,     4,
-     5,    65,     6,     7,    47,    65,    65,     8,    39,     9,
-    11,    56,    44,    44,    51,    58,    34,    10,    47,    57,
-    61,    12,    35,    46,    14,    14,    14,    22,    22,    22,
-    13,    36,    36,    15,    41,    40,    16,    17,    18,    57,
-    23,    24,    40,    36,    36,    25,    35,    41,    26,    27,
-    41,    28,    29,    44,    51,    44,    34,    41,    30,    31,
-    32,    37,    38,    42,    43,    48,    49,    50,    52,    53,
-    54,    55,    36,    60,    36,    62,    63,    44,    64,   nil,
-    36,   nil,    36,   nil,   nil,   nil,    44,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,    45,   nil,   nil,    36,   nil,
-    44,   nil,    36,   nil,   nil,   nil,   nil,    44,   nil,   nil,
-    45,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    45,   nil,
-   nil,   nil,   nil,    44,   nil,    44,    44,   nil,   nil,   nil,
+    44,    52,    48,    36,    35,    46,    62,    34,    40,    41,
+    58,    39,    57,    10,    66,     1,     2,    47,    66,    66,
+    46,    59,     3,    36,     4,    36,    36,    36,    36,    33,
+    33,    33,    33,     5,    39,     6,     7,    47,    14,    14,
+    14,     8,    44,    44,    52,    62,    34,    10,    35,    57,
+    58,    47,    46,     9,    59,    22,    22,    22,    11,    12,
+    13,    36,    36,    15,    16,    41,    17,    18,    23,    40,
+    58,    24,    35,    36,    36,    25,    40,    26,    41,    27,
+    28,    41,    29,    30,    44,    52,    44,    34,    41,    31,
+    32,    37,    38,    42,    43,    49,    50,    51,    53,    54,
+    55,    56,    61,    36,    63,    36,    64,    65,    44,   nil,
+   nil,    36,   nil,    36,   nil,   nil,   nil,    44,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    48,   nil,   nil,    36,
+   nil,    44,   nil,    36,   nil,   nil,   nil,   nil,    44,   nil,
+   nil,    48,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    48,
+   nil,   nil,   nil,   nil,    44,   nil,    44,    44,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,    44,   nil,   nil,    44,   nil,   nil,   nil,
-   nil,    45,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    44,    45,    44,    45 ]
+   nil,   nil,   nil,   nil,    44,   nil,   nil,    44,   nil,   nil,
+   nil,   nil,    48,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,    44,    48,    44,    48 ]
 
 racc_goto_pointer = [
-   nil,    20,    22,    22,    20,   -12,    30,    27,   -55,    35,
-     3,    36,    38,     9,    40,   -43,   -89,     7,   -65,   nil,
-   nil,   nil,  -120,     9,   -63,    13,   -57,    16,   -55,    18,
-   -49,    56,    56,   -19,   -26,   -62,   -10,   -25,    18,  -108,
-  -141,  -153,     2,   -89,   -34,   -44,  -163,  -176,   -91,  -126,
-   -19,   -33,    -6,   -54,    44,   -30,   -79,   -73,     3,   nil,
-   -25,  -117,   -65,  -112,    13,  -169 ]
+   nil,    15,    16,    20,    15,    -9,    33,    30,   -51,    49,
+     3,    54,    46,     9,    24,   -44,   -92,     6,   -67,   nil,
+   nil,   nil,  -123,     7,   -64,    13,   -59,    16,   -57,    18,
+   -55,    56,    56,    -6,   -26,   -67,   -10,   -26,    18,  -113,
+  -138,  -153,     2,   -90,   -34,   nil,  -165,  -174,   -44,   -92,
+  -127,   -20,   -33,    -7,   -55,    44,   -31,   -72,   -73,    12,
+   nil,   -27,  -123,   -67,  -113,    12,  -187 ]
 
 racc_goto_default = [
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
    nil,    45,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    22,
     23,    24,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,    73,    79,   nil,   nil,   nil,
-   nil,   nil,    46,   164,   202,   nil,   nil,   nil,   nil,   nil,
-    80,   nil,   nil,   nil,   nil,   nil,    83,    85,   nil,    44,
-   nil,   nil,   nil,   nil,   nil,   201 ]
+   nil,   nil,    46,   165,   203,    98,   nil,   nil,   nil,   nil,
+   nil,    80,   nil,   nil,   nil,   nil,   nil,    83,    85,   nil,
+    44,   nil,   nil,   nil,   nil,   nil,   202 ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -977,81 +977,82 @@ racc_reduce_table = [
   3, 94, :_reduce_66,
   1, 95, :_reduce_67,
   3, 95, :_reduce_68,
-  0, 98, :_reduce_69,
-  1, 98, :_reduce_70,
-  3, 98, :_reduce_71,
-  3, 98, :_reduce_72,
-  6, 98, :_reduce_73,
-  0, 103, :_reduce_74,
-  0, 104, :_reduce_75,
-  7, 98, :_reduce_76,
-  3, 98, :_reduce_77,
+  0, 103, :_reduce_none,
+  1, 103, :_reduce_none,
+  0, 98, :_reduce_71,
+  1, 98, :_reduce_72,
+  3, 98, :_reduce_73,
+  3, 98, :_reduce_74,
+  6, 98, :_reduce_75,
+  0, 104, :_reduce_76,
+  0, 105, :_reduce_77,
+  7, 98, :_reduce_78,
+  3, 98, :_reduce_79,
   0, 92, :_reduce_none,
-  1, 92, :_reduce_79,
-  1, 87, :_reduce_80,
-  2, 87, :_reduce_81,
-  3, 87, :_reduce_82,
-  1, 106, :_reduce_83,
-  2, 106, :_reduce_84,
+  1, 92, :_reduce_81,
+  1, 87, :_reduce_82,
+  2, 87, :_reduce_83,
+  3, 87, :_reduce_84,
+  1, 107, :_reduce_85,
+  2, 107, :_reduce_86,
   1, 99, :_reduce_none,
   1, 99, :_reduce_none,
-  0, 107, :_reduce_87,
-  0, 108, :_reduce_88,
-  6, 69, :_reduce_89,
+  0, 108, :_reduce_89,
   0, 109, :_reduce_90,
-  0, 110, :_reduce_91,
-  5, 69, :_reduce_92,
-  1, 88, :_reduce_93,
-  2, 88, :_reduce_94,
-  3, 88, :_reduce_95,
-  1, 111, :_reduce_96,
-  2, 111, :_reduce_97,
-  1, 112, :_reduce_none,
-  1, 91, :_reduce_99,
-  1, 91, :_reduce_100,
+  6, 69, :_reduce_91,
+  0, 110, :_reduce_92,
+  0, 111, :_reduce_93,
+  5, 69, :_reduce_94,
+  1, 88, :_reduce_95,
+  2, 88, :_reduce_96,
+  3, 88, :_reduce_97,
+  1, 112, :_reduce_98,
+  2, 112, :_reduce_99,
+  1, 113, :_reduce_none,
+  1, 91, :_reduce_101,
+  1, 91, :_reduce_102,
   1, 59, :_reduce_none,
   2, 59, :_reduce_none,
-  2, 113, :_reduce_none,
-  2, 113, :_reduce_none,
-  4, 114, :_reduce_105,
-  1, 115, :_reduce_106,
-  3, 115, :_reduce_107,
-  0, 116, :_reduce_108,
-  1, 116, :_reduce_109,
-  3, 116, :_reduce_110,
-  5, 116, :_reduce_111,
-  7, 116, :_reduce_112,
-  0, 117, :_reduce_113,
-  0, 118, :_reduce_114,
-  8, 116, :_reduce_115,
-  3, 116, :_reduce_116,
-  1, 101, :_reduce_117,
-  1, 101, :_reduce_118,
+  2, 114, :_reduce_none,
+  2, 114, :_reduce_none,
+  4, 115, :_reduce_107,
+  1, 116, :_reduce_108,
+  3, 116, :_reduce_109,
+  0, 117, :_reduce_110,
+  1, 117, :_reduce_111,
+  3, 117, :_reduce_112,
+  5, 117, :_reduce_113,
+  7, 117, :_reduce_114,
+  0, 118, :_reduce_115,
+  0, 119, :_reduce_116,
+  8, 117, :_reduce_117,
+  3, 117, :_reduce_118,
   1, 101, :_reduce_119,
-  1, 102, :_reduce_120,
-  3, 102, :_reduce_121,
-  2, 102, :_reduce_122,
-  4, 102, :_reduce_123,
-  0, 100, :_reduce_none,
-  3, 100, :_reduce_125,
+  1, 101, :_reduce_120,
+  1, 101, :_reduce_121,
+  1, 102, :_reduce_122,
+  3, 102, :_reduce_123,
+  2, 102, :_reduce_124,
+  4, 102, :_reduce_125,
+  3, 100, :_reduce_126,
   1, 97, :_reduce_none,
   0, 60, :_reduce_none,
-  0, 119, :_reduce_128,
-  3, 60, :_reduce_129,
+  0, 120, :_reduce_129,
+  3, 60, :_reduce_130,
   1, 67, :_reduce_none,
   0, 68, :_reduce_none,
   1, 68, :_reduce_none,
   1, 68, :_reduce_none,
   1, 68, :_reduce_none,
-  1, 77, :_reduce_135,
-  2, 77, :_reduce_136,
-  1, 120, :_reduce_none,
-  1, 120, :_reduce_none,
-  1, 105, :_reduce_139 ]
+  1, 77, :_reduce_136,
+  2, 77, :_reduce_137,
+  1, 121, :_reduce_none,
+  1, 121, :_reduce_none,
+  1, 106, :_reduce_140 ]
 
-racc_reduce_n = 140
+racc_reduce_n = 141
 
-racc_shift_n = 243
+racc_shift_n = 244
 
 racc_token_table = {
   false => 0,
@@ -1232,9 +1233,10 @@ Racc_token_to_s_table = [
   "id_colon",
   "rule_rhs",
   "symbol",
-  "named_ref_opt",
+  "named_ref",
   "parameterizing_suffix",
   "parameterizing_args",
+  "\"-option@named_ref\"",
   "@15",
   "@16",
   "string_as_id",
@@ -1747,8 +1749,12 @@ module_eval(<<'.,.,', 'parser.y', 262)
   end
 .,.,
 
+# reduce 69 omitted
+
+# reduce 70 omitted
+
 module_eval(<<'.,.,', 'parser.y', 268)
-  def _reduce_69(val, _values, result)
+  def _reduce_71(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1757,7 +1763,7 @@ module_eval(<<'.,.,', 'parser.y', 268)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 273)
-  def _reduce_70(val, _values, result)
+  def _reduce_72(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1766,7 +1772,7 @@ module_eval(<<'.,.,', 'parser.y', 273)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 278)
-  def _reduce_71(val, _values, result)
+  def _reduce_73(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1778,7 +1784,7 @@ module_eval(<<'.,.,', 'parser.y', 278)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 286)
-  def _reduce_72(val, _values, result)
+  def _reduce_74(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1788,7 +1794,7 @@ module_eval(<<'.,.,', 'parser.y', 286)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 292)
-  def _reduce_73(val, _values, result)
+  def _reduce_75(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1798,7 +1804,7 @@ module_eval(<<'.,.,', 'parser.y', 292)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 298)
-  def _reduce_74(val, _values, result)
+  def _reduce_76(val, _values, result)
                   if @prec_seen
                 on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                 @code_after_prec = true
@@ -1810,7 +1816,7 @@ module_eval(<<'.,.,', 'parser.y', 298)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 306)
-  def _reduce_75(val, _values, result)
+  def _reduce_77(val, _values, result)
                   end_c_declaration
 
     result
@@ -1818,7 +1824,7 @@ module_eval(<<'.,.,', 'parser.y', 306)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 310)
-  def _reduce_76(val, _values, result)
+  def _reduce_78(val, _values, result)
                   user_code = val[3]
               user_code.alias_name = val[6]
               builder = val[0]
@@ -1830,7 +1836,7 @@ module_eval(<<'.,.,', 'parser.y', 310)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 318)
-  def _reduce_77(val, _values, result)
+  def _reduce_79(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1841,17 +1847,17 @@ module_eval(<<'.,.,', 'parser.y', 318)
   end
 .,.,
 
-# reduce 78 omitted
+# reduce 80 omitted
 
 module_eval(<<'.,.,', 'parser.y', 326)
-  def _reduce_79(val, _values, result)
+  def _reduce_81(val, _values, result)
      result = val[0].s_value
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 330)
-  def _reduce_80(val, _values, result)
+  def _reduce_82(val, _values, result)
                                result = [{tag: nil, tokens: val[0]}]
 
     result
@@ -1859,7 +1865,7 @@ module_eval(<<'.,.,', 'parser.y', 330)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 334)
-  def _reduce_81(val, _values, result)
+  def _reduce_83(val, _values, result)
                                result = [{tag: val[0], tokens: val[1]}]
 
     result
@@ -1867,7 +1873,7 @@ module_eval(<<'.,.,', 'parser.y', 334)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 338)
-  def _reduce_82(val, _values, result)
+  def _reduce_84(val, _values, result)
                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
@@ -1875,25 +1881,25 @@ module_eval(<<'.,.,', 'parser.y', 338)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 341)
-  def _reduce_83(val, _values, result)
+  def _reduce_85(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 342)
-  def _reduce_84(val, _values, result)
+  def _reduce_86(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 85 omitted
+# reduce 87 omitted
 
-# reduce 86 omitted
+# reduce 88 omitted
 
 module_eval(<<'.,.,', 'parser.y', 349)
-  def _reduce_87(val, _values, result)
+  def _reduce_89(val, _values, result)
                   begin_c_declaration("}")
 
     result
@@ -1901,7 +1907,7 @@ module_eval(<<'.,.,', 'parser.y', 349)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 353)
-  def _reduce_88(val, _values, result)
+  def _reduce_90(val, _values, result)
                   end_c_declaration
 
     result
@@ -1909,7 +1915,7 @@ module_eval(<<'.,.,', 'parser.y', 353)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 357)
-  def _reduce_89(val, _values, result)
+  def _reduce_91(val, _values, result)
                   result = val[0].append(val[3])
 
     result
@@ -1917,7 +1923,7 @@ module_eval(<<'.,.,', 'parser.y', 357)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 361)
-  def _reduce_90(val, _values, result)
+  def _reduce_92(val, _values, result)
                   begin_c_declaration("}")
 
     result
@@ -1925,7 +1931,7 @@ module_eval(<<'.,.,', 'parser.y', 361)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 365)
-  def _reduce_91(val, _values, result)
+  def _reduce_93(val, _values, result)
                   end_c_declaration
 
     result
@@ -1933,7 +1939,7 @@ module_eval(<<'.,.,', 'parser.y', 365)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 369)
-  def _reduce_92(val, _values, result)
+  def _reduce_94(val, _values, result)
                   result = [val[2]]
 
     result
@@ -1941,7 +1947,7 @@ module_eval(<<'.,.,', 'parser.y', 369)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 374)
-  def _reduce_93(val, _values, result)
+  def _reduce_95(val, _values, result)
                                              result = [{tag: nil, tokens: val[0]}]
 
     result
@@ -1949,7 +1955,7 @@ module_eval(<<'.,.,', 'parser.y', 374)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 378)
-  def _reduce_94(val, _values, result)
+  def _reduce_96(val, _values, result)
                                              result = [{tag: val[0], tokens: val[1]}]
 
     result
@@ -1957,7 +1963,7 @@ module_eval(<<'.,.,', 'parser.y', 378)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 382)
-  def _reduce_95(val, _values, result)
+  def _reduce_97(val, _values, result)
                                              result = val[0].append({tag: val[1], tokens: val[2]})
 
     result
@@ -1965,45 +1971,45 @@ module_eval(<<'.,.,', 'parser.y', 382)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 385)
-  def _reduce_96(val, _values, result)
+  def _reduce_98(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 386)
-  def _reduce_97(val, _values, result)
+  def _reduce_99(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 98 omitted
+# reduce 100 omitted
 
 module_eval(<<'.,.,', 'parser.y', 390)
-  def _reduce_99(val, _values, result)
+  def _reduce_101(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 391)
-  def _reduce_100(val, _values, result)
+  def _reduce_102(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-# reduce 101 omitted
-
-# reduce 102 omitted
-
 # reduce 103 omitted
 
 # reduce 104 omitted
 
+# reduce 105 omitted
+
+# reduce 106 omitted
+
 module_eval(<<'.,.,', 'parser.y', 401)
-  def _reduce_105(val, _values, result)
+  def _reduce_107(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -2017,7 +2023,7 @@ module_eval(<<'.,.,', 'parser.y', 401)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 412)
-  def _reduce_106(val, _values, result)
+  def _reduce_108(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2029,7 +2035,7 @@ module_eval(<<'.,.,', 'parser.y', 412)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 420)
-  def _reduce_107(val, _values, result)
+  def _reduce_109(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -2041,7 +2047,7 @@ module_eval(<<'.,.,', 'parser.y', 420)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 429)
-  def _reduce_108(val, _values, result)
+  def _reduce_110(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -2050,7 +2056,7 @@ module_eval(<<'.,.,', 'parser.y', 429)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 434)
-  def _reduce_109(val, _values, result)
+  def _reduce_111(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -2059,7 +2065,7 @@ module_eval(<<'.,.,', 'parser.y', 434)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 439)
-  def _reduce_110(val, _values, result)
+  def _reduce_112(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -2071,7 +2077,7 @@ module_eval(<<'.,.,', 'parser.y', 439)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 447)
-  def _reduce_111(val, _values, result)
+  def _reduce_113(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -2083,7 +2089,7 @@ module_eval(<<'.,.,', 'parser.y', 447)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 455)
-  def _reduce_112(val, _values, result)
+  def _reduce_114(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -2095,7 +2101,7 @@ module_eval(<<'.,.,', 'parser.y', 455)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 463)
-  def _reduce_113(val, _values, result)
+  def _reduce_115(val, _values, result)
                if @prec_seen
              on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
              @code_after_prec = true
@@ -2107,7 +2113,7 @@ module_eval(<<'.,.,', 'parser.y', 463)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 471)
-  def _reduce_114(val, _values, result)
+  def _reduce_116(val, _values, result)
                end_c_declaration
 
     result
@@ -2115,7 +2121,7 @@ module_eval(<<'.,.,', 'parser.y', 471)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 475)
-  def _reduce_115(val, _values, result)
+  def _reduce_117(val, _values, result)
                user_code = val[3]
            user_code.alias_name = val[6]
            user_code.tag = val[7]
@@ -2128,7 +2134,7 @@ module_eval(<<'.,.,', 'parser.y', 475)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 484)
-  def _reduce_116(val, _values, result)
+  def _reduce_118(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2140,69 +2146,67 @@ module_eval(<<'.,.,', 'parser.y', 484)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 491)
-  def _reduce_117(val, _values, result)
+  def _reduce_119(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 492)
-  def _reduce_118(val, _values, result)
+  def _reduce_120(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 493)
-  def _reduce_119(val, _values, result)
+  def _reduce_121(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 495)
-  def _reduce_120(val, _values, result)
+  def _reduce_122(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 496)
-  def _reduce_121(val, _values, result)
+  def _reduce_123(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 497)
-  def _reduce_122(val, _values, result)
+  def _reduce_124(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 498)
-  def _reduce_123(val, _values, result)
+  def _reduce_125(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-# reduce 124 omitted
-
-module_eval(<<'.,.,', 'parser.y', 501)
-  def _reduce_125(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 500)
+  def _reduce_126(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-# reduce 126 omitted
-
 # reduce 127 omitted
 
-module_eval(<<'.,.,', 'parser.y', 508)
-  def _reduce_128(val, _values, result)
+# reduce 128 omitted
+
+module_eval(<<'.,.,', 'parser.y', 507)
+  def _reduce_129(val, _values, result)
                         begin_c_declaration('\Z')
                     @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2210,16 +2214,14 @@ module_eval(<<'.,.,', 'parser.y', 508)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 513)
-  def _reduce_129(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 512)
+  def _reduce_130(val, _values, result)
                         end_c_declaration
                     @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
-
-# reduce 130 omitted
 
 # reduce 131 omitted
 
@@ -2229,26 +2231,28 @@ module_eval(<<'.,.,', 'parser.y', 513)
 
 # reduce 134 omitted
 
-module_eval(<<'.,.,', 'parser.y', 524)
-  def _reduce_135(val, _values, result)
+# reduce 135 omitted
+
+module_eval(<<'.,.,', 'parser.y', 523)
+  def _reduce_136(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 525)
-  def _reduce_136(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 524)
+  def _reduce_137(val, _values, result)
      result = val[0].append(val[1])
     result
   end
 .,.,
 
-# reduce 137 omitted
-
 # reduce 138 omitted
 
-module_eval(<<'.,.,', 'parser.y', 530)
-  def _reduce_139(val, _values, result)
+# reduce 139 omitted
+
+module_eval(<<'.,.,', 'parser.y', 529)
+  def _reduce_140(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/parser.y
+++ b/parser.y
@@ -209,12 +209,7 @@ rule
                   result = val[0].append(builder)
                 }
 
-  rule_rhs: /* empty */
-            {
-              reset_precs
-              result = Grammar::ParameterizingRule::Rhs.new
-            }
-          | "%empty"
+  rule_rhs: empty
             {
               reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
@@ -317,12 +312,7 @@ rule
                 result = val[0].append(builder)
               }
 
-  rhs: /* empty */
-         {
-           reset_precs
-           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
-         }
-     | "%empty"
+  rhs: empty
          {
            reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
@@ -417,6 +407,9 @@ rule
 
   generic_symbol: symbol
                 | TAG
+
+  empty: /* empty */
+       | "%empty"
 
   string_as_id: STRING { result = Lrama::Lexer::Token::Ident.new(s_value: val[0]) }
 end

--- a/parser.y
+++ b/parser.y
@@ -6,7 +6,7 @@ class Lrama::Parser
 
 rule
 
-  input: prologue_declaration* bison_declarations "%%" grammar epilogue?
+  input: prologue_declaration* bison_declaration* "%%" grammar epilogue?
 
   prologue_declaration: "%{"
                           {
@@ -23,8 +23,6 @@ rule
                           }
                       | "%require" STRING
 
-  bison_declarations: /* empty */ { result = "" }
-                    | bison_declarations bison_declaration ";"?
 
   bison_declaration: grammar_declaration
                    | "%expect" INTEGER { @grammar.expect = val[1] }
@@ -68,6 +66,7 @@ rule
                        }
                    | "%no-stdlib" { @grammar.no_stdlib = true }
                    | "%locations" { @grammar.locations = true }
+                   | bison_declaration ";"
 
   grammar_declaration: "%union" "{"
                          {

--- a/parser.y
+++ b/parser.y
@@ -23,7 +23,6 @@ rule
                           }
                       | "%require" STRING
 
-
   bison_declaration: grammar_declaration
                    | "%expect" INTEGER { @grammar.expect = val[1] }
                    | "%define" variable value

--- a/parser.y
+++ b/parser.y
@@ -6,10 +6,7 @@ class Lrama::Parser
 
 rule
 
-  input: prologue_declarations bison_declarations "%%" grammar epilogue?
-
-  prologue_declarations: # empty
-                       | prologue_declarations prologue_declaration
+  input: prologue_declaration* bison_declarations "%%" grammar epilogue?
 
   prologue_declaration: "%{"
                           {

--- a/parser.y
+++ b/parser.y
@@ -6,7 +6,7 @@ class Lrama::Parser
 
 rule
 
-  input: prologue_declaration* bison_declaration* "%%" rules_or_grammar_declaration+ epilogue?
+  input: prologue_declaration* bison_declaration* "%%" rules_or_grammar_declaration+ epilogue_declaration?
 
   prologue_declaration: "%{"
                           {
@@ -387,16 +387,16 @@ rule
 
   named_ref: '[' IDENTIFIER ']' { result = val[1].s_value }
 
-  epilogue: "%%"
-              {
-                begin_c_declaration('\Z')
-                @grammar.epilogue_first_lineno = @lexer.line + 1
-              }
-            C_DECLARATION
-              {
-                end_c_declaration
-                @grammar.epilogue = val[2].s_value
-              }
+  epilogue_declaration: "%%"
+                          {
+                            begin_c_declaration('\Z')
+                            @grammar.epilogue_first_lineno = @lexer.line + 1
+                          }
+                        C_DECLARATION
+                          {
+                            end_c_declaration
+                            @grammar.epilogue = val[2].s_value
+                          }
 
   variable: id
 

--- a/parser.y
+++ b/parser.y
@@ -6,7 +6,7 @@ class Lrama::Parser
 
 rule
 
-  input: prologue_declaration* bison_declaration* "%%" grammar epilogue?
+  input: prologue_declaration* bison_declaration* "%%" rules_or_grammar_declaration+ epilogue?
 
   prologue_declaration: "%{"
                           {
@@ -363,29 +363,13 @@ rule
               result = [val[2]]
             }
 
-  token_declarations_for_precedence: token_declaration_list_for_precedence
-                                       {
-                                         result = [{tag: nil, tokens: val[0]}]
-                                       }
-                                   | TAG token_declaration_list_for_precedence
-                                       {
-                                         result = [{tag: val[0], tokens: val[1]}]
-                                       }
-                                   | token_declarations_for_precedence TAG token_declaration_list_for_precedence
-                                       {
-                                         result = val[0].append({tag: val[1], tokens: val[2]})
-                                       }
-
-  token_declaration_list_for_precedence: token_declaration_for_precedence { result = [val[0]] }
-                                       | token_declaration_list_for_precedence token_declaration_for_precedence { result = val[0].append(val[1]) }
-
-  token_declaration_for_precedence: id
+  token_declarations_for_precedence: id+ { result = [{tag: nil, tokens: val[0]}] }
+                                   | TAG id+ { result = [{tag: val[0], tokens: val[1]}] }
+                                   | id TAG id+ { result = val[0].append({tag: val[1], tokens: val[2]}) }
 
   id: IDENTIFIER { on_action_error("ident after %prec", val[0]) if @prec_seen }
     | CHARACTER { on_action_error("char after %prec", val[0]) if @prec_seen }
 
-  grammar: rules_or_grammar_declaration
-         | grammar rules_or_grammar_declaration
 
   rules_or_grammar_declaration: rules ";"?
                               | grammar_declaration ";"

--- a/parser.y
+++ b/parser.y
@@ -40,98 +40,50 @@ rule
                            @grammar.parse_param = Grammar::Code::NoReferenceCode.new(type: :parse_param, token_code: token).token_code.s_value
                          }
                        }
-                   | "%code" IDENTIFIER "{"
+                   | "%code" IDENTIFIER param
                        {
-                         begin_c_declaration("}")
+                         @grammar.add_percent_code(id: val[1], code: val[2])
                        }
-                     C_DECLARATION
+                   | "%initial-action" param
                        {
-                         end_c_declaration
-                       }
-                     "}"
-                       {
-                         @grammar.add_percent_code(id: val[1], code: val[4])
-                       }
-                   | "%initial-action" "{"
-                       {
-                         begin_c_declaration("}")
-                       }
-                     C_DECLARATION
-                       {
-                         end_c_declaration
-                       }
-                     "}"
-                       {
-                         @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[3])
+                         @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[1])
                        }
                    | "%no-stdlib" { @grammar.no_stdlib = true }
                    | "%locations" { @grammar.locations = true }
                    | bison_declaration ";"
 
-  grammar_declaration: "%union" "{"
-                         {
-                           begin_c_declaration("}")
-                         }
-                       C_DECLARATION
-                         {
-                           end_c_declaration
-                         }
-                       "}"
+  grammar_declaration: "%union" param
                          {
                            @grammar.set_union(
-                             Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[3]),
-                             val[3].line
+                             Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[1]),
+                             val[1].line
                            )
                          }
                      | symbol_declaration
                      | rule_declaration
                      | inline_declaration
-                     | "%destructor" "{"
-                         {
-                           begin_c_declaration("}")
-                         }
-                       C_DECLARATION
-                         {
-                           end_c_declaration
-                         }
-                       "}" generic_symbol+
+                     | "%destructor" param generic_symbol+
                          {
                            @grammar.add_destructor(
-                             ident_or_tags: val[6],
-                             token_code: val[3],
-                             lineno: val[3].line
+                             ident_or_tags: val[2],
+                             token_code: val[1],
+                             lineno: val[1].line
                            )
                          }
-                     | "%printer" "{"
-                         {
-                           begin_c_declaration("}")
-                         }
-                       C_DECLARATION
-                         {
-                           end_c_declaration
-                         }
-                       "}" generic_symbol+
+                     | "%printer" param generic_symbol+
                          {
                            @grammar.add_printer(
-                             ident_or_tags: val[6],
-                             token_code: val[3],
-                             lineno: val[3].line
+                             ident_or_tags: val[2],
+                             token_code: val[1],
+                             lineno: val[1].line
                            )
                          }
-                     | "%error-token" "{"
-                         {
-                           begin_c_declaration("}")
-                         }
-                       C_DECLARATION
-                         {
-                           end_c_declaration
-                         }
-                       "}" generic_symbol+
+                     | "%error-token" param generic_symbol+
                          {
                            @grammar.add_error_token(
-                             ident_or_tags: val[6],
-                             token_code: val[3],
-                             lineno: val[3].line
+                             ident_or_tags: val[2],
+                             token_code: val[1],
+                             lineno: val[1].line
                            )
                          }
                      | "%after-shift" IDENTIFIER

--- a/parser.y
+++ b/parser.y
@@ -205,27 +205,24 @@ rule
                           @precedence_number += 1
                         }
 
-  token_declarations: token_declaration_list
+  token_declarations: token_declaration+
                         {
                           val[0].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: nil, replace: true)
                           }
                         }
-                    | TAG token_declaration_list
+                    | TAG token_declaration+
                         {
                           val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
                         }
-                    | token_declarations TAG token_declaration_list
+                    | token_declarations TAG token_declaration+
                         {
                           val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
                         }
-
-  token_declaration_list: token_declaration { result = [val[0]] }
-                        | token_declaration_list token_declaration { result = val[0].append(val[1]) }
 
   token_declaration: id INTEGER? alias { result = val }
 

--- a/parser.y
+++ b/parser.y
@@ -6,7 +6,7 @@ class Lrama::Parser
 
 rule
 
-  input: prologue_declarations bison_declarations "%%" grammar epilogue_opt
+  input: prologue_declarations bison_declarations "%%" grammar epilogue?
 
   prologue_declarations: # empty
                        | prologue_declarations prologue_declaration
@@ -502,17 +502,16 @@ rule
 
   id_colon: IDENT_COLON
 
-  epilogue_opt: # empty
-              | "%%"
-                  {
-                    begin_c_declaration('\Z')
-                    @grammar.epilogue_first_lineno = @lexer.line + 1
-                  }
-                C_DECLARATION
-                  {
-                    end_c_declaration
-                    @grammar.epilogue = val[2].s_value
-                  }
+  epilogue: "%%"
+              {
+                begin_c_declaration('\Z')
+                @grammar.epilogue_first_lineno = @lexer.line + 1
+              }
+            C_DECLARATION
+              {
+                end_c_declaration
+                @grammar.epilogue = val[2].s_value
+              }
 
   variable: id
 

--- a/parser.y
+++ b/parser.y
@@ -274,7 +274,7 @@ rule
               reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
             }
-          | rule_rhs symbol named_ref_opt
+          | rule_rhs symbol named_ref?
             {
               token = val[1]
               token.alias_name = val[2]
@@ -306,7 +306,7 @@ rule
             {
               end_c_declaration
             }
-          "}" named_ref_opt
+          "}" named_ref?
             {
               user_code = val[3]
               user_code.alias_name = val[6]
@@ -397,7 +397,7 @@ rule
   rules_or_grammar_declaration: rules ";"?
                               | grammar_declaration ";"
 
-  rules: id_colon named_ref_opt ":" rhs_list
+  rules: id_colon named_ref? ":" rhs_list
            {
              lhs = val[0]
              lhs.alias_name = val[1]
@@ -435,7 +435,7 @@ rule
            reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
          }
-     | rhs symbol named_ref_opt
+     | rhs symbol named_ref?
          {
            token = val[1]
            token.alias_name = val[2]
@@ -443,7 +443,7 @@ rule
            builder.add_rhs(token)
            result = builder
          }
-     | rhs symbol parameterizing_suffix named_ref_opt TAG?
+     | rhs symbol parameterizing_suffix named_ref? TAG?
          {
            token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
@@ -451,7 +451,7 @@ rule
            builder.line = val[1].first_line
            result = builder
          }
-     | rhs IDENTIFIER "(" parameterizing_args ")" named_ref_opt TAG?
+     | rhs IDENTIFIER "(" parameterizing_args ")" named_ref? TAG?
          {
            token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
@@ -471,7 +471,7 @@ rule
          {
            end_c_declaration
          }
-       "}" named_ref_opt TAG?
+       "}" named_ref? TAG?
          {
            user_code = val[3]
            user_code.alias_name = val[6]
@@ -498,8 +498,7 @@ rule
                      | symbol parameterizing_suffix { result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])] }
                      | IDENTIFIER "(" parameterizing_args ")" { result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])] }
 
-  named_ref_opt: # empty
-               | '[' IDENTIFIER ']' { result = val[1].s_value }
+  named_ref: '[' IDENTIFIER ']' { result = val[1].s_value }
 
   id_colon: IDENT_COLON
 


### PR DESCRIPTION
- Use new racc grammar `+`, `*`, `? `?
- Remove unnecessary line breaks
- Add `midrule_action` and `empty` and `empty` non-terminal symbols to organize
- Remove redundant non-terminal symbols.