### PR TITLE
Bump rbs from v3.6.0 to v3.7.0 and steep from v1.8.0 to v1.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ gem "memory_profiler"
 # Recent steep requires Ruby >= 3.0.0.
 # Then skip install on some CI jobs.
 if !ENV['GITHUB_ACTION'] || ENV['INSTALL_STEEP'] == 'true'
-  gem "rbs", "3.6.0", require: false
-  gem "steep", "1.8.0", require: false
+  gem "rbs", "3.7.0", require: false
+  gem "steep", "1.9.1", require: false
 end

--- a/lib/lrama/bitmap.rb
+++ b/lib/lrama/bitmap.rb
@@ -13,7 +13,7 @@ module Lrama
     end
 
     def self.to_array(int)
-      a = []
+      a = [] #: Array[Integer]
       i = 0
 
       while int > 0 do

--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -382,7 +382,7 @@ module Lrama
     end
 
     def validate_rule_lhs_is_nterm!
-      errors = []
+      errors = [] #: Array[String]
 
       rules.each do |rule|
         next if rule.lhs.nterm?

--- a/lib/lrama/grammar/parameterizing_rule/rhs.rb
+++ b/lib/lrama/grammar/parameterizing_rule/rhs.rb
@@ -16,7 +16,7 @@ module Lrama
           return unless user_code
 
           resolved = Lexer::Token::UserCode.new(s_value: user_code.s_value, location: user_code.location)
-          var_to_arg = {}
+          var_to_arg = {} #: Hash[String, String]
           symbols.each do |sym|
             resolved_sym = bindings.resolve_symbol(sym)
             if resolved_sym != sym

--- a/lib/lrama/grammar/rule_builder.rb
+++ b/lib/lrama/grammar/rule_builder.rb
@@ -67,7 +67,7 @@ module Lrama
       end
 
       def resolve_inline_rules
-        resolved_builders = []
+        resolved_builders = [] #: Array[RuleBuilder]
         rhs.each_with_index do |token, i|
           if (inline_rule = @parameterizing_rule_resolver.find_inline(token))
             inline_rule.rhs_list.each do |inline_rhs|

--- a/lib/lrama/lexer/token/user_code.rb
+++ b/lib/lrama/lexer/token/user_code.rb
@@ -16,7 +16,7 @@ module Lrama
 
         def _references
           scanner = StringScanner.new(s_value)
-          references = []
+          references = [] #: Array[Grammar::Reference]
 
           until scanner.eos? do
             case

--- a/lib/lrama/state/reduce.rb
+++ b/lib/lrama/state/reduce.rb
@@ -26,9 +26,8 @@ module Lrama
       end
 
       def selected_look_ahead
-        if @look_ahead
-          # @type ivar @look_ahead: Array<Grammar::Symbol>
-          @look_ahead - @not_selected_symbols
+        if look_ahead
+          look_ahead - @not_selected_symbols
         else
           []
         end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,6 +1,14 @@
 ---
 path: ".gem_rbs_collection"
 gems:
+- name: diff-lcs
+  version: '1.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: f2fa96be08e0f7fe5237a45d2b69d9d7a5d0b416
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: erb
   version: '0'
   source:
@@ -18,7 +26,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 4b0d2f72e63b6c3e92dc54e19ce23dd24524f9a7
+    revision: f2fa96be08e0f7fe5237a45d2b69d9d7a5d0b416
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: stackprof
@@ -26,7 +34,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 4b0d2f72e63b6c3e92dc54e19ce23dd24524f9a7
+    revision: f2fa96be08e0f7fe5237a45d2b69d9d7a5d0b416
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: strscan


### PR DESCRIPTION
The following warnings and errors have been fixed as a result of the version update:

```
bundle exec steep check
# Type checking files:

............F.........................F..................................F...FF.......F......

lib/lrama/grammar/parameterizing_rule/rhs.rb:19:23: [warning] Empty hash doesn't have type annotation
│ Diagnostic ID: Ruby::UnannotatedEmptyCollection
│
└           var_to_arg = {}
                         ~~

lib/lrama/bitmap.rb:16:10: [warning] Empty array doesn't have type annotation
│ Diagnostic ID: Ruby::UnannotatedEmptyCollection
│
└       a = []
            ~~

lib/lrama/grammar/rule_builder.rb:70:28: [warning] Empty array doesn't have type annotation
│ Diagnostic ID: Ruby::UnannotatedEmptyCollection
│
└         resolved_builders = []
                              ~~

lib/lrama/lexer/token/user_code.rb:19:23: [warning] Empty array doesn't have type annotation
│ Diagnostic ID: Ruby::UnannotatedEmptyCollection
│
└           references = []
                         ~~

lib/lrama/state/reduce.rb:30:36: [error] Type annotation has a syntax error: Failed to parse a type in annotation
│ Diagnostic ID: Ruby::AnnotationSyntaxError
│
└           # @type ivar @look_ahead: Array<Grammar::Symbol>
                                      ~~~~~~~~~~~~~~~~~~~~~~

lib/lrama/grammar.rb:385:15: [warning] Empty array doesn't have type annotation
│ Diagnostic ID: Ruby::UnannotatedEmptyCollection
│
└       errors = []
                 ~~

Detected 6 problems from 6 files
rake aborted!
```