### PR TITLE
Optimize Lexer comment reading

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -169,12 +169,11 @@ module Lrama
     def lex_comment
       until @scanner.eos? do
         case
-        when @scanner.scan(/\n/)
-          newline
-        when @scanner.scan(/\*\//)
+        when @scanner.scan_until(/[\s\S]*?\*\//)
+          @scanner.matched.count("\n").times { newline }
           return
-        else
-          @scanner.getch
+        when @scanner.scan_until(/\n/)
+          newline
         end
       end
     end


### PR DESCRIPTION
This pull request changes the `StringScanner#getch` to read one character at a time and optimizes Lexer's comment reading.
The effect is seen when there are many comments.

```yacc
/*
 * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis hendrerit, mi non eleifend aliquet, arcu lectus vulputate est, in suscipit lacus nibh a ligula. Nulla non mi sit amet lectus malesuada elementum et sed ex. Nam porttitor ut urna id consequat. Sed neque ex, feugiat ut convallis sit amet, laoreet vitae sapien. Aliquam vestibulum elit mauris, eu ornare leo consectetur nec. Suspendisse bibendum blandit pretium. Suspendisse eget tortor non libero sodales aliquam id vel risus.
 *
 * Maecenas ac cursus velit. Sed vehicula nisl mattis eros malesuada, eu volutpat lorem volutpat. Mauris et metus venenatis, facilisis tortor eu, tempus dui. Quisque vel dui eu felis elementum gravida. Proin sed eros odio. Curabitur porttitor maximus tellus nec luctus. Vestibulum at feugiat sapien, at pharetra orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer iaculis enim vitae nisi commodo lacinia. Proin sapien erat, convallis aliquet orci eu, aliquet dapibus massa. Donec ultricies, sapien non pellentesque elementum, metus odio hendrerit urna, sed interdum metus risus sit amet ligula. In at feugiat dolor, non egestas leo. Quisque augue orci, hendrerit sed ipsum ut, tristique aliquet mauris. Praesent non lectus scelerisque, facilisis ante at, eleifend sapien.
 *
 * Nam dignissim suscipit nibh at dictum. Quisque ac sagittis nulla. Etiam at ipsum eget massa viverra egestas. Suspendisse fermentum iaculis rhoncus. Suspendisse non odio a arcu porta pretium semper sed ex. Quisque facilisis lorem tortor, ut efficitur diam aliquet eu. Nam ac turpis ut neque finibus varius et at diam. Cras mi ligula, pharetra eget purus nec, luctus malesuada sem. Praesent eget convallis tellus. Sed non euismod diam, vulputate porttitor metus. Sed ante lectus, venenatis id tortor in, vehicula euismod magna. In mattis ullamcorper arcu, nec malesuada elit consectetur et. Aliquam vitae tincidunt sapien. Aliquam eu congue tortor, sed laoreet tellus. Sed id elementum lorem.
 *
 * Quisque luctus, quam at volutpat aliquet, massa ex ultrices quam, rutrum eleifend sem odio nec lectus. Morbi id semper leo. Sed dapibus, sapien at tincidunt scelerisque, augue ex iaculis elit, non rutrum nisl turpis id lacus. In posuere tortor id mattis lobortis. Pellentesque eget quam ut quam luctus bibendum quis eget justo. Suspendisse mollis, quam vitae volutpat ornare, lacus magna elementum arcu, vitae tristique diam urna mollis nulla. Nunc ullamcorper blandit gravida. Duis non enim risus. Nunc auctor nibh non ultricies maximus. Duis tempor venenatis sapien id fermentum. Nulla vel arcu eu eros tristique sagittis. Vestibulum quis leo orci.
 *
 * Proin finibus molestie nunc eu dapibus. Mauris non placerat purus. Aliquam a porttitor dolor. Nam elit dui, convallis sit amet ante eu, lacinia posuere leo. Suspendisse vel tortor tellus. Aenean posuere maximus sapien sit amet feugiat. Nulla viverra auctor est, vitae dignissim lacus finibus sit amet. Phasellus bibendum velit id nunc ultrices placerat. Proin et egestas nisl. Sed ultricies sed dolor eu vehicula. Quisque in egestas nibh, sed scelerisque odio. Nunc aliquam rhoncus mauris, cursus mattis turpis pharetra rhoncus. Sed eget sapien vitae orci fringilla pretium. Nam nec ipsum id lectus pretium lobortis non ac justo. Mauris et dolor sed mauris consectetur volutpat in eget urna.
 * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis hendrerit, mi non eleifend aliquet, arcu lectus vulputate est, in suscipit lacus nibh a ligula. Nulla non mi sit amet lectus malesuada elementum et sed ex. Nam porttitor ut urna id consequat. Sed neque ex, feugiat ut convallis sit amet, laoreet vitae sapien. Aliquam vestibulum elit mauris, eu ornare leo consectetur nec. Suspendisse bibendum blandit pretium. Suspendisse eget tortor non libero sodales aliquam id vel risus.
 *
 * Maecenas ac cursus velit. Sed vehicula nisl mattis eros malesuada, eu volutpat lorem volutpat. Mauris et metus venenatis, facilisis tortor eu, tempus dui. Quisque vel dui eu felis elementum gravida. Proin sed eros odio. Curabitur porttitor maximus tellus nec luctus. Vestibulum at feugiat sapien, at pharetra orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer iaculis enim vitae nisi commodo lacinia. Proin sapien erat, convallis aliquet orci eu, aliquet dapibus massa. Donec ultricies, sapien non pellentesque elementum, metus odio hendrerit urna, sed interdum metus risus sit amet ligula. In at feugiat dolor, non egestas leo. Quisque augue orci, hendrerit sed ipsum ut, tristique aliquet mauris. Praesent non lectus scelerisque, facilisis ante at, eleifend sapien.
 *
 * Nam dignissim suscipit nibh at dictum. Quisque ac sagittis nulla. Etiam at ipsum eget massa viverra egestas. Suspendisse fermentum iaculis rhoncus. Suspendisse non odio a arcu porta pretium semper sed ex. Quisque facilisis lorem tortor, ut efficitur diam aliquet eu. Nam ac turpis ut neque finibus varius et at diam. Cras mi ligula, pharetra eget purus nec, luctus malesuada sem. Praesent eget convallis tellus. Sed non euismod diam, vulputate porttitor metus. Sed ante lectus, venenatis id tortor in, vehicula euismod magna. In mattis ullamcorper arcu, nec malesuada elit consectetur et. Aliquam vitae tincidunt sapien. Aliquam eu congue tortor, sed laoreet tellus. Sed id elementum lorem.
 *
 * Quisque luctus, quam at volutpat aliquet, massa ex ultrices quam, rutrum eleifend sem odio nec lectus. Morbi id semper leo. Sed dapibus, sapien at tincidunt scelerisque, augue ex iaculis elit, non rutrum nisl turpis id lacus. In posuere tortor id mattis lobortis. Pellentesque eget quam ut quam luctus bibendum quis eget justo. Suspendisse mollis, quam vitae volutpat ornare, lacus magna elementum arcu, vitae tristique diam urna mollis nulla. Nunc ullamcorper blandit gravida. Duis non enim risus. Nunc auctor nibh non ultricies maximus. Duis tempor venenatis sapien id fermentum. Nulla vel arcu eu eros tristique sagittis. Vestibulum quis leo orci.
 *
 * Proin finibus molestie nunc eu dapibus. Mauris non placerat purus. Aliquam a porttitor dolor. Nam elit dui, convallis sit amet ante eu, lacinia posuere leo. Suspendisse vel tortor tellus. Aenean posuere maximus sapien sit amet feugiat. Nulla viverra auctor est, vitae dignissim lacus finibus sit amet. Phasellus bibendum velit id nunc ultrices placerat. Proin et egestas nisl. Sed ultricies sed dolor eu vehicula. Quisque in egestas nibh, sed scelerisque odio. Nunc aliquam rhoncus mauris, cursus mattis turpis pharetra rhoncus. Sed eget sapien vitae orci fringilla pretium. Nam nec ipsum id lectus pretium lobortis non ac justo. Mauris et dolor sed mauris consectetur volutpat in eget urna.
 */

%{
%}

%union {
    int i;
}

%token <i> number

%%

program         : number
                ;

%%

```

Before
```
❯ exe/lrama --trace=time -o long_comment.tmp.c --header=long_comment.tmp.h long_comment.y
parse    0.00299 s
parse    0.00317 s
compute_lr0_states    0.00005 s
compute_direct_read_sets    0.00002 s
compute_reads_relation    0.00000 s
compute_read_sets    0.00001 s
compute_includes_relation    0.00000 s
compute_lookback_relation    0.00001 s
compute_follow_sets    0.00001 s
compute_look_ahead_sets    0.00001 s
compute_conflicts    0.00001 s
compute_default_reduction    0.00001 s
compute_yydefact    0.00002 s
compute_yydefgoto    0.00001 s
sort_actions    0.00000 s
compute_packed_table    0.00001 s
render    0.00725 s
```

After
```
❯ exe/lrama --trace=time -o long_comment.tmp.c --header=long_comment.tmp.h long_comment.y
parse    0.00040 s
parse    0.00311 s
compute_lr0_states    0.00004 s
compute_direct_read_sets    0.00001 s
compute_reads_relation    0.00000 s
compute_read_sets    0.00001 s
compute_includes_relation    0.00000 s
compute_lookback_relation    0.00000 s
compute_follow_sets    0.00000 s
compute_look_ahead_sets    0.00001 s
compute_conflicts    0.00001 s
compute_default_reduction    0.00001 s
compute_yydefact    0.00002 s
compute_yydefgoto    0.00001 s
sort_actions    0.00000 s
compute_packed_table    0.00001 s
render    0.00614 s
```