### PR TITLE
Fix an error when specify `--define=foo`

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -57,7 +57,7 @@ module Lrama
       @aux = Auxiliary.new
       @no_stdlib = false
       @locations = false
-      @define = define.map {|d| d.split('=') }.to_h
+      @define = define
 
       append_special_symbols
     end

--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -62,7 +62,12 @@ module Lrama
         o.separator 'Tuning the Parser:'
         o.on('-S', '--skeleton=FILE', 'specify the skeleton to use') {|v| @options.skeleton = v }
         o.on('-t', '--debug', 'display debugging outputs of internal parser') {|v| @options.debug = true }
-        o.on('-D', '--define=NAME[=VALUE]', Array, "similar to '%define NAME VALUE'") {|v| @options.define = v }
+        o.on('-D', '--define=NAME[=VALUE]', Array, "similar to '%define NAME VALUE'") do |v|
+          @options.define = v.each_with_object({}) do |item, hash|
+            key, value = item.split('=', 2)
+            hash[key] = value
+          end
+        end
         o.separator ''
         o.separator 'Output:'
         o.on('-H', '--header=[FILE]', 'also produce a header file named FILE') {|v| @options.header = true; @options.header_file = v }

--- a/lib/lrama/options.rb
+++ b/lib/lrama/options.rb
@@ -6,11 +6,11 @@ module Lrama
   class Options
     attr_accessor :skeleton #: String
     attr_accessor :header #: bool
-    attr_accessor :header_file #: String
-    attr_accessor :report_file #: String
+    attr_accessor :header_file #: String?
+    attr_accessor :report_file #: String?
     attr_accessor :outfile #: String
     attr_accessor :error_recovery #: bool
-    attr_accessor :grammar_file #: String
+    attr_accessor :grammar_file #: String?
     attr_accessor :trace_opts #: Hash[Symbol, bool]?
     attr_accessor :report_opts #: Hash[Symbol, bool]?
     attr_accessor :diagnostic #: bool

--- a/lib/lrama/options.rb
+++ b/lib/lrama/options.rb
@@ -12,7 +12,7 @@ module Lrama
 
     def initialize
       @skeleton = "bison/yacc.c"
-      @define = []
+      @define = {}
       @header = false
       @header_file = nil
       @report_file = nil

--- a/lib/lrama/options.rb
+++ b/lib/lrama/options.rb
@@ -1,15 +1,27 @@
+# rbs_inline: enabled
 # frozen_string_literal: true
 
 module Lrama
   # Command line options.
   class Options
-    attr_accessor :skeleton, :header, :header_file,
-                  :report_file, :outfile,
-                  :error_recovery, :grammar_file,
-                  :trace_opts, :report_opts,
-                  :diagnostic, :y, :debug, :define,
-                  :diagram, :diagram_file, :profile_opts
+    attr_accessor :skeleton #: String
+    attr_accessor :header #: bool
+    attr_accessor :header_file #: String
+    attr_accessor :report_file #: String
+    attr_accessor :outfile #: String
+    attr_accessor :error_recovery #: bool
+    attr_accessor :grammar_file #: String
+    attr_accessor :trace_opts #: Hash[Symbol, bool]?
+    attr_accessor :report_opts #: Hash[Symbol, bool]?
+    attr_accessor :diagnostic #: bool
+    attr_accessor :y #: IO
+    attr_accessor :debug #: bool
+    attr_accessor :define #: Hash[String, String]
+    attr_accessor :diagram #: bool
+    attr_accessor :diagram_file #: String
+    attr_accessor :profile_opts #: Hash[Symbol, bool]?
 
+    # @rbs () -> void
     def initialize
       @skeleton = "bison/yacc.c"
       @define = {}

--- a/lib/lrama/options.rb
+++ b/lib/lrama/options.rb
@@ -12,7 +12,7 @@ module Lrama
 
     def initialize
       @skeleton = "bison/yacc.c"
-      @define = {}
+      @define = []
       @header = false
       @header_file = nil
       @report_file = nil

--- a/sig/generated/lrama/options.rbs
+++ b/sig/generated/lrama/options.rbs
@@ -1,20 +1,41 @@
+# Generated from lib/lrama/options.rb with RBS::Inline
+
 module Lrama
+  # Command line options.
   class Options
     attr_accessor skeleton: String
-    attr_accessor define: Hash[String, String]
+
     attr_accessor header: bool
-    attr_accessor header_file: String?
-    attr_accessor report_file: String?
+
+    attr_accessor header_file: String
+
+    attr_accessor report_file: String
+
     attr_accessor outfile: String
+
     attr_accessor error_recovery: bool
-    attr_accessor grammar_file: String?
+
+    attr_accessor grammar_file: String
+
     attr_accessor trace_opts: Hash[Symbol, bool]?
+
     attr_accessor report_opts: Hash[Symbol, bool]?
+
     attr_accessor diagnostic: bool
+
     attr_accessor y: IO
+
     attr_accessor debug: bool
+
+    attr_accessor define: Hash[String, String]
+
+    attr_accessor diagram: bool
+
+    attr_accessor diagram_file: String
+
     attr_accessor profile_opts: Hash[Symbol, bool]?
 
+    # @rbs () -> void
     def initialize: () -> void
   end
 end

--- a/sig/generated/lrama/options.rbs
+++ b/sig/generated/lrama/options.rbs
@@ -7,15 +7,15 @@ module Lrama
 
     attr_accessor header: bool
 
-    attr_accessor header_file: String
+    attr_accessor header_file: String?
 
-    attr_accessor report_file: String
+    attr_accessor report_file: String?
 
     attr_accessor outfile: String
 
     attr_accessor error_recovery: bool
 
-    attr_accessor grammar_file: String
+    attr_accessor grammar_file: String?
 
     attr_accessor trace_opts: Hash[Symbol, bool]?
 

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -346,20 +346,20 @@ RSpec.describe Lrama::OptionParser do
 
   describe "@define" do
     context "when define option is not passed" do
-      it "returns empty array" do
+      it "returns empty hash" do
         option_parser = Lrama::OptionParser.new
         option_parser.send(:parse, [fixture_path("command/basic.y")])
         options = option_parser.instance_variable_get(:@options)
-        expect(options.define).to eq([])
+        expect(options.define).to eq({})
       end
     end
 
     context "when define option is passed" do
-      it "returns array of define options" do
+      it "returns hash of define options" do
         option_parser = Lrama::OptionParser.new
         option_parser.send(:parse, ["--define=YYDEBUG=1", fixture_path("command/basic.y")])
         options = option_parser.instance_variable_get(:@options)
-        expect(options.define).to eq(["YYDEBUG=1"])
+        expect(options.define).to eq({'YYDEBUG' => "1"})
       end
     end
   end

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -355,11 +355,22 @@ RSpec.describe Lrama::OptionParser do
     end
 
     context "when define option is passed" do
-      it "returns hash of define options" do
-        option_parser = Lrama::OptionParser.new
-        option_parser.send(:parse, ["--define=YYDEBUG=1", fixture_path("command/basic.y")])
-        options = option_parser.instance_variable_get(:@options)
-        expect(options.define).to eq({'YYDEBUG' => "1"})
+      context "when value includes equal sign" do
+        it "returns hash of define options" do
+          option_parser = Lrama::OptionParser.new
+          option_parser.send(:parse, ["--define=foo=1", fixture_path("command/basic.y")])
+          options = option_parser.instance_variable_get(:@options)
+          expect(options.define).to eq({'foo' => "1"})
+        end
+      end
+
+      context "when value doesn't include equal sign" do
+        it "returns hash of define options" do
+          option_parser = Lrama::OptionParser.new
+          option_parser.send(:parse, ["--define=foo", fixture_path("command/basic.y")])
+          options = option_parser.instance_variable_get(:@options)
+          expect(options.define).to eq({'foo' => nil})
+        end
       end
     end
   end

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -343,4 +343,24 @@ RSpec.describe Lrama::OptionParser do
       end
     end
   end
+
+  describe "@define" do
+    context "when define option is not passed" do
+      it "returns empty array" do
+        option_parser = Lrama::OptionParser.new
+        option_parser.send(:parse, [fixture_path("command/basic.y")])
+        options = option_parser.instance_variable_get(:@options)
+        expect(options.define).to eq([])
+      end
+    end
+
+    context "when define option is passed" do
+      it "returns array of define options" do
+        option_parser = Lrama::OptionParser.new
+        option_parser.send(:parse, ["--define=YYDEBUG=1", fixture_path("command/basic.y")])
+        options = option_parser.instance_variable_get(:@options)
+        expect(options.define).to eq(["YYDEBUG=1"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
```
❯ exe/lrama --define=foo sample/calc.y
wrong array length at 0 (expected 2, was 1)
```

This is occurring and has been addressed below:
https://github.com/ruby/lrama/blob/7fa74d84a68b3632950b969d29ccf012a0ea4a42/lib/lrama/grammar.rb#L60