### PR TITLE
Make the rbs_inline task run when the steep task is run

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,11 @@ desc "steep check"
 task :steep do
   sh "bundle exec steep check"
 end
+task :steep => :rbs_inline
 
 desc "Run rbs-inline"
 task :rbs_inline do
   sh "bundle exec rbs-inline --output lib/"
 end
 
-task default: %i[spec rbs_inline steep]
+task default: %i[spec steep]


### PR DESCRIPTION
This allows us to merge the two commands that used to be executed when performing a steep check into a single command.

### before
```
$ bundle exec rake rbs_inline
$ bundle exec rake steep
```

### after
```
$ bundle exec rake steep
```