### PR TITLE
Simplify inline rule resolution using shorthand syntax for block arguments

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -294,7 +294,7 @@ module Lrama
     end
 
     def resolve_inline_rules
-      while @rule_builders.any? {|r| r.has_inline_rules? } do
+      while @rule_builders.any?(&:has_inline_rules?) do
         @rule_builders = @rule_builders.flat_map do |builder|
           if builder.has_inline_rules?
             builder.resolve_inline_rules


### PR DESCRIPTION
Just change use `@rule_builders.any?(&:has_inline_rules?)`