### PR TITLE
Add test job for multiple compilers for C

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,25 @@ jobs:
       - run: flex --help
       - run: bundle install
       - run: bundle exec rspec
+  test-c:
+    needs: ruby-versions
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['head']
+        compiler: ['cc', 'gcc', 'clang']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: flex --help
+      - run: bundle install
+      - run: bundle exec rspec
+        env:
+          COMPILER: ${{ matrix.compiler }}
   test-cpp:
     needs: ruby-versions
     runs-on: ubuntu-20.04

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "integration" do
     end
 
     def file_extension
-      ENV['COMPILER'] == "gcc" ? ".c" : ".cpp"
+      ['cc', 'gcc', 'clang'].include?(ENV['COMPILER']) ? ".c" : ".cpp"
     end
 
     def test_parser(parser_name, input, expected, expect_success: true, lrama_command_args: [], debug: false)


### PR DESCRIPTION
This PR adds GitHub Actions jobs for multiple C language compilers. Specifically, it introduces tests for both cc and clang.