### PR TITLE
Fix an error when `str.length` is greater than `length`

### DIFF
--- a/lib/lrama/counterexamples/derivation.rb
+++ b/lib/lrama/counterexamples/derivation.rb
@@ -44,7 +44,7 @@ module Lrama
           str << "#{item.next_sym.display_name}"
           length = _render_for_report(derivation.left, len, strings, index + 1)
           # I want String#ljust!
-          str << " " * (length - str.length)
+          str << " " * (length - str.length) if length > str.length
         else
           str << " • #{item.symbols_after_dot.map(&:display_name).join(" ")} "
           return str.length


### PR DESCRIPTION
This PR fix an error when `str.length` is greater than `length`. 

Reproduced by parse.y below:
https://gist.github.com/ydah/70186de8a1ff14fa2cd16b338b9fc0e0