### PR TITLE
Reorder RBS collection installation in CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -136,7 +136,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle install
-      - run: bundle exec rbs collection install
       - run: bundle exec rbs-inline --output lib/
       - name: Check for uncommitted changes
         run: |
@@ -146,6 +145,7 @@ jobs:
             exit 1
           fi
         shell: bash
+      - run: bundle exec rbs collection install
       - run: bundle exec steep check
   test-ruby:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Check for uncommitted changes must be performed before `bundle exec rbs collection install`. Because running `bundle exec rbs collection install` may cause changes.