### PR TITLE
Update NEWS.md for Lrama 0.7.0 release notes, adding support for `-t` option and tracing only explicit rules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,52 @@
 # NEWS for Lrama
 
+## Lrama 0.7.0 (2025-XX-XX)
+
+## Support `-t` option as same as `--debug` option
+
+Support to `-t` option as same as `--debug` option.
+These options align with Bison behavior. So same as `--debug` option.
+
+## Trace only explicit rules
+
+Support to trace only explicit rules.
+If you use `--trace=rules` option, it shows include mid-rule actions. If you want to show only explicit rules, you can use `--trace=only-explicit-rules` option.
+
+Example:
+
+```yacc
+%{
+%}
+%union {
+    int i;
+}
+%token <i> number
+%type <i> program
+%%
+program         : number { printf("%d", $1); } number { $$ = $1 + $3; }
+                ;
+%%
+```
+
+Result of `--trace=rules`:
+
+```console
+$ exe/lrama --trace=rules sample.y
+Grammar rules:
+$accept -> program YYEOF
+$@1 -> ε
+program -> number $@1 number
+```
+
+Result of `--trace=only-explicit-rules`:
+
+```console
+$ exe/lrama --trace=explicit-rules sample.y
+Grammar rules:
+$accept -> program YYEOF
+program -> number number
+```
+
 ## Lrama 0.6.11 (2024-12-23)
 
 ### Add support for %type declarations using %nterm in Nonterminal Symbols


### PR DESCRIPTION
Just update NEWS