### PR TITLE
Use rbs-inline and rewrite bitmap.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,6 @@ gem "memory_profiler"
 # Then skip install on some CI jobs.
 if !ENV['GITHUB_ACTION'] || ENV['INSTALL_STEEP'] == 'true'
   gem "rbs", "3.7.0", require: false
+  gem "rbs-inline", require: false
   gem "steep", "1.9.1", require: false
 end

--- a/lib/lrama/bitmap.rb
+++ b/lib/lrama/bitmap.rb
@@ -1,7 +1,9 @@
+# rbs_inline: enabled
 # frozen_string_literal: true
 
 module Lrama
   module Bitmap
+    # @rbs (Array[Integer] ary) -> Integer
     def self.from_array(ary)
       bit = 0
 
@@ -12,6 +14,7 @@ module Lrama
       bit
     end
 
+    # @rbs (Integer int) -> Array[Integer]
     def self.to_array(int)
       a = [] #: Array[Integer]
       i = 0

--- a/sig/generated/lrama/bitmap.rbs
+++ b/sig/generated/lrama/bitmap.rbs
@@ -1,0 +1,11 @@
+# Generated from lib/lrama/bitmap.rb with RBS::Inline
+
+module Lrama
+  module Bitmap
+    # @rbs (Array[Integer] ary) -> Integer
+    def self.from_array: (Array[Integer] ary) -> Integer
+
+    # @rbs (Integer int) -> Array[Integer]
+    def self.to_array: (Integer int) -> Array[Integer]
+  end
+end

--- a/sig/lrama/bitmap.rbs
+++ b/sig/lrama/bitmap.rbs
@@ -1,7 +1,0 @@
-module Lrama
-  module Bitmap
-    def self.from_array: (Array[int] ary) -> Integer
-
-    def self.to_array: (Integer int) -> Array[Integer]
-  end
-end


### PR DESCRIPTION
I'll be installing rbs-inline, which we discussed previously.
rbs-inline requires writing the type information to `.rb` files and generating `.rbs` files with `rbs-inline --output`.
ref: https://github.com/soutaro/rbs-inline?tab=readme-ov-file#usage

I were also considering installing rubocop-on-rbs, but decided to pass on it because rubocop has not use yet.