### PR TITLE
Add warning output when using %require, which exists only for compatibility with Bison

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -28,7 +28,7 @@ module Lrama
     attr_reader :percent_codes, :eof_symbol, :error_symbol, :undef_symbol, :accept_symbol, :aux, :parameterizing_rule_resolver
     attr_accessor :union, :expect, :printers, :error_tokens, :lex_param, :parse_param, :initial_action,
                   :after_shift, :before_reduce, :after_reduce, :after_shift_error_token, :after_pop_stack,
-                  :symbols_resolver, :types, :rules, :rule_builders, :sym_to_rules, :no_stdlib, :locations, :define
+                  :symbols_resolver, :types, :rules, :rule_builders, :sym_to_rules, :no_stdlib, :locations, :define, :required
 
     def_delegators "@symbols_resolver", :symbols, :nterms, :terms, :add_nterm, :add_term, :find_term_by_s_value,
                                         :find_symbol_by_number!, :find_symbol_by_id!, :token_to_symbol,
@@ -58,6 +58,7 @@ module Lrama
       @no_stdlib = false
       @locations = false
       @define = define
+      @required = false
 
       append_special_symbols
     end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -910,7 +910,7 @@ racc_reduce_table = [
   0, 67, :_reduce_10,
   0, 68, :_reduce_11,
   5, 59, :_reduce_12,
-  2, 59, :_reduce_none,
+  2, 59, :_reduce_13,
   1, 73, :_reduce_14,
   2, 73, :_reduce_15,
   1, 60, :_reduce_none,
@@ -1304,7 +1304,12 @@ module_eval(<<'.,.,', 'parser.y', 21)
   end
 .,.,
 
-# reduce 13 omitted
+module_eval(<<'.,.,', 'parser.y', 23)
+  def _reduce_13(val, _values, result)
+     @grammar.required = true
+    result
+  end
+.,.,
 
 module_eval(<<'.,.,', 'parser.y', 54)
   def _reduce_14(val, _values, result)

--- a/lib/lrama/warnings.rb
+++ b/lib/lrama/warnings.rb
@@ -3,6 +3,7 @@
 
 require_relative 'warnings/conflicts'
 require_relative 'warnings/redefined_rules'
+require_relative 'warnings/required'
 
 module Lrama
   class Warnings
@@ -10,12 +11,14 @@ module Lrama
     def initialize(logger, warnings)
       @conflicts = Conflicts.new(logger, warnings)
       @redefined_rules = RedefinedRules.new(logger, warnings)
+      @required = Required.new(logger, warnings)
     end
 
     # @rbs (Lrama::Grammar grammar, Lrama::States states) -> void
     def warn(grammar, states)
       @conflicts.warn(states)
       @redefined_rules.warn(grammar)
+      @required.warn(grammar)
     end
   end
 end

--- a/lib/lrama/warnings/required.rb
+++ b/lib/lrama/warnings/required.rb
@@ -1,0 +1,23 @@
+# rbs_inline: enabled
+# frozen_string_literal: true
+
+module Lrama
+  class Warnings
+    class Required
+      # @rbs (Lrama::Logger logger, bool warnings) -> void
+      def initialize(logger, warnings = false, **_)
+        @logger = logger
+        @warnings = warnings
+      end
+
+      # @rbs (Lrama::Grammar grammar) -> void
+      def warn(grammar)
+        return unless @warnings
+
+        if grammar.required
+          @logger.warn("%require is provided for compatibility with bison and can be removed after migration to lrama")
+        end
+      end
+    end
+  end
+end

--- a/lib/lrama/warnings/required.rb
+++ b/lib/lrama/warnings/required.rb
@@ -15,7 +15,7 @@ module Lrama
         return unless @warnings
 
         if grammar.required
-          @logger.warn("%require is provided for compatibility with bison and can be removed after migration to lrama")
+          @logger.warn("currently, %require is simply valid as a grammar but does nothing")
         end
       end
     end

--- a/parser.y
+++ b/parser.y
@@ -21,7 +21,7 @@ rule
                           {
                             @grammar.prologue = val[2].s_value
                           }
-                      | "%require" STRING
+                      | "%require" STRING { @grammar.required = true }
 
   bison_declaration: grammar_declaration
                    | "%expect" INTEGER { @grammar.expect = val[1] }

--- a/sig/generated/lrama/warnings/required.rbs
+++ b/sig/generated/lrama/warnings/required.rbs
@@ -1,0 +1,13 @@
+# Generated from lib/lrama/warnings/required.rb with RBS::Inline
+
+module Lrama
+  class Warnings
+    class Required
+      # @rbs (Lrama::Logger logger, bool warnings) -> void
+      def initialize: (Lrama::Logger logger, bool warnings) -> void
+
+      # @rbs (Lrama::Grammar grammar) -> void
+      def warn: (Lrama::Grammar grammar) -> void
+    end
+  end
+end

--- a/spec/lrama/warnings/required_spec.rb
+++ b/spec/lrama/warnings/required_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Lrama::Warnings::Required do
+  describe "#warn" do
+    let(:y) do
+      <<~STR
+        %require "3.0"
+        %{
+        // Prologue
+        %}
+        %union {
+            int i;
+        }
+        %token <i> tNUMBER
+        %%
+        program: tNUMBER
+                ;
+      STR
+    end
+
+    context "when warnings true" do
+      it "has warns for require is provided for compatibility with bison" do
+        grammar = Lrama::Parser.new(y, "states/required.y").parse
+        grammar.prepare
+        grammar.validate!
+        states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+        states.compute
+        logger = Lrama::Logger.new
+        allow(logger).to receive(:warn)
+        Lrama::Warnings.new(logger, true).warn(grammar, states)
+        expect(logger).to have_received(:warn).with("%require is provided for compatibility with bison and can be removed after migration to lrama")
+      end
+    end
+
+    context "when warnings false" do
+      it "has not warns for require is provided for compatibility with bison" do
+        grammar = Lrama::Parser.new(y, "states/required.y").parse
+        grammar.prepare
+        grammar.validate!
+        states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+        states.compute
+        logger = Lrama::Logger.new
+        allow(logger).to receive(:warn)
+        Lrama::Warnings.new(logger, false).warn(grammar, states)
+        expect(logger).not_to have_received(:warn).with("%require is provided for compatibility with bison and can be removed after migration to lrama")
+      end
+    end
+  end
+end

--- a/spec/lrama/warnings/required_spec.rb
+++ b/spec/lrama/warnings/required_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Lrama::Warnings::Required do
         logger = Lrama::Logger.new
         allow(logger).to receive(:warn)
         Lrama::Warnings.new(logger, false).warn(grammar, states)
-        expect(logger).not_to have_received(:warn).with("currently, %require is simply valid as a grammar but does nothing")
+        expect(logger).not_to have_received(:warn)
       end
     end
   end

--- a/spec/lrama/warnings/required_spec.rb
+++ b/spec/lrama/warnings/required_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Lrama::Warnings::Required do
         logger = Lrama::Logger.new
         allow(logger).to receive(:warn)
         Lrama::Warnings.new(logger, true).warn(grammar, states)
-        expect(logger).to have_received(:warn).with("%require is provided for compatibility with bison and can be removed after migration to lrama")
+        expect(logger).to have_received(:warn).with("currently, %require is simply valid as a grammar but does nothing")
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe Lrama::Warnings::Required do
         logger = Lrama::Logger.new
         allow(logger).to receive(:warn)
         Lrama::Warnings.new(logger, false).warn(grammar, states)
-        expect(logger).not_to have_received(:warn).with("%require is provided for compatibility with bison and can be removed after migration to lrama")
+        expect(logger).not_to have_received(:warn).with("currently, %require is simply valid as a grammar but does nothing")
       end
     end
   end


### PR DESCRIPTION
This PR adds a warning output when using %require, which exists only for compatibility with Bison. 
see: https://www.gnu.org/software/bison/manual/html_node/Require-Decl.html