### PR TITLE
Specify `--parser` for RUN_OPTS and SPECOPTS when run test-all

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -186,4 +186,8 @@ jobs:
       - run: ../autogen.sh
       - run: ../configure -C --disable-install-doc
       - run: make
-      - run: make test-all
+      - run: make test-all RUN_OPTS="$RUN_OPTS" SPECOPTS="$SPECOPTS"
+        env:
+          EXCLUDES: '../test/.excludes-parsey'
+          RUN_OPTS: ${{ matrix.run_opts || '--parser=parse.y' }}
+          SPECOPTS: ${{ matrix.specopts || '-T --parser=parse.y' }}


### PR DESCRIPTION
Ref: https://github.com/ruby/ruby/blob/354e790794d9fd4996172da9235e3b09fcb3e4ca/.github/workflows/parsey.yml#L76-L83