### PR TITLE
Print conflicts of each state on output file

### DIFF
--- a/lib/lrama/reporter/states.rb
+++ b/lib/lrama/reporter/states.rb
@@ -51,6 +51,28 @@ module Lrama
           end
           io << "\n"
 
+          # Report conflicts
+          unless state.conflicts.empty?
+            state.conflicts.each do |conflict|
+              syms = conflict.symbols.map do |sym|
+                sym.id.s_value
+              end
+
+              io << "    Conflict on #{syms.join(", ")}. "
+
+              case conflict.type
+              when :shift_reduce
+                io << "shift/reduce(#{conflict.reduce.item.rule.lhs.display_name})\n"
+              when :reduce_reduce
+                io << "reduce(#{conflict.reduce1.item.rule.lhs.display_name})/reduce(#{conflict.reduce2.item.rule.lhs.display_name})\n"
+              else
+                raise "Unknown conflict type #{conflict.type}"
+              end
+            end
+
+            io << "\n"
+          end
+
           # Report shifts
           tmp = state.term_transitions.reject do |shift, _|
             shift.not_selected

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -100,6 +100,10 @@ RSpec.describe Lrama::States do
             8 $@3: ε •  [tSTRING]
            10 class: keyword_class • $@3 tSTRING '?' "end" $@4
 
+            Conflict on tSTRING. shift/reduce($@1)
+            Conflict on tSTRING. shift/reduce($@3)
+            Conflict on tSTRING. reduce($@1)/reduce($@3)
+
             tSTRING  shift, and go to state 6
 
             tSTRING  reduce using rule 5 ($@1)
@@ -388,6 +392,8 @@ RSpec.describe Lrama::States do
             3  | • a
             4 B: ε •
 
+            Conflict on a. shift/reduce(B)
+
             a  shift, and go to state 1
 
             a  reduce using rule 4 (B)
@@ -573,6 +579,8 @@ RSpec.describe Lrama::States do
             2  | B C D • A
             3  | • a
             4 B: ε •
+
+            Conflict on a. shift/reduce(B)
 
             a  shift, and go to state 1
 
@@ -1399,6 +1407,8 @@ RSpec.describe Lrama::States do
               2     | expr '+' expr •
               3     | expr • '*' expr
 
+              Conflict on '+'. shift/reduce(expr)
+
               '+'  shift, and go to state 5
               '*'  shift, and go to state 6
 
@@ -1414,6 +1424,8 @@ RSpec.describe Lrama::States do
               2 expr: expr • '+' expr
               3     | expr • '*' expr
               3     | expr '*' expr •
+
+              Conflict on '*'. shift/reduce(expr)
 
               '*'  shift, and go to state 6
 


### PR DESCRIPTION
These information are useful when a state has many actions like below.

```
State 135 conflicts: 1 reduce/reduce
...
State 135

  129 mlhs_node: user_variable •  [',']
  138 lhs: user_variable •  ['=']
  697 var_ref: user_variable •  ["end-of-input", "'rescue'", "'ensure'", "'end'", "'elsif'", "'else'", "'when'", "'in'", "'and'", "'or'", "'if' modifier", "'unless' modifier", "'while' modifier", "'until' modifier", "'rescue' modifier", "dummy end", '.', "**", "<=>", "==", "===", "!=", ">=", "<=", "&&", "||", "=~", "!~", "..", "...", "<<", ">>", "&.", "::", "=>", "'}'", '?', '>', '<', '|', '^', '&', '+', '-', '*', '/', '%', '}', '[', '\n', ',', ')', ';']
  699 var_lhs: user_variable •  ["operator-assignment"]

    "end-of-input"         reduce using rule 697 (var_ref)
    "'rescue'"             reduce using rule 697 (var_ref)
    "'ensure'"             reduce using rule 697 (var_ref)
    "'end'"                reduce using rule 697 (var_ref)
    "'elsif'"              reduce using rule 697 (var_ref)
    "'else'"               reduce using rule 697 (var_ref)
    "'when'"               reduce using rule 697 (var_ref)
    "'in'"                 reduce using rule 697 (var_ref)
    "'and'"                reduce using rule 697 (var_ref)
    "'or'"                 reduce using rule 697 (var_ref)
    "'if' modifier"        reduce using rule 697 (var_ref)
    "'unless' modifier"    reduce using rule 697 (var_ref)
    "'while' modifier"     reduce using rule 697 (var_ref)
    "'until' modifier"     reduce using rule 697 (var_ref)
    "'rescue' modifier"    reduce using rule 697 (var_ref)
    "dummy end"            reduce using rule 697 (var_ref)
    '.'                    reduce using rule 697 (var_ref)
    "**"                   reduce using rule 697 (var_ref)
    "<=>"                  reduce using rule 697 (var_ref)
    "=="                   reduce using rule 697 (var_ref)
    "==="                  reduce using rule 697 (var_ref)
    "!="                   reduce using rule 697 (var_ref)
    ">="                   reduce using rule 697 (var_ref)
    "<="                   reduce using rule 697 (var_ref)
    "&&"                   reduce using rule 697 (var_ref)
    "||"                   reduce using rule 697 (var_ref)
    "=~"                   reduce using rule 697 (var_ref)
    "!~"                   reduce using rule 697 (var_ref)
    ".."                   reduce using rule 697 (var_ref)
    "..."                  reduce using rule 697 (var_ref)
    "<<"                   reduce using rule 697 (var_ref)
    ">>"                   reduce using rule 697 (var_ref)
    "&."                   reduce using rule 697 (var_ref)
    "::"                   reduce using rule 697 (var_ref)
    "operator-assignment"  reduce using rule 699 (var_lhs)
    "=>"                   reduce using rule 697 (var_ref)
    "'}'"                  reduce using rule 697 (var_ref)
    '='                    reduce using rule 138 (lhs)
    '?'                    reduce using rule 697 (var_ref)
    '>'                    reduce using rule 697 (var_ref)
    '<'                    reduce using rule 697 (var_ref)
    '|'                    reduce using rule 697 (var_ref)
    '^'                    reduce using rule 697 (var_ref)
    '&'                    reduce using rule 697 (var_ref)
    '+'                    reduce using rule 697 (var_ref)
    '-'                    reduce using rule 697 (var_ref)
    '*'                    reduce using rule 697 (var_ref)
    '/'                    reduce using rule 697 (var_ref)
    '%'                    reduce using rule 697 (var_ref)
    '}'                    reduce using rule 697 (var_ref)
    '['                    reduce using rule 697 (var_ref)
    '\n'                   reduce using rule 697 (var_ref)
    ','                    reduce using rule 697 (var_ref)
    ','                    reduce using rule 129 (mlhs_node)
    ')'                    reduce using rule 697 (var_ref)
    ';'                    reduce using rule 697 (var_ref)
```