### PR TITLE
Change the `-t` option, which was reserved, to match bison and behave the same as `--debug`

### DIFF
--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -59,8 +59,7 @@ module Lrama
         o.separator ''
         o.separator 'Tuning the Parser:'
         o.on('-S', '--skeleton=FILE', 'specify the skeleton to use') {|v| @options.skeleton = v }
-        o.on('-t', 'reserved, do nothing') { }
-        o.on('--debug', 'display debugging outputs of internal parser') {|v| @options.debug = true }
+        o.on('-t', '--debug', 'display debugging outputs of internal parser') {|v| @options.debug = true }
         o.separator ''
         o.separator 'Output:'
         o.on('-H', '--header=[FILE]', 'also produce a header file named FILE') {|v| @options.header = true; @options.header_file = v }

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -48,8 +48,7 @@ RSpec.describe Lrama::OptionParser do
 
           Tuning the Parser:
               -S, --skeleton=FILE              specify the skeleton to use
-              -t                               reserved, do nothing
-                  --debug                      display debugging outputs of internal parser
+              -t, --debug                      display debugging outputs of internal parser
 
           Output:
               -H, --header=[FILE]              also produce a header file named FILE


### PR DESCRIPTION
This PR change the `-t` option, which was reserved, to match bison, so that it works the same as `--debug`.

```
❯ bison -h
Usage: bison [OPTION]... FILE
: (snip)
Tuning the Parser:
  -L, --language=LANGUAGE          specify the output programming language
  -S, --skeleton=FILE              specify the skeleton to use
  -t, --debug                      instrument the parser for tracing
  ^^
```