### PR TITLE
Add support for %type declarations using `%nterm` in Nonterminal Symbols

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -30,7 +30,7 @@ module Lrama
                   :after_shift, :before_reduce, :after_reduce, :after_shift_error_token, :after_pop_stack,
                   :symbols_resolver, :types, :rules, :rule_builders, :sym_to_rules, :no_stdlib, :locations
 
-    def_delegators "@symbols_resolver", :symbols, :nterms, :terms, :add_nterm, :add_term,
+    def_delegators "@symbols_resolver", :symbols, :nterms, :terms, :add_nterm, :add_term, :find_term_by_s_value,
                                         :find_symbol_by_number!, :find_symbol_by_id!, :token_to_symbol,
                                         :find_symbol_by_s_value!, :fill_symbol_number, :fill_nterm_type,
                                         :fill_printer, :fill_destructor, :fill_error_token, :sort_by_number!

--- a/lib/lrama/grammar/symbols/resolver.rb
+++ b/lib/lrama/grammar/symbols/resolver.rb
@@ -57,6 +57,10 @@ module Lrama
           nterm
         end
 
+        def find_term_by_s_value(s_value)
+          terms.find { |s| s.id.s_value == s_value }
+        end
+
         def find_symbol_by_s_value(s_value)
           symbols.find { |s| s.id.s_value == s_value }
         end

--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -16,6 +16,7 @@ module Lrama
       %union
       %token
       %type
+      %nterm
       %left
       %right
       %nonassoc

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 404)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 416)
 
 include Lrama::Report::Duration
 
@@ -728,172 +728,174 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    94,    50,    95,   168,    50,    77,   174,    50,    77,   168,
-    50,    77,   174,     6,    77,    85,    50,    50,    49,    49,
-    77,    74,    81,    50,    50,    49,    49,    42,    81,    81,
-    50,    50,    49,    49,    43,    81,   115,    50,    92,    49,
-   151,    77,   101,   152,    46,   172,   170,   171,   152,   177,
+    94,    49,    95,   168,    49,    76,   174,    49,    76,   168,
+    49,    76,   174,     6,    76,    85,    49,     4,    48,     5,
+    76,    73,    49,    49,    48,    48,    76,    73,    81,    49,
+    49,    48,    48,   151,    81,    81,   152,    49,    92,    48,
+    41,   172,    81,    49,   152,    48,   170,   171,   115,   177,
    171,    96,   170,   171,    86,   177,   171,    20,    24,    25,
-    26,    27,    28,    29,    30,    31,    92,    34,    32,    33,
-    36,    37,    38,    39,    40,    50,     4,    49,     5,    77,
+    26,    27,    28,    29,    30,    31,    92,    32,    33,    34,
+    35,    36,    37,    38,    39,    49,     4,    48,     5,    76,
    101,   182,   183,   184,   130,    20,    24,    25,    26,    27,
-    28,    29,    30,    31,    47,    34,    32,    33,    36,    37,
-    38,    39,    40,    11,    12,    13,    14,    15,    16,    17,
-    18,    19,    54,    20,    24,    25,    26,    27,    28,    29,
-    30,    31,    54,    34,    32,    33,    36,    37,    38,    39,
-    40,    11,    12,    13,    14,    15,    16,    17,    18,    19,
-    45,    20,    24,    25,    26,    27,    28,    29,    30,    31,
-    54,    34,    32,    33,    36,    37,    38,    39,    40,    50,
-     4,    49,     5,    77,   101,    50,    50,    49,    49,    77,
-   101,    50,    50,    49,    49,    77,    77,    50,    50,    49,
-    49,    77,    77,    50,    50,    49,   198,    77,    77,    50,
-    50,   198,    49,    77,    77,    50,    50,   198,    49,    77,
-   182,   183,   184,   130,   205,   210,   217,   206,   206,   206,
-    50,    50,    49,    49,    50,    50,    49,    49,    50,    57,
-    49,   182,   183,   184,   118,   119,    54,    54,    54,    54,
-    54,    63,    64,    65,    66,    67,    69,    87,    54,    54,
-   106,   110,   117,   124,   125,   127,   130,   131,   135,   140,
-   141,   142,   143,   145,   146,    77,   155,   140,   158,   155,
-   162,   163,    69,   165,   166,   173,   178,   155,   185,   130,
-   189,   155,   191,   130,   155,   200,   155,   130,    69,   166,
-   207,   166,    69,    69,   215,   130,    69 ]
+    28,    29,    30,    31,    42,    32,    33,    34,    35,    36,
+    37,    38,    39,    11,    12,    13,    14,    15,    16,    17,
+    18,    19,    45,    20,    24,    25,    26,    27,    28,    29,
+    30,    31,    46,    32,    33,    34,    35,    36,    37,    38,
+    39,    11,    12,    13,    14,    15,    16,    17,    18,    19,
+    44,    20,    24,    25,    26,    27,    28,    29,    30,    31,
+    53,    32,    33,    34,    35,    36,    37,    38,    39,    49,
+    49,    48,    48,    76,   101,    49,    49,    48,    48,    76,
+   101,    49,    49,    48,    48,    76,   101,    49,    49,    48,
+    48,    76,    76,    49,    49,    48,    48,    76,    76,    49,
+    49,    48,   198,    76,    76,    49,    49,   198,    48,    76,
+    76,    49,    49,   198,    48,    76,   182,   183,   184,   130,
+   205,   210,   217,   206,   206,   206,    49,    49,    48,    48,
+    49,    53,    48,   182,   183,   184,   118,   119,    53,    56,
+    53,    53,    53,    53,    53,    62,    63,    64,    65,    66,
+    68,    87,    53,    53,   106,   110,   110,   117,   124,   125,
+   127,   130,   131,   135,   140,   141,   142,   143,   145,   146,
+    76,   155,   140,   158,   155,   162,   163,    68,   165,   166,
+   173,   178,   155,   185,   130,   189,   155,   191,   130,   155,
+   200,   155,   130,    68,   166,   207,   166,    68,    68,   215,
+   130,    68 ]
 
 racc_action_check = [
-    48,   154,    48,   154,   160,   154,   160,   179,   160,   179,
-   190,   179,   190,     1,   190,    40,    35,    36,    35,    36,
-    35,    35,    36,    37,    38,    37,    38,     5,    37,    38,
-    39,    79,    39,    79,     6,    39,    79,    60,    46,    60,
-   139,    60,    60,   139,     9,   157,   154,   154,   157,   160,
-   160,    48,   179,   179,    40,   190,   190,    46,    46,    46,
-    46,    46,    46,    46,    46,    46,    88,    46,    46,    46,
-    46,    46,    46,    46,    46,    61,     0,    61,     0,    61,
-    61,   167,   167,   167,   167,    88,    88,    88,    88,    88,
-    88,    88,    88,    88,    11,    88,    88,    88,    88,    88,
+    47,   154,    47,   154,   160,   154,   160,   179,   160,   179,
+   190,   179,   190,     1,   190,    39,    33,     0,    33,     0,
+    33,    33,    34,    35,    34,    35,    34,    34,    35,    36,
+    37,    36,    37,   139,    36,    37,   139,    38,    45,    38,
+     5,   157,    38,    79,   157,    79,   154,   154,    79,   160,
+   160,    47,   179,   179,    39,   190,   190,    45,    45,    45,
+    45,    45,    45,    45,    45,    45,    88,    45,    45,    45,
+    45,    45,    45,    45,    45,    59,     2,    59,     2,    59,
+    59,   167,   167,   167,   167,    88,    88,    88,    88,    88,
+    88,    88,    88,    88,     6,    88,    88,    88,    88,    88,
     88,    88,    88,     3,     3,     3,     3,     3,     3,     3,
-     3,     3,    13,     3,     3,     3,     3,     3,     3,     3,
-     3,     3,    14,     3,     3,     3,     3,     3,     3,     3,
+     3,     3,     9,     3,     3,     3,     3,     3,     3,     3,
+     3,     3,    11,     3,     3,     3,     3,     3,     3,     3,
      3,     8,     8,     8,     8,     8,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
-    15,     8,     8,     8,     8,     8,     8,     8,     8,    62,
-     2,    62,     2,    62,    62,   102,    12,   102,    12,   102,
-   102,    72,    74,    72,    74,    72,    74,   110,   170,   110,
-   170,   110,   170,   177,   185,   177,   185,   177,   185,   191,
-   206,   191,   206,   191,   206,   207,    70,   207,    70,   207,
-   175,   175,   175,   175,   197,   202,   214,   197,   202,   214,
-    81,   106,    81,   106,   107,   113,   107,   113,   115,    16,
-   115,   199,   199,   199,    86,    86,    17,    20,    24,    25,
-    26,    27,    28,    29,    30,    31,    34,    41,    52,    57,
-    68,    71,    85,    89,    90,    91,    92,    98,   109,   117,
-   118,   119,   120,   129,   130,   136,   141,   142,   144,   145,
-   146,   147,   151,   152,   153,   159,   164,   166,   168,   169,
-   172,   173,   174,   176,   178,   188,   189,   193,   194,   196,
-   198,   201,   203,   205,   209,   210,   216 ]
+    13,     8,     8,     8,     8,     8,     8,     8,     8,    60,
+    12,    60,    12,    60,    60,    61,    69,    61,    69,    61,
+    61,   102,    81,   102,    81,   102,   102,    71,    73,    71,
+    73,    71,    73,   110,   170,   110,   170,   110,   170,   177,
+   185,   177,   185,   177,   185,   191,   206,   191,   206,   191,
+   206,   207,   106,   207,   106,   207,   175,   175,   175,   175,
+   197,   202,   214,   197,   202,   214,   107,   113,   107,   113,
+   115,    14,   115,   199,   199,   199,    86,    86,    15,    16,
+    17,    20,    24,    25,    26,    27,    28,    29,    30,    31,
+    32,    40,    51,    56,    67,    70,    77,    85,    89,    90,
+    91,    92,    98,   109,   117,   118,   119,   120,   129,   130,
+   136,   141,   142,   144,   145,   146,   147,   151,   152,   153,
+   159,   164,   166,   168,   169,   172,   173,   174,   176,   178,
+   188,   189,   193,   194,   196,   198,   201,   203,   205,   209,
+   210,   216 ]
 
 racc_action_pointer = [
-    66,    13,   150,    90,   nil,    20,    34,   nil,   118,    35,
-   nil,    88,   163,    63,    73,   101,   214,   177,   nil,   nil,
-   178,   nil,   nil,   nil,   179,   180,   181,   226,   227,   228,
-   229,   230,   nil,   nil,   228,    13,    14,    20,    21,    27,
-    10,   235,   nil,   nil,   nil,   nil,    34,   nil,    -5,   nil,
-   nil,   nil,   189,   nil,   nil,   nil,   nil,   190,   nil,   nil,
-    34,    72,   156,   nil,   nil,   nil,   nil,   nil,   232,   nil,
-   193,   233,   168,   nil,   169,   nil,   nil,   nil,   nil,    28,
-   nil,   207,   nil,   nil,   nil,   201,   220,   nil,    62,   234,
-   222,   223,   192,   nil,   nil,   nil,   nil,   nil,   245,   nil,
-   nil,   nil,   162,   nil,   nil,   nil,   208,   211,   nil,   242,
-   174,   nil,   nil,   212,   nil,   215,   nil,   244,   207,   210,
-   241,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   210,
-   249,   nil,   nil,   nil,   nil,   nil,   248,   nil,   nil,    -2,
-   nil,   209,   252,   nil,   256,   212,   205,   211,   nil,   nil,
-   nil,   254,   258,   218,    -2,   nil,   nil,     3,   nil,   219,
-     1,   nil,   nil,   nil,   223,   nil,   220,    30,   227,   215,
-   175,   nil,   227,   224,   231,   149,   219,   180,   227,     4,
-   nil,   nil,   nil,   nil,   nil,   181,   nil,   nil,   273,   229,
-     7,   186,   nil,   223,   270,   nil,   233,   162,   239,   170,
-   nil,   235,   163,   274,   nil,   275,   187,   192,   nil,   234,
-   231,   nil,   nil,   nil,   164,   nil,   278,   nil,   nil ]
+     7,    13,    66,    90,   nil,    33,    94,   nil,   118,   103,
+   nil,   116,   157,   101,   172,   179,   224,   181,   nil,   nil,
+   182,   nil,   nil,   nil,   183,   184,   185,   230,   231,   232,
+   233,   234,   232,    13,    19,    20,    26,    27,    34,    10,
+   239,   nil,   nil,   nil,   nil,    34,   nil,    -5,   nil,   nil,
+   nil,   193,   nil,   nil,   nil,   nil,   194,   nil,   nil,    72,
+   156,   162,   nil,   nil,   nil,   nil,   nil,   236,   nil,   163,
+   237,   174,   nil,   175,   nil,   nil,   nil,   238,   nil,    40,
+   nil,   169,   nil,   nil,   nil,   206,   222,   nil,    62,   239,
+   227,   228,   197,   nil,   nil,   nil,   nil,   nil,   250,   nil,
+   nil,   nil,   168,   nil,   nil,   nil,   199,   213,   nil,   247,
+   180,   nil,   nil,   214,   nil,   217,   nil,   249,   212,   215,
+   246,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   215,
+   254,   nil,   nil,   nil,   nil,   nil,   253,   nil,   nil,    -9,
+   nil,   214,   257,   nil,   261,   217,   210,   216,   nil,   nil,
+   nil,   259,   263,   223,    -2,   nil,   nil,    -1,   nil,   224,
+     1,   nil,   nil,   nil,   228,   nil,   225,    30,   232,   220,
+   181,   nil,   232,   229,   236,   155,   224,   186,   232,     4,
+   nil,   nil,   nil,   nil,   nil,   187,   nil,   nil,   278,   234,
+     7,   192,   nil,   228,   275,   nil,   238,   168,   244,   172,
+   nil,   240,   169,   279,   nil,   280,   193,   198,   nil,   239,
+   236,   nil,   nil,   nil,   170,   nil,   283,   nil,   nil ]
 
 racc_action_default = [
-    -1,  -129,    -1,    -3,   -10,  -129,  -129,    -2,    -3,  -129,
-   -16,  -129,  -129,  -129,  -129,  -129,  -129,  -129,   -24,   -25,
-  -129,   -32,   -33,   -34,  -129,  -129,  -129,  -129,  -129,  -129,
-  -129,  -129,   -43,   -44,   -51,  -129,  -129,  -129,  -129,  -129,
-  -129,  -129,   -13,   219,    -4,   -26,  -129,   -17,  -124,   -95,
-   -96,  -123,   -14,   -19,   -87,   -20,   -21,  -129,   -23,   -31,
-  -129,  -129,  -129,   -38,   -39,   -40,   -41,   -42,   -45,   -52,
-  -129,   -46,   -80,   -82,  -129,   -85,   -86,  -128,   -47,   -90,
-   -92,  -129,   -48,   -49,   -50,  -129,  -129,   -11,    -5,    -7,
-   -97,  -129,   -69,   -18,  -125,  -126,  -127,   -15,  -129,   -22,
-   -27,   -28,   -29,   -35,   -36,   -37,  -129,   -53,   -55,   -57,
-  -129,   -81,   -83,   -90,   -91,  -129,   -93,  -129,  -129,  -129,
-  -129,    -6,    -8,    -9,  -121,   -98,   -99,  -100,   -70,  -129,
-  -129,   -88,   -30,   -56,   -54,   -58,   -77,   -84,   -94,  -129,
-   -63,   -67,  -129,   -12,  -129,   -67,  -129,  -129,   -59,   -78,
-   -79,   -51,  -129,   -61,   -65,   -68,   -71,  -129,  -122,  -101,
-  -102,  -104,  -120,   -89,  -129,   -64,   -67,   -69,   -95,   -69,
-  -129,  -117,  -129,   -67,   -95,   -69,   -69,  -129,   -67,   -66,
-   -72,   -73,  -110,  -111,  -112,  -129,   -75,   -76,  -129,   -67,
-  -103,  -129,  -105,   -69,   -51,  -109,   -60,  -129,   -95,  -113,
-  -118,   -62,  -129,   -51,  -108,   -51,  -129,  -129,  -115,  -129,
-   -69,  -106,   -74,  -114,  -129,  -119,   -51,  -116,  -107 ]
+    -1,  -128,    -1,    -3,   -10,  -128,  -128,    -2,    -3,  -128,
+   -16,  -128,  -128,  -128,  -128,  -128,  -128,  -128,   -24,   -25,
+  -128,   -32,   -33,   -34,  -128,  -128,  -128,  -128,  -128,  -128,
+  -128,  -128,   -50,  -128,  -128,  -128,  -128,  -128,  -128,  -128,
+  -128,   -13,   219,    -4,   -26,  -128,   -17,  -123,   -94,   -95,
+  -122,   -14,   -19,   -86,   -20,   -21,  -128,   -23,   -31,  -128,
+  -128,  -128,   -38,   -39,   -40,   -41,   -42,   -43,   -51,  -128,
+   -44,   -79,   -81,  -128,   -84,   -85,  -127,   -45,   -46,   -89,
+   -91,  -128,   -47,   -48,   -49,  -128,  -128,   -11,    -5,    -7,
+   -96,  -128,   -68,   -18,  -124,  -125,  -126,   -15,  -128,   -22,
+   -27,   -28,   -29,   -35,   -36,   -37,  -128,   -52,   -54,   -56,
+  -128,   -80,   -82,   -89,   -90,  -128,   -92,  -128,  -128,  -128,
+  -128,    -6,    -8,    -9,  -120,   -97,   -98,   -99,   -69,  -128,
+  -128,   -87,   -30,   -55,   -53,   -57,   -76,   -83,   -93,  -128,
+   -62,   -66,  -128,   -12,  -128,   -66,  -128,  -128,   -58,   -77,
+   -78,   -50,  -128,   -60,   -64,   -67,   -70,  -128,  -121,  -100,
+  -101,  -103,  -119,   -88,  -128,   -63,   -66,   -68,   -94,   -68,
+  -128,  -116,  -128,   -66,   -94,   -68,   -68,  -128,   -66,   -65,
+   -71,   -72,  -109,  -110,  -111,  -128,   -74,   -75,  -128,   -66,
+  -102,  -128,  -104,   -68,   -50,  -108,   -59,  -128,   -94,  -112,
+  -117,   -61,  -128,   -50,  -107,   -50,  -128,  -128,  -114,  -128,
+   -68,  -105,   -73,  -113,  -128,  -118,   -50,  -115,  -106 ]
 
 racc_goto_table = [
-    70,   100,   100,   100,   129,    51,    89,    73,   153,    91,
-   103,   104,   105,    58,   161,   139,    59,   176,   108,     1,
-    60,    61,    62,    53,    55,    56,   181,   122,   123,    79,
-    79,    79,    79,   114,   193,   116,   160,     3,    41,     7,
-   157,   120,   161,   100,   111,   196,   112,   176,   121,    48,
-    93,    91,   132,    99,   133,   134,   201,    68,   208,    71,
-     9,   148,    97,   109,   190,    44,   136,   114,   179,   138,
-   197,   149,   113,   150,   113,    98,   202,   147,   126,   180,
-   159,   186,   137,    78,    82,    83,    84,   192,   194,   188,
-   209,   144,   214,   nil,   nil,   167,   nil,   nil,   nil,   109,
-   109,   175,   nil,   nil,   nil,   203,   113,   nil,   113,   nil,
-   nil,   187,   nil,   nil,   nil,   nil,   nil,   164,   195,   nil,
-   167,   nil,   216,   nil,   nil,   nil,   199,   nil,   nil,   nil,
-   nil,   175,   199,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   213,   199,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   204,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   211,
-   nil,   212,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   218 ]
+    69,    50,   100,   100,   100,   129,   153,    89,    91,   103,
+   104,   105,   181,   114,    57,   116,   111,    58,   112,   108,
+   193,    59,    60,    61,    79,    79,    79,    79,    52,    54,
+    55,   176,   161,     1,   160,     9,   122,     3,   139,     7,
+    43,   123,   197,   196,   208,   100,    40,   114,   202,   138,
+   121,    91,   132,    99,   201,   137,   133,   134,   109,   120,
+   161,   176,   190,   157,   214,    47,    97,    93,   113,    67,
+   113,    78,    82,    83,    84,    70,    77,   148,   136,   179,
+   180,   149,   186,   150,    98,   147,   126,   159,   192,   194,
+   188,   209,   144,   nil,   nil,   109,   109,   167,   nil,   nil,
+   nil,   nil,   113,   175,   113,   nil,   203,   nil,   nil,   nil,
+   nil,   nil,   nil,   187,   nil,   nil,   nil,   nil,   nil,   164,
+   195,   nil,   167,   216,   nil,   nil,   nil,   nil,   199,   nil,
+   nil,   nil,   nil,   175,   199,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   213,
+   199,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   204,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   211,   nil,   212,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   218 ]
 
 racc_goto_check = [
-    28,    20,    20,    20,    41,    30,     8,    44,    34,    12,
-    22,    22,    22,    15,    40,    33,    15,    39,    29,     1,
-    15,    15,    15,    16,    16,    16,    37,     5,     9,    30,
-    30,    30,    30,    47,    37,    47,    51,     6,    10,     6,
-    33,    11,    40,    20,    44,    34,    44,    39,     8,    13,
-    14,    12,    22,    15,    29,    29,    34,    23,    37,    24,
-     7,    31,    16,    30,    51,     7,    32,    47,    35,    47,
-    38,    42,    30,    43,    30,    45,    38,    46,    49,    41,
-    50,    41,    44,    25,    25,    25,    25,    41,    41,    52,
-    53,    54,    38,   nil,   nil,    20,   nil,   nil,   nil,    30,
-    30,    20,   nil,   nil,   nil,    41,    30,   nil,    30,   nil,
-   nil,    20,   nil,   nil,   nil,   nil,   nil,    28,    20,   nil,
-    20,   nil,    41,   nil,   nil,   nil,    20,   nil,   nil,   nil,
-   nil,    20,    20,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,    20,    20,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    28,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    28,
-   nil,    28,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    28 ]
+    27,    29,    20,    20,    20,    40,    33,     8,    12,    22,
+    22,    22,    36,    46,    15,    46,    43,    15,    43,    28,
+    36,    15,    15,    15,    29,    29,    29,    29,    16,    16,
+    16,    38,    39,     1,    50,     7,     5,     6,    32,     6,
+     7,     9,    37,    33,    36,    20,    10,    46,    37,    46,
+     8,    12,    22,    15,    33,    43,    28,    28,    29,    11,
+    39,    38,    50,    32,    37,    13,    16,    14,    29,    23,
+    29,    25,    25,    25,    25,    24,    24,    30,    31,    34,
+    40,    41,    40,    42,    44,    45,    48,    49,    40,    40,
+    51,    52,    53,   nil,   nil,    29,    29,    20,   nil,   nil,
+   nil,   nil,    29,    20,    29,   nil,    40,   nil,   nil,   nil,
+   nil,   nil,   nil,    20,   nil,   nil,   nil,   nil,   nil,    27,
+    20,   nil,    20,    40,   nil,   nil,   nil,   nil,    20,   nil,
+   nil,   nil,   nil,    20,    20,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    20,
+    20,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    27,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,    27,   nil,    27,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,    27 ]
 
 racc_goto_pointer = [
-   nil,    19,   nil,   nil,   nil,   -62,    37,    57,   -40,   -61,
-    34,   -46,   -37,    37,     2,    -4,    10,   nil,   nil,   nil,
-   -59,   nil,   -50,    23,    24,    47,   nil,   nil,   -34,   -52,
-    -7,   -75,   -43,  -102,  -133,   -98,   nil,  -141,  -115,  -143,
-  -131,   -88,   -65,   -63,   -28,    21,   -54,   -46,   nil,   -12,
-   -65,  -109,   -82,  -110,   -33 ]
+   nil,    33,   nil,   nil,   nil,   -53,    37,    32,   -38,   -48,
+    42,   -28,   -37,    53,    20,    -3,    15,   nil,   nil,   nil,
+   -57,   nil,   -50,    37,    42,    36,   nil,   -32,   -50,   -11,
+   -59,   -31,   -79,  -135,   -87,   nil,  -155,  -143,  -129,  -113,
+   -87,   -55,   -53,   -55,    31,   -46,   -66,   nil,    -4,   -58,
+  -111,   -81,  -109,   -32 ]
 
 racc_goto_default = [
    nil,   nil,     2,     8,    88,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    10,   nil,   nil,    52,   nil,    21,    22,    23,
-    72,   102,   nil,   nil,   nil,   nil,    35,   107,   nil,   nil,
-    75,   nil,   nil,   nil,   nil,   154,   128,   nil,   nil,   169,
-   156,   nil,    76,   nil,   nil,   nil,   nil,    80,    90,   nil,
-   nil,   nil,   nil,   nil,   nil ]
+   nil,   nil,    10,   nil,   nil,    51,   nil,    21,    22,    23,
+    71,   102,   nil,   nil,   nil,   nil,   107,   nil,   nil,    74,
+   nil,   nil,   nil,   nil,   154,   128,   nil,   nil,   169,   156,
+   nil,    75,   nil,    72,   nil,   nil,    80,    90,   nil,   nil,
+   nil,   nil,   nil,   nil ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -939,94 +941,93 @@ racc_reduce_table = [
   2, 69, :_reduce_40,
   2, 69, :_reduce_41,
   2, 69, :_reduce_42,
-  1, 83, :_reduce_43,
-  1, 83, :_reduce_44,
   2, 74, :_reduce_none,
+  2, 74, :_reduce_44,
+  2, 74, :_reduce_45,
   2, 74, :_reduce_46,
   2, 74, :_reduce_47,
   2, 74, :_reduce_48,
   2, 74, :_reduce_49,
-  2, 74, :_reduce_50,
-  0, 85, :_reduce_none,
-  1, 85, :_reduce_none,
-  1, 86, :_reduce_53,
-  2, 86, :_reduce_54,
-  2, 80, :_reduce_55,
-  3, 80, :_reduce_56,
-  0, 89, :_reduce_none,
-  1, 89, :_reduce_none,
-  3, 84, :_reduce_59,
-  8, 75, :_reduce_60,
-  5, 76, :_reduce_61,
-  8, 76, :_reduce_62,
-  1, 90, :_reduce_63,
-  3, 90, :_reduce_64,
-  1, 91, :_reduce_65,
-  3, 91, :_reduce_66,
+  0, 84, :_reduce_none,
+  1, 84, :_reduce_none,
+  1, 85, :_reduce_52,
+  2, 85, :_reduce_53,
+  2, 80, :_reduce_54,
+  3, 80, :_reduce_55,
+  0, 88, :_reduce_none,
+  1, 88, :_reduce_none,
+  3, 83, :_reduce_58,
+  8, 75, :_reduce_59,
+  5, 76, :_reduce_60,
+  8, 76, :_reduce_61,
+  1, 89, :_reduce_62,
+  3, 89, :_reduce_63,
+  1, 90, :_reduce_64,
+  3, 90, :_reduce_65,
+  0, 96, :_reduce_none,
+  1, 96, :_reduce_none,
   0, 97, :_reduce_none,
   1, 97, :_reduce_none,
-  0, 98, :_reduce_none,
-  1, 98, :_reduce_none,
-  1, 92, :_reduce_71,
-  3, 92, :_reduce_72,
-  3, 92, :_reduce_73,
-  6, 92, :_reduce_74,
-  3, 92, :_reduce_75,
-  3, 92, :_reduce_76,
-  0, 100, :_reduce_none,
-  1, 100, :_reduce_none,
-  1, 88, :_reduce_79,
-  1, 101, :_reduce_80,
-  2, 101, :_reduce_81,
-  1, 81, :_reduce_82,
-  2, 81, :_reduce_83,
-  3, 81, :_reduce_84,
+  1, 91, :_reduce_70,
+  3, 91, :_reduce_71,
+  3, 91, :_reduce_72,
+  6, 91, :_reduce_73,
+  3, 91, :_reduce_74,
+  3, 91, :_reduce_75,
+  0, 99, :_reduce_none,
+  1, 99, :_reduce_none,
+  1, 87, :_reduce_78,
+  1, 100, :_reduce_79,
+  2, 100, :_reduce_80,
+  1, 81, :_reduce_81,
+  2, 81, :_reduce_82,
+  3, 81, :_reduce_83,
   1, 77, :_reduce_none,
   1, 77, :_reduce_none,
+  0, 101, :_reduce_86,
   0, 102, :_reduce_87,
-  0, 103, :_reduce_88,
-  5, 72, :_reduce_89,
-  1, 104, :_reduce_90,
-  2, 104, :_reduce_91,
-  1, 82, :_reduce_92,
-  2, 82, :_reduce_93,
-  3, 82, :_reduce_94,
-  1, 87, :_reduce_95,
-  1, 87, :_reduce_96,
-  0, 106, :_reduce_none,
-  1, 106, :_reduce_none,
+  5, 72, :_reduce_88,
+  1, 103, :_reduce_89,
+  2, 103, :_reduce_90,
+  1, 82, :_reduce_91,
+  2, 82, :_reduce_92,
+  3, 82, :_reduce_93,
+  1, 86, :_reduce_94,
+  1, 86, :_reduce_95,
+  0, 105, :_reduce_none,
+  1, 105, :_reduce_none,
   2, 61, :_reduce_none,
   2, 61, :_reduce_none,
-  4, 105, :_reduce_101,
-  1, 107, :_reduce_102,
-  3, 107, :_reduce_103,
-  1, 108, :_reduce_104,
-  3, 108, :_reduce_105,
-  5, 108, :_reduce_106,
-  7, 108, :_reduce_107,
-  4, 108, :_reduce_108,
-  3, 108, :_reduce_109,
-  1, 94, :_reduce_110,
-  1, 94, :_reduce_111,
+  4, 104, :_reduce_100,
+  1, 106, :_reduce_101,
+  3, 106, :_reduce_102,
+  1, 107, :_reduce_103,
+  3, 107, :_reduce_104,
+  5, 107, :_reduce_105,
+  7, 107, :_reduce_106,
+  4, 107, :_reduce_107,
+  3, 107, :_reduce_108,
+  1, 93, :_reduce_109,
+  1, 93, :_reduce_110,
+  1, 93, :_reduce_111,
   1, 94, :_reduce_112,
-  1, 95, :_reduce_113,
-  3, 95, :_reduce_114,
-  2, 95, :_reduce_115,
-  4, 95, :_reduce_116,
+  3, 94, :_reduce_113,
+  2, 94, :_reduce_114,
+  4, 94, :_reduce_115,
+  0, 108, :_reduce_116,
   0, 109, :_reduce_117,
-  0, 110, :_reduce_118,
-  5, 96, :_reduce_119,
-  3, 93, :_reduce_120,
-  0, 111, :_reduce_121,
-  3, 62, :_reduce_122,
+  5, 95, :_reduce_118,
+  3, 92, :_reduce_119,
+  0, 110, :_reduce_120,
+  3, 62, :_reduce_121,
   1, 70, :_reduce_none,
   0, 71, :_reduce_none,
   1, 71, :_reduce_none,
   1, 71, :_reduce_none,
   1, 71, :_reduce_none,
-  1, 99, :_reduce_128 ]
+  1, 98, :_reduce_127 ]
 
-racc_reduce_n = 129
+racc_reduce_n = 128
 
 racc_shift_n = 219
 
@@ -1194,7 +1195,6 @@ Racc_token_to_s_table = [
   "token_declarations",
   "symbol_declarations",
   "token_declarations_for_precedence",
-  "\"-group@\\\"%type\\\"|\\\"%nterm\\\"\"",
   "token_declaration",
   "\"-option@TAG\"",
   "\"-many1@token_declaration\"",
@@ -1506,24 +1506,10 @@ module_eval(<<'.,.,', 'parser.y', 105)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 159)
-  def _reduce_43(val, _values, result)
-    result = val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 159)
-  def _reduce_44(val, _values, result)
-    result = val
-    result
-  end
-.,.,
-
-# reduce 45 omitted
+# reduce 43 omitted
 
 module_eval(<<'.,.,', 'parser.y', 111)
-  def _reduce_46(val, _values, result)
+  def _reduce_44(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               @grammar.add_type(id: id, tag: hash[:tag])
@@ -1535,7 +1521,23 @@ module_eval(<<'.,.,', 'parser.y', 111)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 119)
-  def _reduce_47(val, _values, result)
+  def _reduce_45(val, _values, result)
+                              val[1].each {|hash|
+                            hash[:tokens].each {|id|
+                              if @grammar.find_term_by_s_value(id.s_value)
+                                on_action_error("symbol #{id.s_value} redeclared as a nonterminal", id)
+                              else
+                                @grammar.add_type(id: id, tag: hash[:tag])
+                              end
+                            }
+                          }
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 131)
+  def _reduce_46(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1548,8 +1550,8 @@ module_eval(<<'.,.,', 'parser.y', 119)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 129)
-  def _reduce_48(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 141)
+  def _reduce_47(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1562,8 +1564,8 @@ module_eval(<<'.,.,', 'parser.y', 129)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 139)
-  def _reduce_49(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 151)
+  def _reduce_48(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1576,8 +1578,8 @@ module_eval(<<'.,.,', 'parser.y', 139)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 149)
-  def _reduce_50(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 161)
+  def _reduce_49(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1590,11 +1592,18 @@ module_eval(<<'.,.,', 'parser.y', 149)
   end
 .,.,
 
+# reduce 50 omitted
+
 # reduce 51 omitted
 
-# reduce 52 omitted
+module_eval(<<'.,.,', 'parser.y', 184)
+  def _reduce_52(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
-module_eval(<<'.,.,', 'parser.y', 172)
+module_eval(<<'.,.,', 'parser.y', 184)
   def _reduce_53(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
@@ -1603,13 +1612,6 @@ module_eval(<<'.,.,', 'parser.y', 172)
 
 module_eval(<<'.,.,', 'parser.y', 172)
   def _reduce_54(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 160)
-  def _reduce_55(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
@@ -1618,8 +1620,8 @@ module_eval(<<'.,.,', 'parser.y', 160)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 166)
-  def _reduce_56(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 178)
+  def _reduce_55(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
@@ -1628,19 +1630,19 @@ module_eval(<<'.,.,', 'parser.y', 166)
   end
 .,.,
 
+# reduce 56 omitted
+
 # reduce 57 omitted
 
-# reduce 58 omitted
-
-module_eval(<<'.,.,', 'parser.y', 171)
-  def _reduce_59(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 183)
+  def _reduce_58(val, _values, result)
      result = val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 175)
-  def _reduce_60(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 187)
+  def _reduce_59(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1648,8 +1650,8 @@ module_eval(<<'.,.,', 'parser.y', 175)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 181)
-  def _reduce_61(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 193)
+  def _reduce_60(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1657,8 +1659,8 @@ module_eval(<<'.,.,', 'parser.y', 181)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 186)
-  def _reduce_62(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 198)
+  def _reduce_61(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1666,22 +1668,22 @@ module_eval(<<'.,.,', 'parser.y', 186)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 190)
-  def _reduce_63(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 202)
+  def _reduce_62(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 191)
-  def _reduce_64(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 203)
+  def _reduce_63(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 195)
-  def _reduce_65(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 207)
+  def _reduce_64(val, _values, result)
                       builder = val[0]
                   result = [builder]
 
@@ -1689,8 +1691,8 @@ module_eval(<<'.,.,', 'parser.y', 195)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 200)
-  def _reduce_66(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 212)
+  def _reduce_65(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
 
@@ -1698,16 +1700,16 @@ module_eval(<<'.,.,', 'parser.y', 200)
   end
 .,.,
 
+# reduce 66 omitted
+
 # reduce 67 omitted
 
 # reduce 68 omitted
 
 # reduce 69 omitted
 
-# reduce 70 omitted
-
-module_eval(<<'.,.,', 'parser.y', 206)
-  def _reduce_71(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 218)
+  def _reduce_70(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1715,8 +1717,8 @@ module_eval(<<'.,.,', 'parser.y', 206)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 211)
-  def _reduce_72(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 223)
+  def _reduce_71(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1727,8 +1729,8 @@ module_eval(<<'.,.,', 'parser.y', 211)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 219)
-  def _reduce_73(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 231)
+  def _reduce_72(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1737,8 +1739,8 @@ module_eval(<<'.,.,', 'parser.y', 219)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 225)
-  def _reduce_74(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 237)
+  def _reduce_73(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1747,8 +1749,8 @@ module_eval(<<'.,.,', 'parser.y', 225)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 231)
-  def _reduce_75(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 243)
+  def _reduce_74(val, _values, result)
                   user_code = val[1]
               user_code.alias_name = val[2]
               builder = val[0]
@@ -1759,8 +1761,8 @@ module_eval(<<'.,.,', 'parser.y', 231)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 239)
-  def _reduce_76(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 251)
+  def _reduce_75(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1771,128 +1773,130 @@ module_eval(<<'.,.,', 'parser.y', 239)
   end
 .,.,
 
+# reduce 76 omitted
+
 # reduce 77 omitted
 
-# reduce 78 omitted
-
-module_eval(<<'.,.,', 'parser.y', 246)
-  def _reduce_79(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 258)
+  def _reduce_78(val, _values, result)
      result = val[0].s_value if val[0]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 253)
+module_eval(<<'.,.,', 'parser.y', 265)
+  def _reduce_79(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 265)
   def _reduce_80(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 253)
+module_eval(<<'.,.,', 'parser.y', 260)
   def _reduce_81(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 248)
-  def _reduce_82(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 249)
-  def _reduce_83(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 261)
+  def _reduce_82(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 250)
-  def _reduce_84(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 262)
+  def _reduce_83(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
+# reduce 84 omitted
+
 # reduce 85 omitted
 
-# reduce 86 omitted
-
-module_eval(<<'.,.,', 'parser.y', 256)
-  def _reduce_87(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 268)
+  def _reduce_86(val, _values, result)
                    begin_c_declaration("}")
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 260)
-  def _reduce_88(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 272)
+  def _reduce_87(val, _values, result)
                    end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 264)
-  def _reduce_89(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 276)
+  def _reduce_88(val, _values, result)
                    result = val[2]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 272)
+module_eval(<<'.,.,', 'parser.y', 284)
+  def _reduce_89(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 284)
   def _reduce_90(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 272)
+module_eval(<<'.,.,', 'parser.y', 279)
   def _reduce_91(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 267)
-  def _reduce_92(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 268)
-  def _reduce_93(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 280)
+  def _reduce_92(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 269)
-  def _reduce_94(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 281)
+  def _reduce_93(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 271)
-  def _reduce_95(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 283)
+  def _reduce_94(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 272)
-  def _reduce_96(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 284)
+  def _reduce_95(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
+
+# reduce 96 omitted
 
 # reduce 97 omitted
 
@@ -1900,10 +1904,8 @@ module_eval(<<'.,.,', 'parser.y', 272)
 
 # reduce 99 omitted
 
-# reduce 100 omitted
-
-module_eval(<<'.,.,', 'parser.y', 280)
-  def _reduce_101(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 292)
+  def _reduce_100(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -1916,8 +1918,8 @@ module_eval(<<'.,.,', 'parser.y', 280)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 291)
-  def _reduce_102(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 303)
+  def _reduce_101(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -1928,8 +1930,8 @@ module_eval(<<'.,.,', 'parser.y', 291)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 299)
-  def _reduce_103(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 311)
+  def _reduce_102(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -1940,8 +1942,8 @@ module_eval(<<'.,.,', 'parser.y', 299)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 308)
-  def _reduce_104(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 320)
+  def _reduce_103(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -1949,8 +1951,8 @@ module_eval(<<'.,.,', 'parser.y', 308)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 313)
-  def _reduce_105(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 325)
+  def _reduce_104(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -1961,8 +1963,8 @@ module_eval(<<'.,.,', 'parser.y', 313)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 321)
-  def _reduce_106(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 333)
+  def _reduce_105(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -1973,8 +1975,8 @@ module_eval(<<'.,.,', 'parser.y', 321)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 329)
-  def _reduce_107(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 341)
+  def _reduce_106(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -1985,8 +1987,8 @@ module_eval(<<'.,.,', 'parser.y', 329)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 337)
-  def _reduce_108(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 349)
+  def _reduce_107(val, _values, result)
                user_code = val[1]
            user_code.alias_name = val[2]
            user_code.tag = val[3]
@@ -1998,8 +2000,8 @@ module_eval(<<'.,.,', 'parser.y', 337)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 346)
-  def _reduce_109(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 358)
+  def _reduce_108(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -2010,57 +2012,57 @@ module_eval(<<'.,.,', 'parser.y', 346)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 353)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 365)
+  def _reduce_109(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 354)
-  def _reduce_111(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 366)
+  def _reduce_110(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 355)
-  def _reduce_112(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 367)
+  def _reduce_111(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 357)
-  def _reduce_113(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 369)
+  def _reduce_112(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 358)
-  def _reduce_114(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 370)
+  def _reduce_113(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 359)
-  def _reduce_115(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 371)
+  def _reduce_114(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 360)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 372)
+  def _reduce_115(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 364)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 376)
+  def _reduce_116(val, _values, result)
                           if @prec_seen
                         on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                         @code_after_prec = true
@@ -2071,31 +2073,31 @@ module_eval(<<'.,.,', 'parser.y', 364)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 372)
-  def _reduce_118(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 384)
+  def _reduce_117(val, _values, result)
                           end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 376)
-  def _reduce_119(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 388)
+  def _reduce_118(val, _values, result)
                           result = val[2]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 379)
-  def _reduce_120(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 391)
+  def _reduce_119(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 383)
-  def _reduce_121(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 395)
+  def _reduce_120(val, _values, result)
                                 begin_c_declaration('\Z')
                             @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2103,14 +2105,16 @@ module_eval(<<'.,.,', 'parser.y', 383)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 388)
-  def _reduce_122(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 400)
+  def _reduce_121(val, _values, result)
                                 end_c_declaration
                             @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
+
+# reduce 122 omitted
 
 # reduce 123 omitted
 
@@ -2120,10 +2124,8 @@ module_eval(<<'.,.,', 'parser.y', 388)
 
 # reduce 126 omitted
 
-# reduce 127 omitted
-
-module_eval(<<'.,.,', 'parser.y', 399)
-  def _reduce_128(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 411)
+  def _reduce_127(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -728,305 +728,307 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    92,    48,    93,   166,    48,    75,   172,    48,    75,   166,
-    48,    75,   172,   149,    75,    83,   150,     6,    11,    12,
-    13,    14,    15,    16,    17,    18,    19,    40,    20,    24,
-    25,    26,    27,    28,    29,    30,    31,    90,    32,    33,
-    34,    35,    36,    37,    38,   168,   169,    41,   175,   169,
-    94,   168,   169,    84,   175,   169,    20,    24,    25,    26,
-    27,    28,    29,    30,    31,    90,    32,    33,    34,    35,
-    36,    37,    38,    48,    48,    47,    47,    75,    72,    79,
-   170,   116,   117,   150,    20,    24,    25,    26,    27,    28,
-    29,    30,    31,    44,    32,    33,    34,    35,    36,    37,
-    38,    11,    12,    13,    14,    15,    16,    17,    18,    19,
-    43,    20,    24,    25,    26,    27,    28,    29,    30,    31,
-    45,    32,    33,    34,    35,    36,    37,    38,    48,    48,
-    47,    47,    52,    79,    79,    48,     4,    47,     5,    48,
-    79,    47,    52,    75,    99,    48,     4,    47,     5,    75,
-    99,    48,    48,    47,    47,    75,    99,   113,    48,    48,
-    47,    47,    75,    99,    48,    48,    47,    47,    75,    75,
-    48,    48,    47,    47,    75,    75,    48,    48,    47,   196,
-    75,    75,    48,    48,   196,    47,    75,    75,    48,    48,
-   196,    47,    75,   180,   181,   182,   128,   180,   181,   182,
-   128,   203,   208,   215,   204,   204,   204,    48,    48,    47,
-    47,    48,    48,    47,    47,    48,    52,    47,   180,   181,
-   182,    55,    52,    52,    52,    52,    52,    61,    62,    63,
-    64,    65,    67,    85,    52,    52,   104,   108,   115,   122,
-   123,   125,   128,   129,   133,   138,   139,   140,   141,   143,
-   144,    75,   153,   138,   156,   153,   160,   161,    67,   163,
-   164,   171,   176,   153,   183,   128,   187,   153,   189,   128,
-   153,   198,   153,   128,    67,   164,   205,   164,    67,    67,
-   213,   128,    67 ]
+    94,    50,    95,   168,    50,    77,   174,    50,    77,   168,
+    50,    77,   174,     6,    77,    85,    50,    50,    49,    49,
+    77,    74,    81,    50,    50,    49,    49,    42,    81,    81,
+    50,    50,    49,    49,    43,    81,   115,    50,    92,    49,
+   151,    77,   101,   152,    46,   172,   170,   171,   152,   177,
+   171,    96,   170,   171,    86,   177,   171,    20,    24,    25,
+    26,    27,    28,    29,    30,    31,    92,    34,    32,    33,
+    36,    37,    38,    39,    40,    50,     4,    49,     5,    77,
+   101,   182,   183,   184,   130,    20,    24,    25,    26,    27,
+    28,    29,    30,    31,    47,    34,    32,    33,    36,    37,
+    38,    39,    40,    11,    12,    13,    14,    15,    16,    17,
+    18,    19,    54,    20,    24,    25,    26,    27,    28,    29,
+    30,    31,    54,    34,    32,    33,    36,    37,    38,    39,
+    40,    11,    12,    13,    14,    15,    16,    17,    18,    19,
+    45,    20,    24,    25,    26,    27,    28,    29,    30,    31,
+    54,    34,    32,    33,    36,    37,    38,    39,    40,    50,
+     4,    49,     5,    77,   101,    50,    50,    49,    49,    77,
+   101,    50,    50,    49,    49,    77,    77,    50,    50,    49,
+    49,    77,    77,    50,    50,    49,   198,    77,    77,    50,
+    50,   198,    49,    77,    77,    50,    50,   198,    49,    77,
+   182,   183,   184,   130,   205,   210,   217,   206,   206,   206,
+    50,    50,    49,    49,    50,    50,    49,    49,    50,    57,
+    49,   182,   183,   184,   118,   119,    54,    54,    54,    54,
+    54,    63,    64,    65,    66,    67,    69,    87,    54,    54,
+   106,   110,   117,   124,   125,   127,   130,   131,   135,   140,
+   141,   142,   143,   145,   146,    77,   155,   140,   158,   155,
+   162,   163,    69,   165,   166,   173,   178,   155,   185,   130,
+   189,   155,   191,   130,   155,   200,   155,   130,    69,   166,
+   207,   166,    69,    69,   215,   130,    69 ]
 
 racc_action_check = [
-    46,   152,    46,   152,   158,   152,   158,   177,   158,   177,
-   188,   177,   188,   137,   188,    38,   137,     1,     3,     3,
-     3,     3,     3,     3,     3,     3,     3,     5,     3,     3,
-     3,     3,     3,     3,     3,     3,     3,    44,     3,     3,
-     3,     3,     3,     3,     3,   152,   152,     6,   158,   158,
-    46,   177,   177,    38,   188,   188,    44,    44,    44,    44,
-    44,    44,    44,    44,    44,    86,    44,    44,    44,    44,
-    44,    44,    44,    33,    34,    33,    34,    33,    33,    34,
-   155,    84,    84,   155,    86,    86,    86,    86,    86,    86,
-    86,    86,    86,     9,    86,    86,    86,    86,    86,    86,
-    86,     8,     8,     8,     8,     8,     8,     8,     8,     8,
+    48,   154,    48,   154,   160,   154,   160,   179,   160,   179,
+   190,   179,   190,     1,   190,    40,    35,    36,    35,    36,
+    35,    35,    36,    37,    38,    37,    38,     5,    37,    38,
+    39,    79,    39,    79,     6,    39,    79,    60,    46,    60,
+   139,    60,    60,   139,     9,   157,   154,   154,   157,   160,
+   160,    48,   179,   179,    40,   190,   190,    46,    46,    46,
+    46,    46,    46,    46,    46,    46,    88,    46,    46,    46,
+    46,    46,    46,    46,    46,    61,     0,    61,     0,    61,
+    61,   167,   167,   167,   167,    88,    88,    88,    88,    88,
+    88,    88,    88,    88,    11,    88,    88,    88,    88,    88,
+    88,    88,    88,     3,     3,     3,     3,     3,     3,     3,
+     3,     3,    13,     3,     3,     3,     3,     3,     3,     3,
+     3,     3,    14,     3,     3,     3,     3,     3,     3,     3,
+     3,     8,     8,     8,     8,     8,     8,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
-    11,     8,     8,     8,     8,     8,     8,     8,    35,    36,
-    35,    36,    13,    35,    36,    37,     0,    37,     0,    58,
-    37,    58,    14,    58,    58,    59,     2,    59,     2,    59,
-    59,    60,    77,    60,    77,    60,    60,    77,   100,    12,
-   100,    12,   100,   100,    70,    72,    70,    72,    70,    72,
-   108,   168,   108,   168,   108,   168,   175,   183,   175,   183,
-   175,   183,   189,   204,   189,   204,   189,   204,   205,    68,
-   205,    68,   205,   165,   165,   165,   165,   173,   173,   173,
-   173,   195,   200,   212,   195,   200,   212,    79,   104,    79,
-   104,   105,   111,   105,   111,   113,    15,   113,   197,   197,
-   197,    16,    17,    20,    24,    25,    26,    27,    28,    29,
-    30,    31,    32,    39,    50,    55,    66,    69,    83,    87,
-    88,    89,    90,    96,   107,   115,   116,   117,   118,   127,
-   128,   134,   139,   140,   142,   143,   144,   145,   149,   150,
-   151,   157,   162,   164,   166,   167,   170,   171,   172,   174,
-   176,   186,   187,   191,   192,   194,   196,   199,   201,   203,
-   207,   208,   214 ]
+    15,     8,     8,     8,     8,     8,     8,     8,     8,    62,
+     2,    62,     2,    62,    62,   102,    12,   102,    12,   102,
+   102,    72,    74,    72,    74,    72,    74,   110,   170,   110,
+   170,   110,   170,   177,   185,   177,   185,   177,   185,   191,
+   206,   191,   206,   191,   206,   207,    70,   207,    70,   207,
+   175,   175,   175,   175,   197,   202,   214,   197,   202,   214,
+    81,   106,    81,   106,   107,   113,   107,   113,   115,    16,
+   115,   199,   199,   199,    86,    86,    17,    20,    24,    25,
+    26,    27,    28,    29,    30,    31,    34,    41,    52,    57,
+    68,    71,    85,    89,    90,    91,    92,    98,   109,   117,
+   118,   119,   120,   129,   130,   136,   141,   142,   144,   145,
+   146,   147,   151,   152,   153,   159,   164,   166,   168,   169,
+   172,   173,   174,   176,   178,   188,   189,   193,   194,   196,
+   198,   201,   203,   205,   209,   210,   216 ]
 
 racc_action_pointer = [
-   126,    17,   136,     5,   nil,    20,    47,   nil,    88,    84,
-   nil,   114,   156,    84,    94,   168,   216,   174,   nil,   nil,
-   175,   nil,   nil,   nil,   176,   177,   178,   222,   223,   224,
-   225,   226,   224,    70,    71,   125,   126,   132,    10,   231,
-   nil,   nil,   nil,   nil,    33,   nil,    -5,   nil,   nil,   nil,
-   186,   nil,   nil,   nil,   nil,   187,   nil,   nil,   136,   142,
-   148,   nil,   nil,   nil,   nil,   nil,   228,   nil,   186,   229,
-   161,   nil,   162,   nil,   nil,   nil,   nil,   149,   nil,   204,
-   nil,   nil,   nil,   198,    77,   nil,    61,   230,   218,   219,
-   189,   nil,   nil,   nil,   nil,   nil,   241,   nil,   nil,   nil,
-   155,   nil,   nil,   nil,   205,   208,   nil,   238,   167,   nil,
-   nil,   209,   nil,   212,   nil,   240,   204,   207,   237,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   207,   245,   nil,
-   nil,   nil,   nil,   nil,   244,   nil,   nil,   -28,   nil,   206,
-   248,   nil,   252,   209,   202,   208,   nil,   nil,   nil,   250,
-   254,   215,    -2,   nil,   nil,    39,   nil,   216,     1,   nil,
-   nil,   nil,   220,   nil,   217,   143,   224,   212,   168,   nil,
-   224,   221,   228,   147,   216,   173,   224,     4,   nil,   nil,
-   nil,   nil,   nil,   174,   nil,   nil,   269,   226,     7,   179,
-   nil,   220,   266,   nil,   230,   160,   236,   168,   nil,   232,
-   161,   270,   nil,   271,   180,   185,   nil,   231,   228,   nil,
-   nil,   nil,   162,   nil,   274,   nil,   nil ]
+    66,    13,   150,    90,   nil,    20,    34,   nil,   118,    35,
+   nil,    88,   163,    63,    73,   101,   214,   177,   nil,   nil,
+   178,   nil,   nil,   nil,   179,   180,   181,   226,   227,   228,
+   229,   230,   nil,   nil,   228,    13,    14,    20,    21,    27,
+    10,   235,   nil,   nil,   nil,   nil,    34,   nil,    -5,   nil,
+   nil,   nil,   189,   nil,   nil,   nil,   nil,   190,   nil,   nil,
+    34,    72,   156,   nil,   nil,   nil,   nil,   nil,   232,   nil,
+   193,   233,   168,   nil,   169,   nil,   nil,   nil,   nil,    28,
+   nil,   207,   nil,   nil,   nil,   201,   220,   nil,    62,   234,
+   222,   223,   192,   nil,   nil,   nil,   nil,   nil,   245,   nil,
+   nil,   nil,   162,   nil,   nil,   nil,   208,   211,   nil,   242,
+   174,   nil,   nil,   212,   nil,   215,   nil,   244,   207,   210,
+   241,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   210,
+   249,   nil,   nil,   nil,   nil,   nil,   248,   nil,   nil,    -2,
+   nil,   209,   252,   nil,   256,   212,   205,   211,   nil,   nil,
+   nil,   254,   258,   218,    -2,   nil,   nil,     3,   nil,   219,
+     1,   nil,   nil,   nil,   223,   nil,   220,    30,   227,   215,
+   175,   nil,   227,   224,   231,   149,   219,   180,   227,     4,
+   nil,   nil,   nil,   nil,   nil,   181,   nil,   nil,   273,   229,
+     7,   186,   nil,   223,   270,   nil,   233,   162,   239,   170,
+   nil,   235,   163,   274,   nil,   275,   187,   192,   nil,   234,
+   231,   nil,   nil,   nil,   164,   nil,   278,   nil,   nil ]
 
 racc_action_default = [
-    -1,  -127,    -1,    -3,   -10,  -127,  -127,    -2,    -3,  -127,
-   -16,  -127,  -127,  -127,  -127,  -127,  -127,  -127,   -24,   -25,
-  -127,   -32,   -33,   -34,  -127,  -127,  -127,  -127,  -127,  -127,
-  -127,  -127,   -49,  -127,  -127,  -127,  -127,  -127,  -127,  -127,
-   -13,   217,    -4,   -26,  -127,   -17,  -122,   -93,   -94,  -121,
-   -14,   -19,   -85,   -20,   -21,  -127,   -23,   -31,  -127,  -127,
-  -127,   -38,   -39,   -40,   -41,   -42,   -43,   -50,  -127,   -44,
-   -78,   -80,  -127,   -83,   -84,  -126,   -45,   -88,   -90,  -127,
-   -46,   -47,   -48,  -127,  -127,   -11,    -5,    -7,   -95,  -127,
-   -67,   -18,  -123,  -124,  -125,   -15,  -127,   -22,   -27,   -28,
-   -29,   -35,   -36,   -37,  -127,   -51,   -53,   -55,  -127,   -79,
-   -81,   -88,   -89,  -127,   -91,  -127,  -127,  -127,  -127,    -6,
-    -8,    -9,  -119,   -96,   -97,   -98,   -68,  -127,  -127,   -86,
-   -30,   -54,   -52,   -56,   -75,   -82,   -92,  -127,   -61,   -65,
-  -127,   -12,  -127,   -65,  -127,  -127,   -57,   -76,   -77,   -49,
-  -127,   -59,   -63,   -66,   -69,  -127,  -120,   -99,  -100,  -102,
-  -118,   -87,  -127,   -62,   -65,   -67,   -93,   -67,  -127,  -115,
-  -127,   -65,   -93,   -67,   -67,  -127,   -65,   -64,   -70,   -71,
-  -108,  -109,  -110,  -127,   -73,   -74,  -127,   -65,  -101,  -127,
-  -103,   -67,   -49,  -107,   -58,  -127,   -93,  -111,  -116,   -60,
-  -127,   -49,  -106,   -49,  -127,  -127,  -113,  -127,   -67,  -104,
-   -72,  -112,  -127,  -117,   -49,  -114,  -105 ]
+    -1,  -129,    -1,    -3,   -10,  -129,  -129,    -2,    -3,  -129,
+   -16,  -129,  -129,  -129,  -129,  -129,  -129,  -129,   -24,   -25,
+  -129,   -32,   -33,   -34,  -129,  -129,  -129,  -129,  -129,  -129,
+  -129,  -129,   -43,   -44,   -51,  -129,  -129,  -129,  -129,  -129,
+  -129,  -129,   -13,   219,    -4,   -26,  -129,   -17,  -124,   -95,
+   -96,  -123,   -14,   -19,   -87,   -20,   -21,  -129,   -23,   -31,
+  -129,  -129,  -129,   -38,   -39,   -40,   -41,   -42,   -45,   -52,
+  -129,   -46,   -80,   -82,  -129,   -85,   -86,  -128,   -47,   -90,
+   -92,  -129,   -48,   -49,   -50,  -129,  -129,   -11,    -5,    -7,
+   -97,  -129,   -69,   -18,  -125,  -126,  -127,   -15,  -129,   -22,
+   -27,   -28,   -29,   -35,   -36,   -37,  -129,   -53,   -55,   -57,
+  -129,   -81,   -83,   -90,   -91,  -129,   -93,  -129,  -129,  -129,
+  -129,    -6,    -8,    -9,  -121,   -98,   -99,  -100,   -70,  -129,
+  -129,   -88,   -30,   -56,   -54,   -58,   -77,   -84,   -94,  -129,
+   -63,   -67,  -129,   -12,  -129,   -67,  -129,  -129,   -59,   -78,
+   -79,   -51,  -129,   -61,   -65,   -68,   -71,  -129,  -122,  -101,
+  -102,  -104,  -120,   -89,  -129,   -64,   -67,   -69,   -95,   -69,
+  -129,  -117,  -129,   -67,   -95,   -69,   -69,  -129,   -67,   -66,
+   -72,   -73,  -110,  -111,  -112,  -129,   -75,   -76,  -129,   -67,
+  -103,  -129,  -105,   -69,   -51,  -109,   -60,  -129,   -95,  -113,
+  -118,   -62,  -129,   -51,  -108,   -51,  -129,  -129,  -115,  -129,
+   -69,  -106,   -74,  -114,  -129,  -119,   -51,  -116,  -107 ]
 
 racc_goto_table = [
-    68,    98,    98,    98,   127,    49,    87,    71,   151,    89,
-   101,   102,   103,   106,   159,    56,   137,   174,    57,     3,
-     9,     7,    58,    59,    60,    42,   179,    77,    77,    77,
-    77,    51,    53,    54,   191,   112,   158,   114,     1,   120,
-   121,   155,   159,    98,   109,   194,   110,   174,   119,   131,
-   132,    89,   130,    97,   195,    39,   199,   118,   206,    46,
-   200,   107,    91,    66,   188,    69,   146,   134,    95,   112,
-   111,   136,   111,   177,   147,   148,   212,    96,   145,   178,
-   124,   184,   135,    76,    80,    81,    82,   190,   192,   157,
-   186,   207,   142,   nil,   nil,   165,   nil,   107,   107,   nil,
-   nil,   173,   nil,   nil,   111,   201,   111,   nil,   nil,   nil,
-   nil,   185,   nil,   nil,   nil,   nil,   nil,   162,   193,   nil,
-   165,   nil,   214,   nil,   nil,   nil,   197,   nil,   nil,   nil,
-   nil,   173,   197,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   211,   197,   nil,
+    70,   100,   100,   100,   129,    51,    89,    73,   153,    91,
+   103,   104,   105,    58,   161,   139,    59,   176,   108,     1,
+    60,    61,    62,    53,    55,    56,   181,   122,   123,    79,
+    79,    79,    79,   114,   193,   116,   160,     3,    41,     7,
+   157,   120,   161,   100,   111,   196,   112,   176,   121,    48,
+    93,    91,   132,    99,   133,   134,   201,    68,   208,    71,
+     9,   148,    97,   109,   190,    44,   136,   114,   179,   138,
+   197,   149,   113,   150,   113,    98,   202,   147,   126,   180,
+   159,   186,   137,    78,    82,    83,    84,   192,   194,   188,
+   209,   144,   214,   nil,   nil,   167,   nil,   nil,   nil,   109,
+   109,   175,   nil,   nil,   nil,   203,   113,   nil,   113,   nil,
+   nil,   187,   nil,   nil,   nil,   nil,   nil,   164,   195,   nil,
+   167,   nil,   216,   nil,   nil,   nil,   199,   nil,   nil,   nil,
+   nil,   175,   199,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   213,   199,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   202,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   209,
-   nil,   210,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   216 ]
+   204,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   211,
+   nil,   212,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   218 ]
 
 racc_goto_check = [
-    27,    20,    20,    20,    40,    29,     8,    43,    33,    12,
-    22,    22,    22,    28,    39,    15,    32,    38,    15,     6,
-     7,     6,    15,    15,    15,     7,    36,    29,    29,    29,
-    29,    16,    16,    16,    36,    46,    50,    46,     1,     5,
-     9,    32,    39,    20,    43,    33,    43,    38,     8,    28,
-    28,    12,    22,    15,    37,    10,    33,    11,    36,    13,
-    37,    29,    14,    23,    50,    24,    30,    31,    16,    46,
-    29,    46,    29,    34,    41,    42,    37,    44,    45,    40,
-    48,    40,    43,    25,    25,    25,    25,    40,    40,    49,
-    51,    52,    53,   nil,   nil,    20,   nil,    29,    29,   nil,
-   nil,    20,   nil,   nil,    29,    40,    29,   nil,   nil,   nil,
-   nil,    20,   nil,   nil,   nil,   nil,   nil,    27,    20,   nil,
-    20,   nil,    40,   nil,   nil,   nil,    20,   nil,   nil,   nil,
+    28,    20,    20,    20,    41,    30,     8,    44,    34,    12,
+    22,    22,    22,    15,    40,    33,    15,    39,    29,     1,
+    15,    15,    15,    16,    16,    16,    37,     5,     9,    30,
+    30,    30,    30,    47,    37,    47,    51,     6,    10,     6,
+    33,    11,    40,    20,    44,    34,    44,    39,     8,    13,
+    14,    12,    22,    15,    29,    29,    34,    23,    37,    24,
+     7,    31,    16,    30,    51,     7,    32,    47,    35,    47,
+    38,    42,    30,    43,    30,    45,    38,    46,    49,    41,
+    50,    41,    44,    25,    25,    25,    25,    41,    41,    52,
+    53,    54,    38,   nil,   nil,    20,   nil,   nil,   nil,    30,
+    30,    20,   nil,   nil,   nil,    41,    30,   nil,    30,   nil,
+   nil,    20,   nil,   nil,   nil,   nil,   nil,    28,    20,   nil,
+    20,   nil,    41,   nil,   nil,   nil,    20,   nil,   nil,   nil,
    nil,    20,    20,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,    20,    20,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    27,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    27,
-   nil,    27,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    27 ]
+    28,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    28,
+   nil,    28,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    28 ]
 
 racc_goto_pointer = [
-   nil,    38,   nil,   nil,   nil,   -48,    19,    17,   -38,   -47,
-    51,   -28,   -35,    47,    16,    -2,    18,   nil,   nil,   nil,
-   -57,   nil,   -48,    31,    32,    49,   nil,   -32,   -55,    -7,
-   -68,   -40,   -99,  -131,   -91,   nil,  -139,  -129,  -141,  -129,
-   -86,   -60,   -59,   -26,    25,   -51,   -42,   nil,    -8,   -54,
-  -107,   -79,  -107,   -30 ]
+   nil,    19,   nil,   nil,   nil,   -62,    37,    57,   -40,   -61,
+    34,   -46,   -37,    37,     2,    -4,    10,   nil,   nil,   nil,
+   -59,   nil,   -50,    23,    24,    47,   nil,   nil,   -34,   -52,
+    -7,   -75,   -43,  -102,  -133,   -98,   nil,  -141,  -115,  -143,
+  -131,   -88,   -65,   -63,   -28,    21,   -54,   -46,   nil,   -12,
+   -65,  -109,   -82,  -110,   -33 ]
 
 racc_goto_default = [
-   nil,   nil,     2,     8,    86,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,    10,   nil,   nil,    50,   nil,    21,    22,    23,
-    70,   100,   nil,   nil,   nil,   nil,   105,   nil,   nil,    73,
-   nil,   nil,   nil,   nil,   152,   126,   nil,   nil,   167,   154,
-   nil,    74,   nil,   nil,   nil,   nil,    78,    88,   nil,   nil,
-   nil,   nil,   nil,   nil ]
+   nil,   nil,     2,     8,    88,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    10,   nil,   nil,    52,   nil,    21,    22,    23,
+    72,   102,   nil,   nil,   nil,   nil,    35,   107,   nil,   nil,
+    75,   nil,   nil,   nil,   nil,   154,   128,   nil,   nil,   169,
+   156,   nil,    76,   nil,   nil,   nil,   nil,    80,    90,   nil,
+   nil,   nil,   nil,   nil,   nil ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
-  0, 62, :_reduce_1,
-  2, 62, :_reduce_2,
-  0, 63, :_reduce_3,
-  2, 63, :_reduce_4,
-  1, 64, :_reduce_5,
-  2, 64, :_reduce_6,
-  0, 65, :_reduce_none,
-  1, 65, :_reduce_none,
-  5, 57, :_reduce_none,
-  0, 66, :_reduce_10,
-  0, 67, :_reduce_11,
-  5, 58, :_reduce_12,
-  2, 58, :_reduce_none,
-  1, 72, :_reduce_14,
-  2, 72, :_reduce_15,
-  1, 59, :_reduce_none,
-  2, 59, :_reduce_17,
-  3, 59, :_reduce_none,
+  0, 63, :_reduce_1,
+  2, 63, :_reduce_2,
+  0, 64, :_reduce_3,
+  2, 64, :_reduce_4,
+  1, 65, :_reduce_5,
+  2, 65, :_reduce_6,
+  0, 66, :_reduce_none,
+  1, 66, :_reduce_none,
+  5, 58, :_reduce_none,
+  0, 67, :_reduce_10,
+  0, 68, :_reduce_11,
+  5, 59, :_reduce_12,
   2, 59, :_reduce_none,
-  2, 59, :_reduce_20,
-  2, 59, :_reduce_21,
-  3, 59, :_reduce_22,
-  2, 59, :_reduce_23,
-  1, 59, :_reduce_24,
-  1, 59, :_reduce_25,
-  2, 59, :_reduce_none,
-  1, 77, :_reduce_27,
-  1, 77, :_reduce_28,
-  1, 78, :_reduce_29,
-  2, 78, :_reduce_30,
-  2, 68, :_reduce_31,
-  1, 68, :_reduce_none,
-  1, 68, :_reduce_none,
-  1, 68, :_reduce_none,
-  3, 68, :_reduce_35,
-  3, 68, :_reduce_36,
-  3, 68, :_reduce_37,
-  2, 68, :_reduce_38,
-  2, 68, :_reduce_39,
-  2, 68, :_reduce_40,
-  2, 68, :_reduce_41,
-  2, 68, :_reduce_42,
-  2, 73, :_reduce_none,
-  2, 73, :_reduce_44,
-  2, 73, :_reduce_45,
-  2, 73, :_reduce_46,
-  2, 73, :_reduce_47,
-  2, 73, :_reduce_48,
-  0, 83, :_reduce_none,
-  1, 83, :_reduce_none,
-  1, 84, :_reduce_51,
-  2, 84, :_reduce_52,
-  2, 79, :_reduce_53,
-  3, 79, :_reduce_54,
-  0, 87, :_reduce_none,
-  1, 87, :_reduce_none,
-  3, 82, :_reduce_57,
-  8, 74, :_reduce_58,
-  5, 75, :_reduce_59,
+  1, 73, :_reduce_14,
+  2, 73, :_reduce_15,
+  1, 60, :_reduce_none,
+  2, 60, :_reduce_17,
+  3, 60, :_reduce_none,
+  2, 60, :_reduce_none,
+  2, 60, :_reduce_20,
+  2, 60, :_reduce_21,
+  3, 60, :_reduce_22,
+  2, 60, :_reduce_23,
+  1, 60, :_reduce_24,
+  1, 60, :_reduce_25,
+  2, 60, :_reduce_none,
+  1, 78, :_reduce_27,
+  1, 78, :_reduce_28,
+  1, 79, :_reduce_29,
+  2, 79, :_reduce_30,
+  2, 69, :_reduce_31,
+  1, 69, :_reduce_none,
+  1, 69, :_reduce_none,
+  1, 69, :_reduce_none,
+  3, 69, :_reduce_35,
+  3, 69, :_reduce_36,
+  3, 69, :_reduce_37,
+  2, 69, :_reduce_38,
+  2, 69, :_reduce_39,
+  2, 69, :_reduce_40,
+  2, 69, :_reduce_41,
+  2, 69, :_reduce_42,
+  1, 83, :_reduce_43,
+  1, 83, :_reduce_44,
+  2, 74, :_reduce_none,
+  2, 74, :_reduce_46,
+  2, 74, :_reduce_47,
+  2, 74, :_reduce_48,
+  2, 74, :_reduce_49,
+  2, 74, :_reduce_50,
+  0, 85, :_reduce_none,
+  1, 85, :_reduce_none,
+  1, 86, :_reduce_53,
+  2, 86, :_reduce_54,
+  2, 80, :_reduce_55,
+  3, 80, :_reduce_56,
+  0, 89, :_reduce_none,
+  1, 89, :_reduce_none,
+  3, 84, :_reduce_59,
   8, 75, :_reduce_60,
-  1, 88, :_reduce_61,
-  3, 88, :_reduce_62,
-  1, 89, :_reduce_63,
-  3, 89, :_reduce_64,
-  0, 95, :_reduce_none,
-  1, 95, :_reduce_none,
-  0, 96, :_reduce_none,
-  1, 96, :_reduce_none,
-  1, 90, :_reduce_69,
-  3, 90, :_reduce_70,
-  3, 90, :_reduce_71,
-  6, 90, :_reduce_72,
-  3, 90, :_reduce_73,
-  3, 90, :_reduce_74,
+  5, 76, :_reduce_61,
+  8, 76, :_reduce_62,
+  1, 90, :_reduce_63,
+  3, 90, :_reduce_64,
+  1, 91, :_reduce_65,
+  3, 91, :_reduce_66,
+  0, 97, :_reduce_none,
+  1, 97, :_reduce_none,
   0, 98, :_reduce_none,
   1, 98, :_reduce_none,
-  1, 86, :_reduce_77,
-  1, 99, :_reduce_78,
-  2, 99, :_reduce_79,
-  1, 80, :_reduce_80,
-  2, 80, :_reduce_81,
-  3, 80, :_reduce_82,
-  1, 76, :_reduce_none,
-  1, 76, :_reduce_none,
-  0, 100, :_reduce_85,
-  0, 101, :_reduce_86,
-  5, 71, :_reduce_87,
-  1, 102, :_reduce_88,
-  2, 102, :_reduce_89,
-  1, 81, :_reduce_90,
-  2, 81, :_reduce_91,
-  3, 81, :_reduce_92,
-  1, 85, :_reduce_93,
-  1, 85, :_reduce_94,
-  0, 104, :_reduce_none,
-  1, 104, :_reduce_none,
-  2, 60, :_reduce_none,
-  2, 60, :_reduce_none,
-  4, 103, :_reduce_99,
-  1, 105, :_reduce_100,
-  3, 105, :_reduce_101,
-  1, 106, :_reduce_102,
-  3, 106, :_reduce_103,
-  5, 106, :_reduce_104,
-  7, 106, :_reduce_105,
-  4, 106, :_reduce_106,
-  3, 106, :_reduce_107,
-  1, 92, :_reduce_108,
-  1, 92, :_reduce_109,
-  1, 92, :_reduce_110,
-  1, 93, :_reduce_111,
-  3, 93, :_reduce_112,
-  2, 93, :_reduce_113,
-  4, 93, :_reduce_114,
-  0, 107, :_reduce_115,
-  0, 108, :_reduce_116,
-  5, 94, :_reduce_117,
-  3, 91, :_reduce_118,
-  0, 109, :_reduce_119,
-  3, 61, :_reduce_120,
-  1, 69, :_reduce_none,
-  0, 70, :_reduce_none,
+  1, 92, :_reduce_71,
+  3, 92, :_reduce_72,
+  3, 92, :_reduce_73,
+  6, 92, :_reduce_74,
+  3, 92, :_reduce_75,
+  3, 92, :_reduce_76,
+  0, 100, :_reduce_none,
+  1, 100, :_reduce_none,
+  1, 88, :_reduce_79,
+  1, 101, :_reduce_80,
+  2, 101, :_reduce_81,
+  1, 81, :_reduce_82,
+  2, 81, :_reduce_83,
+  3, 81, :_reduce_84,
+  1, 77, :_reduce_none,
+  1, 77, :_reduce_none,
+  0, 102, :_reduce_87,
+  0, 103, :_reduce_88,
+  5, 72, :_reduce_89,
+  1, 104, :_reduce_90,
+  2, 104, :_reduce_91,
+  1, 82, :_reduce_92,
+  2, 82, :_reduce_93,
+  3, 82, :_reduce_94,
+  1, 87, :_reduce_95,
+  1, 87, :_reduce_96,
+  0, 106, :_reduce_none,
+  1, 106, :_reduce_none,
+  2, 61, :_reduce_none,
+  2, 61, :_reduce_none,
+  4, 105, :_reduce_101,
+  1, 107, :_reduce_102,
+  3, 107, :_reduce_103,
+  1, 108, :_reduce_104,
+  3, 108, :_reduce_105,
+  5, 108, :_reduce_106,
+  7, 108, :_reduce_107,
+  4, 108, :_reduce_108,
+  3, 108, :_reduce_109,
+  1, 94, :_reduce_110,
+  1, 94, :_reduce_111,
+  1, 94, :_reduce_112,
+  1, 95, :_reduce_113,
+  3, 95, :_reduce_114,
+  2, 95, :_reduce_115,
+  4, 95, :_reduce_116,
+  0, 109, :_reduce_117,
+  0, 110, :_reduce_118,
+  5, 96, :_reduce_119,
+  3, 93, :_reduce_120,
+  0, 111, :_reduce_121,
+  3, 62, :_reduce_122,
   1, 70, :_reduce_none,
-  1, 70, :_reduce_none,
-  1, 70, :_reduce_none,
-  1, 97, :_reduce_126 ]
+  0, 71, :_reduce_none,
+  1, 71, :_reduce_none,
+  1, 71, :_reduce_none,
+  1, 71, :_reduce_none,
+  1, 99, :_reduce_128 ]
 
-racc_reduce_n = 127
+racc_reduce_n = 129
 
-racc_shift_n = 217
+racc_shift_n = 219
 
 racc_token_table = {
   false => 0,
@@ -1064,29 +1066,30 @@ racc_token_table = {
   "-temp-group" => 32,
   "%token" => 33,
   "%type" => 34,
-  "%left" => 35,
-  "%right" => 36,
-  "%precedence" => 37,
-  "%nonassoc" => 38,
-  "%rule" => 39,
-  "(" => 40,
-  ")" => 41,
-  ":" => 42,
-  "%inline" => 43,
-  "," => 44,
-  "|" => 45,
-  "%empty" => 46,
-  "%prec" => 47,
-  "{" => 48,
-  "}" => 49,
-  "?" => 50,
-  "+" => 51,
-  "*" => 52,
-  "[" => 53,
-  "]" => 54,
-  "{...}" => 55 }
+  "%nterm" => 35,
+  "%left" => 36,
+  "%right" => 37,
+  "%precedence" => 38,
+  "%nonassoc" => 39,
+  "%rule" => 40,
+  "(" => 41,
+  ")" => 42,
+  ":" => 43,
+  "%inline" => 44,
+  "," => 45,
+  "|" => 46,
+  "%empty" => 47,
+  "%prec" => 48,
+  "{" => 49,
+  "}" => 50,
+  "?" => 51,
+  "+" => 52,
+  "*" => 53,
+  "[" => 54,
+  "]" => 55,
+  "{...}" => 56 }
 
-racc_nt_base = 56
+racc_nt_base = 57
 
 racc_use_result_var = true
 
@@ -1143,6 +1146,7 @@ Racc_token_to_s_table = [
   "\"-temp-group\"",
   "\"%token\"",
   "\"%type\"",
+  "\"%nterm\"",
   "\"%left\"",
   "\"%right\"",
   "\"%precedence\"",
@@ -1190,6 +1194,7 @@ Racc_token_to_s_table = [
   "token_declarations",
   "symbol_declarations",
   "token_declarations_for_precedence",
+  "\"-group@\\\"%type\\\"|\\\"%nterm\\\"\"",
   "token_declaration",
   "\"-option@TAG\"",
   "\"-many1@token_declaration\"",
@@ -1501,10 +1506,24 @@ module_eval(<<'.,.,', 'parser.y', 105)
   end
 .,.,
 
-# reduce 43 omitted
+module_eval(<<'.,.,', 'parser.y', 159)
+  def _reduce_43(val, _values, result)
+    result = val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 159)
+  def _reduce_44(val, _values, result)
+    result = val
+    result
+  end
+.,.,
+
+# reduce 45 omitted
 
 module_eval(<<'.,.,', 'parser.y', 111)
-  def _reduce_44(val, _values, result)
+  def _reduce_46(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               @grammar.add_type(id: id, tag: hash[:tag])
@@ -1516,7 +1535,7 @@ module_eval(<<'.,.,', 'parser.y', 111)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 119)
-  def _reduce_45(val, _values, result)
+  def _reduce_47(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1530,7 +1549,7 @@ module_eval(<<'.,.,', 'parser.y', 119)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 129)
-  def _reduce_46(val, _values, result)
+  def _reduce_48(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1544,7 +1563,7 @@ module_eval(<<'.,.,', 'parser.y', 129)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 139)
-  def _reduce_47(val, _values, result)
+  def _reduce_49(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1558,7 +1577,7 @@ module_eval(<<'.,.,', 'parser.y', 139)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 149)
-  def _reduce_48(val, _values, result)
+  def _reduce_50(val, _values, result)
                               val[1].each {|hash|
                             hash[:tokens].each {|id|
                               sym = @grammar.add_term(id: id)
@@ -1571,26 +1590,26 @@ module_eval(<<'.,.,', 'parser.y', 149)
   end
 .,.,
 
-# reduce 49 omitted
+# reduce 51 omitted
 
-# reduce 50 omitted
+# reduce 52 omitted
 
 module_eval(<<'.,.,', 'parser.y', 172)
-  def _reduce_51(val, _values, result)
+  def _reduce_53(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 172)
-  def _reduce_52(val, _values, result)
+  def _reduce_54(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 160)
-  def _reduce_53(val, _values, result)
+  def _reduce_55(val, _values, result)
                               val[1].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
                           }
@@ -1600,7 +1619,7 @@ module_eval(<<'.,.,', 'parser.y', 160)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 166)
-  def _reduce_54(val, _values, result)
+  def _reduce_56(val, _values, result)
                               val[2].each {|token_declaration|
                             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
                           }
@@ -1609,19 +1628,19 @@ module_eval(<<'.,.,', 'parser.y', 166)
   end
 .,.,
 
-# reduce 55 omitted
+# reduce 57 omitted
 
-# reduce 56 omitted
+# reduce 58 omitted
 
 module_eval(<<'.,.,', 'parser.y', 171)
-  def _reduce_57(val, _values, result)
+  def _reduce_59(val, _values, result)
      result = val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 175)
-  def _reduce_58(val, _values, result)
+  def _reduce_60(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1630,7 +1649,7 @@ module_eval(<<'.,.,', 'parser.y', 175)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 181)
-  def _reduce_59(val, _values, result)
+  def _reduce_61(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, [], val[4], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1639,7 +1658,7 @@ module_eval(<<'.,.,', 'parser.y', 181)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 186)
-  def _reduce_60(val, _values, result)
+  def _reduce_62(val, _values, result)
                             rule = Grammar::ParameterizingRule::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
                         @grammar.add_parameterizing_rule(rule)
 
@@ -1648,21 +1667,21 @@ module_eval(<<'.,.,', 'parser.y', 186)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 190)
-  def _reduce_61(val, _values, result)
+  def _reduce_63(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 191)
-  def _reduce_62(val, _values, result)
+  def _reduce_64(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 195)
-  def _reduce_63(val, _values, result)
+  def _reduce_65(val, _values, result)
                       builder = val[0]
                   result = [builder]
 
@@ -1671,7 +1690,7 @@ module_eval(<<'.,.,', 'parser.y', 195)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 200)
-  def _reduce_64(val, _values, result)
+  def _reduce_66(val, _values, result)
                       builder = val[2]
                   result = val[0].append(builder)
 
@@ -1679,16 +1698,16 @@ module_eval(<<'.,.,', 'parser.y', 200)
   end
 .,.,
 
-# reduce 65 omitted
-
-# reduce 66 omitted
-
 # reduce 67 omitted
 
 # reduce 68 omitted
 
+# reduce 69 omitted
+
+# reduce 70 omitted
+
 module_eval(<<'.,.,', 'parser.y', 206)
-  def _reduce_69(val, _values, result)
+  def _reduce_71(val, _values, result)
                   reset_precs
               result = Grammar::ParameterizingRule::Rhs.new
 
@@ -1697,7 +1716,7 @@ module_eval(<<'.,.,', 'parser.y', 206)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 211)
-  def _reduce_70(val, _values, result)
+  def _reduce_72(val, _values, result)
                   token = val[1]
               token.alias_name = val[2]
               builder = val[0]
@@ -1709,7 +1728,7 @@ module_eval(<<'.,.,', 'parser.y', 211)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 219)
-  def _reduce_71(val, _values, result)
+  def _reduce_73(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
                 result = builder
@@ -1719,7 +1738,7 @@ module_eval(<<'.,.,', 'parser.y', 219)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 225)
-  def _reduce_72(val, _values, result)
+  def _reduce_74(val, _values, result)
                     builder = val[0]
                 builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
                 result = builder
@@ -1729,7 +1748,7 @@ module_eval(<<'.,.,', 'parser.y', 225)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 231)
-  def _reduce_73(val, _values, result)
+  def _reduce_75(val, _values, result)
                   user_code = val[1]
               user_code.alias_name = val[2]
               builder = val[0]
@@ -1741,7 +1760,7 @@ module_eval(<<'.,.,', 'parser.y', 231)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 239)
-  def _reduce_74(val, _values, result)
+  def _reduce_76(val, _values, result)
                   sym = @grammar.find_symbol_by_id!(val[2])
               @prec_seen = true
               builder = val[0]
@@ -1752,58 +1771,58 @@ module_eval(<<'.,.,', 'parser.y', 239)
   end
 .,.,
 
-# reduce 75 omitted
+# reduce 77 omitted
 
-# reduce 76 omitted
+# reduce 78 omitted
 
 module_eval(<<'.,.,', 'parser.y', 246)
-  def _reduce_77(val, _values, result)
+  def _reduce_79(val, _values, result)
      result = val[0].s_value if val[0]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 253)
-  def _reduce_78(val, _values, result)
+  def _reduce_80(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 253)
-  def _reduce_79(val, _values, result)
+  def _reduce_81(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 248)
-  def _reduce_80(val, _values, result)
+  def _reduce_82(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 249)
-  def _reduce_81(val, _values, result)
+  def _reduce_83(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 250)
-  def _reduce_82(val, _values, result)
+  def _reduce_84(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-# reduce 83 omitted
+# reduce 85 omitted
 
-# reduce 84 omitted
+# reduce 86 omitted
 
 module_eval(<<'.,.,', 'parser.y', 256)
-  def _reduce_85(val, _values, result)
+  def _reduce_87(val, _values, result)
                    begin_c_declaration("}")
 
     result
@@ -1811,7 +1830,7 @@ module_eval(<<'.,.,', 'parser.y', 256)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 260)
-  def _reduce_86(val, _values, result)
+  def _reduce_88(val, _values, result)
                    end_c_declaration
 
     result
@@ -1819,7 +1838,7 @@ module_eval(<<'.,.,', 'parser.y', 260)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 264)
-  def _reduce_87(val, _values, result)
+  def _reduce_89(val, _values, result)
                    result = val[2]
 
     result
@@ -1827,64 +1846,64 @@ module_eval(<<'.,.,', 'parser.y', 264)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 272)
-  def _reduce_88(val, _values, result)
+  def _reduce_90(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 272)
-  def _reduce_89(val, _values, result)
+  def _reduce_91(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 267)
-  def _reduce_90(val, _values, result)
+  def _reduce_92(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 268)
-  def _reduce_91(val, _values, result)
+  def _reduce_93(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 269)
-  def _reduce_92(val, _values, result)
+  def _reduce_94(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 271)
-  def _reduce_93(val, _values, result)
+  def _reduce_95(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 272)
-  def _reduce_94(val, _values, result)
+  def _reduce_96(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-# reduce 95 omitted
-
-# reduce 96 omitted
-
 # reduce 97 omitted
 
 # reduce 98 omitted
 
+# reduce 99 omitted
+
+# reduce 100 omitted
+
 module_eval(<<'.,.,', 'parser.y', 280)
-  def _reduce_99(val, _values, result)
+  def _reduce_101(val, _values, result)
                  lhs = val[0]
              lhs.alias_name = val[1]
              val[3].each do |builder|
@@ -1898,7 +1917,7 @@ module_eval(<<'.,.,', 'parser.y', 280)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 291)
-  def _reduce_100(val, _values, result)
+  def _reduce_102(val, _values, result)
                     builder = val[0]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -1910,7 +1929,7 @@ module_eval(<<'.,.,', 'parser.y', 291)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 299)
-  def _reduce_101(val, _values, result)
+  def _reduce_103(val, _values, result)
                     builder = val[2]
                 if !builder.line
                   builder.line = @lexer.line - 1
@@ -1922,7 +1941,7 @@ module_eval(<<'.,.,', 'parser.y', 299)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 308)
-  def _reduce_102(val, _values, result)
+  def _reduce_104(val, _values, result)
                reset_precs
            result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -1931,7 +1950,7 @@ module_eval(<<'.,.,', 'parser.y', 308)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 313)
-  def _reduce_103(val, _values, result)
+  def _reduce_105(val, _values, result)
                token = val[1]
            token.alias_name = val[2]
            builder = val[0]
@@ -1943,7 +1962,7 @@ module_eval(<<'.,.,', 'parser.y', 313)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 321)
-  def _reduce_104(val, _values, result)
+  def _reduce_106(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
            builder = val[0]
            builder.add_rhs(token)
@@ -1955,7 +1974,7 @@ module_eval(<<'.,.,', 'parser.y', 321)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 329)
-  def _reduce_105(val, _values, result)
+  def _reduce_107(val, _values, result)
                token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
            builder = val[0]
            builder.add_rhs(token)
@@ -1967,7 +1986,7 @@ module_eval(<<'.,.,', 'parser.y', 329)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 337)
-  def _reduce_106(val, _values, result)
+  def _reduce_108(val, _values, result)
                user_code = val[1]
            user_code.alias_name = val[2]
            user_code.tag = val[3]
@@ -1980,7 +1999,7 @@ module_eval(<<'.,.,', 'parser.y', 337)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 346)
-  def _reduce_107(val, _values, result)
+  def _reduce_109(val, _values, result)
                sym = @grammar.find_symbol_by_id!(val[2])
            @prec_seen = true
            builder = val[0]
@@ -1992,56 +2011,56 @@ module_eval(<<'.,.,', 'parser.y', 346)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 353)
-  def _reduce_108(val, _values, result)
+  def _reduce_110(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 354)
-  def _reduce_109(val, _values, result)
+  def _reduce_111(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 355)
-  def _reduce_110(val, _values, result)
+  def _reduce_112(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 357)
-  def _reduce_111(val, _values, result)
+  def _reduce_113(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 358)
-  def _reduce_112(val, _values, result)
+  def _reduce_114(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 359)
-  def _reduce_113(val, _values, result)
+  def _reduce_115(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 360)
-  def _reduce_114(val, _values, result)
+  def _reduce_116(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 364)
-  def _reduce_115(val, _values, result)
+  def _reduce_117(val, _values, result)
                           if @prec_seen
                         on_action_error("multiple User_code after %prec", val[0])  if @code_after_prec
                         @code_after_prec = true
@@ -2053,7 +2072,7 @@ module_eval(<<'.,.,', 'parser.y', 364)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 372)
-  def _reduce_116(val, _values, result)
+  def _reduce_118(val, _values, result)
                           end_c_declaration
 
     result
@@ -2061,7 +2080,7 @@ module_eval(<<'.,.,', 'parser.y', 372)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 376)
-  def _reduce_117(val, _values, result)
+  def _reduce_119(val, _values, result)
                           result = val[2]
 
     result
@@ -2069,14 +2088,14 @@ module_eval(<<'.,.,', 'parser.y', 376)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 379)
-  def _reduce_118(val, _values, result)
+  def _reduce_120(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 383)
-  def _reduce_119(val, _values, result)
+  def _reduce_121(val, _values, result)
                                 begin_c_declaration('\Z')
                             @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2085,7 +2104,7 @@ module_eval(<<'.,.,', 'parser.y', 383)
 .,.,
 
 module_eval(<<'.,.,', 'parser.y', 388)
-  def _reduce_120(val, _values, result)
+  def _reduce_122(val, _values, result)
                                 end_c_declaration
                             @grammar.epilogue = val[2].s_value
 
@@ -2093,18 +2112,18 @@ module_eval(<<'.,.,', 'parser.y', 388)
   end
 .,.,
 
-# reduce 121 omitted
-
-# reduce 122 omitted
-
 # reduce 123 omitted
 
 # reduce 124 omitted
 
 # reduce 125 omitted
 
+# reduce 126 omitted
+
+# reduce 127 omitted
+
 module_eval(<<'.,.,', 'parser.y', 399)
-  def _reduce_126(val, _values, result)
+  def _reduce_128(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/parser.y
+++ b/parser.y
@@ -107,11 +107,23 @@ rule
                          }
 
   symbol_declaration: "%token" token_declarations
-                    | ("%type" | "%nterm") symbol_declarations
+                    | "%type" symbol_declarations
                         {
                           val[1].each {|hash|
                             hash[:tokens].each {|id|
                               @grammar.add_type(id: id, tag: hash[:tag])
+                            }
+                          }
+                        }
+                    | "%nterm" symbol_declarations
+                        {
+                          val[1].each {|hash|
+                            hash[:tokens].each {|id|
+                              if @grammar.find_term_by_s_value(id.s_value)
+                                on_action_error("symbol #{id.s_value} redeclared as a nonterminal", id)
+                              else
+                                @grammar.add_type(id: id, tag: hash[:tag])
+                              end
                             }
                           }
                         }

--- a/parser.y
+++ b/parser.y
@@ -107,7 +107,7 @@ rule
                          }
 
   symbol_declaration: "%token" token_declarations
-                    | "%type" symbol_declarations
+                    | ("%type" | "%nterm") symbol_declarations
                         {
                           val[1].each {|hash|
                             hash[:tokens].each {|id|

--- a/spec/lrama/diagnostics_spec.rb
+++ b/spec/lrama/diagnostics_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Lrama::Diagnostics do
           %token tEQEQ  "=="
 
           %type <i> class /* comment for class */
+          %nterm <str> string /* comment for string */
 
           %nonassoc tEQEQ
           %left  tPLUS tMINUS '>'

--- a/spec/lrama/grammar/code_spec.rb
+++ b/spec/lrama/grammar/code_spec.rb
@@ -176,9 +176,9 @@ RSpec.describe Lrama::Grammar::Code do
         %type <rule2> rule2
         %type <rule3> rule3
         %type <rule4> rule4
-        %type <rule5> rule5
-        %type <rule6> rule6
-        %type <rule7> rule7
+        %nterm <rule5> rule5
+        %nterm <rule6> rule6
+        %nterm <rule7> rule7
 
         %%
 

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -3710,6 +3710,32 @@ RSpec.describe Lrama::Parser do
           ERROR
         end
       end
+
+      context "when pass the terminal symbol to `%nterm`" do
+        it "raises an error" do
+          y = <<~INPUT
+            %{
+            // Prologue
+            %}
+            
+            %token EOI 0 "EOI"
+            %nterm EOI
+            
+            %%
+            
+            program: /* empty */
+                   ;
+          INPUT
+
+          parser = Lrama::Parser.new(y, "error_messages/parse.y")
+
+          expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
+            error_messages/parse.y:6:7: symbol EOI redeclared as a nonterminal
+            %nterm EOI
+                   ^^^
+          ERROR
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR add support for %type declarations using `%nterm` in Nonterminal Symbols. https://www.gnu.org/software/bison/manual/html_node/Type-Decl.html