### PR TITLE
Enhance debug option handling to include 'parse.trace' definition

### DIFF
--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -62,6 +62,7 @@ module Lrama
         o.separator 'Tuning the Parser:'
         o.on('-S', '--skeleton=FILE', 'specify the skeleton to use') {|v| @options.skeleton = v }
         o.on('-t', '--debug', 'display debugging outputs of internal parser') {|v| @options.debug = true }
+        o.separator "                                     same as '-Dparse.trace'"
         o.on('-D', '--define=NAME[=VALUE]', Array, "similar to '%define NAME VALUE'") do |v|
           @options.define = v.each_with_object({}) do |item, hash|
             key, value = item.split('=', 2)

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -660,7 +660,7 @@ include Lrama::Report::Duration
 
 def initialize(text, path, debug = false, define = {})
   @grammar_file = Lrama::Lexer::GrammarFile.new(path, text)
-  @yydebug = debug
+  @yydebug = debug || define.key?('parse.trace')
   @rule_counter = Lrama::Grammar::Counter.new(0)
   @midrule_action_counter = Lrama::Grammar::Counter.new(1)
   @define = define

--- a/parser.y
+++ b/parser.y
@@ -430,7 +430,7 @@ include Lrama::Report::Duration
 
 def initialize(text, path, debug = false, define = {})
   @grammar_file = Lrama::Lexer::GrammarFile.new(path, text)
-  @yydebug = debug
+  @yydebug = debug || define.key?('parse.trace')
   @rule_counter = Lrama::Grammar::Counter.new(0)
   @midrule_action_counter = Lrama::Grammar::Counter.new(1)
   @define = define

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Lrama::OptionParser do
           Tuning the Parser:
               -S, --skeleton=FILE              specify the skeleton to use
               -t, --debug                      display debugging outputs of internal parser
+                                               same as '-Dparse.trace'
               -D, --define=NAME[=VALUE]        similar to '%define NAME VALUE'
 
           Output:

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -42,6 +42,64 @@ RSpec.describe Lrama::Parser do
     HEADER
   end
 
+  describe "#initialize" do
+    context 'when debug is true and define is not include `parse.trace`' do
+      context 'with define is not specified' do
+        it '@yydebug is true' do
+          parser = Lrama::Parser.new("", "", true)
+          yydebug = parser.instance_variable_get(:@yydebug)
+          expect(yydebug).to be_truthy
+        end
+      end
+
+      context 'with define is specified' do
+        context 'with `api.pure`' do
+          it '@yydebug is false' do
+            parser = Lrama::Parser.new("", "", true, {'api.pure' => nil})
+            yydebug = parser.instance_variable_get(:@yydebug)
+            expect(yydebug).to be_truthy
+          end
+        end
+
+        context 'with `parse.trace`' do
+          it '@yydebug is true' do
+            parser = Lrama::Parser.new("", "", true, {'parse.trace' => nil})
+            yydebug = parser.instance_variable_get(:@yydebug)
+            expect(yydebug).to be_truthy
+          end
+        end
+      end
+    end
+
+    context 'when debug is false and define is not include `parse.trace`' do
+      context 'with define is not specified' do
+        it '@yydebug is false' do
+          parser = Lrama::Parser.new("", "", false)
+          yydebug = parser.instance_variable_get(:@yydebug)
+          expect(yydebug).to be_falsey
+        end
+      end
+
+      context 'with define is specified' do
+        context 'with `api.pure`' do
+          it '@yydebug is false' do
+            parser = Lrama::Parser.new("", "", false, {'api.pure' => nil})
+            yydebug = parser.instance_variable_get(:@yydebug)
+            expect(yydebug).to be_falsey
+          end
+        end
+
+        context 'with `parse.trace`' do
+          it '@yydebug is true' do
+            parser = Lrama::Parser.new("", "", false, {'parse.trace' => nil})
+            yydebug = parser.instance_variable_get(:@yydebug)
+            expect(yydebug).to be_truthy
+          end
+        end
+      end
+    end
+  end
+
   describe '#parse' do
     it "basic" do
       path = "common/basic.y"

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Lrama::Parser do
 
       context 'with define is specified' do
         context 'with `api.pure`' do
-          it '@yydebug is false' do
+          it '@yydebug is true' do
             parser = Lrama::Parser.new("", "", true, {'api.pure' => nil})
             yydebug = parser.instance_variable_get(:@yydebug)
             expect(yydebug).to be_truthy


### PR DESCRIPTION
Following bison's behavior:
```command
$ bison -h
Usage: bison [OPTION]... FILE
Generate a deterministic LR or generalized LR (GLR) parser employing
LALR(1), IELR(1), or canonical LR(1) parser tables.
: (snip)
Tuning the Parser:
  -L, --language=LANGUAGE          specify the output programming language
  -S, --skeleton=FILE              specify the skeleton to use
  -t, --debug                      instrument the parser for tracing
                                   same as '-Dparse.trace'
                                   ^^^^^^^^^^^^^^^^^^^^^^^
```