### PR TITLE
Ensure compatibility with Bison for `--locations` option

### DIFF
--- a/lib/lrama/command.rb
+++ b/lib/lrama/command.rb
@@ -46,7 +46,7 @@ module Lrama
 
     def build_grammar(text)
       grammar =
-        Lrama::Parser.new(text, @options.grammar_file, @options.debug, @options.define).parse
+        Lrama::Parser.new(text, @options.grammar_file, @options.debug, @options.locations, @options.define).parse
       merge_stdlib(grammar)
       prepare_grammar(grammar)
       grammar
@@ -68,7 +68,9 @@ module Lrama
       stdlib_grammar = Lrama::Parser.new(
         stdlib_text,
         STDLIB_FILE_PATH,
-        @options.debug
+        @options.debug,
+        @options.locations,
+        @options.define,
       ).parse
 
       grammar.prepend_parameterized_rules(stdlib_grammar.parameterized_rules)

--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -101,8 +101,8 @@ module Lrama
                                         :find_symbol_by_s_value!, :fill_symbol_number, :fill_nterm_type,
                                         :fill_printer, :fill_destructor, :fill_error_token, :sort_by_number!
 
-    # @rbs (Counter rule_counter) -> void
-    def initialize(rule_counter, define = {})
+    # @rbs (Counter rule_counter, bool locations, Hash[String, String] define) -> void
+    def initialize(rule_counter, locations, define = {})
       @rule_counter = rule_counter
 
       # Code defined by "%code"
@@ -123,7 +123,7 @@ module Lrama
       @accept_symbol = nil
       @aux = Auxiliary.new
       @no_stdlib = false
-      @locations = false
+      @locations = locations
       @define = define
       @required = false
 

--- a/lib/lrama/option_parser.rb
+++ b/lib/lrama/option_parser.rb
@@ -78,6 +78,7 @@ module Lrama
         o.on('-S', '--skeleton=FILE', 'specify the skeleton to use') {|v| @options.skeleton = v }
         o.on('-t', '--debug', 'display debugging outputs of internal parser') {|v| @options.debug = true }
         o.separator "                                     same as '-Dparse.trace'"
+        o.on('--locations', 'enable location support') {|v| @options.locations = true }
         o.on('-D', '--define=NAME[=VALUE]', Array, "similar to '%define NAME VALUE'") do |v|
           @options.define = v.each_with_object({}) do |item, hash| # steep:ignore UnannotatedEmptyCollection
             key, value = item.split('=', 2)

--- a/lib/lrama/options.rb
+++ b/lib/lrama/options.rb
@@ -5,6 +5,7 @@ module Lrama
   # Command line options.
   class Options
     attr_accessor :skeleton #: String
+    attr_accessor :locations #: bool
     attr_accessor :header #: bool
     attr_accessor :header_file #: String?
     attr_accessor :report_file #: String?
@@ -24,6 +25,7 @@ module Lrama
     # @rbs () -> void
     def initialize
       @skeleton = "bison/yacc.c"
+      @locations = false
       @define = {}
       @header = false
       @header_file = nil

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -659,18 +659,19 @@ module_eval(<<'...end parser.y/module_eval...', 'parser.y', 472)
 
 include Lrama::Tracer::Duration
 
-def initialize(text, path, debug = false, define = {})
+def initialize(text, path, debug = false, locations = false, define = {})
   @grammar_file = Lrama::Lexer::GrammarFile.new(path, text)
   @yydebug = debug || define.key?('parse.trace')
   @rule_counter = Lrama::Grammar::Counter.new(0)
   @midrule_action_counter = Lrama::Grammar::Counter.new(1)
+  @locations = locations
   @define = define
 end
 
 def parse
   report_duration(:parse) do
     @lexer = Lrama::Lexer.new(@grammar_file)
-    @grammar = Lrama::Grammar.new(@rule_counter, @define)
+    @grammar = Lrama::Grammar.new(@rule_counter, @locations, @define)
     @precedence_number = 0
     reset_precs
     do_parse

--- a/parser.y
+++ b/parser.y
@@ -472,18 +472,19 @@ end
 
 include Lrama::Tracer::Duration
 
-def initialize(text, path, debug = false, define = {})
+def initialize(text, path, debug = false, locations = false, define = {})
   @grammar_file = Lrama::Lexer::GrammarFile.new(path, text)
   @yydebug = debug || define.key?('parse.trace')
   @rule_counter = Lrama::Grammar::Counter.new(0)
   @midrule_action_counter = Lrama::Grammar::Counter.new(1)
+  @locations = locations
   @define = define
 end
 
 def parse
   report_duration(:parse) do
     @lexer = Lrama::Lexer.new(@grammar_file)
-    @grammar = Lrama::Grammar.new(@rule_counter, @define)
+    @grammar = Lrama::Grammar.new(@rule_counter, @locations, @define)
     @precedence_number = 0
     reset_precs
     do_parse

--- a/sig/generated/lrama/grammar.rbs
+++ b/sig/generated/lrama/grammar.rbs
@@ -126,8 +126,8 @@ module Lrama
 
     attr_accessor required: bool
 
-    # @rbs (Counter rule_counter) -> void
-    def initialize: (Counter rule_counter) -> void
+    # @rbs (Counter rule_counter, bool locations, Hash[String, String] define) -> void
+    def initialize: (Counter rule_counter, bool locations, Hash[String, String] define) -> void
 
     # @rbs (Counter rule_counter, Counter midrule_action_counter) -> RuleBuilder
     def create_rule_builder: (Counter rule_counter, Counter midrule_action_counter) -> RuleBuilder

--- a/sig/generated/lrama/options.rbs
+++ b/sig/generated/lrama/options.rbs
@@ -5,6 +5,8 @@ module Lrama
   class Options
     attr_accessor skeleton: String
 
+    attr_accessor locations: bool
+
     attr_accessor header: bool
 
     attr_accessor header_file: String?

--- a/spec/lrama/option_parser_spec.rb
+++ b/spec/lrama/option_parser_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Lrama::OptionParser do
               -S, --skeleton=FILE              specify the skeleton to use
               -t, --debug                      display debugging outputs of internal parser
                                                same as '-Dparse.trace'
+                  --locations                  enable location support
               -D, --define=NAME[=VALUE]        similar to '%define NAME VALUE'
 
           Output:

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Lrama::Parser do
       context 'with define is specified' do
         context 'with `api.pure`' do
           it '@yydebug is true' do
-            parser = Lrama::Parser.new("", "", true, {'api.pure' => nil})
+            parser = Lrama::Parser.new("", "", true, false, {'api.pure' => nil})
             yydebug = parser.instance_variable_get(:@yydebug)
             expect(yydebug).to be_truthy
           end
@@ -63,7 +63,7 @@ RSpec.describe Lrama::Parser do
 
         context 'with `parse.trace`' do
           it '@yydebug is true' do
-            parser = Lrama::Parser.new("", "", true, {'parse.trace' => nil})
+            parser = Lrama::Parser.new("", "", true, false, {'parse.trace' => nil})
             yydebug = parser.instance_variable_get(:@yydebug)
             expect(yydebug).to be_truthy
           end
@@ -83,7 +83,7 @@ RSpec.describe Lrama::Parser do
       context 'with define is specified' do
         context 'with `api.pure`' do
           it '@yydebug is false' do
-            parser = Lrama::Parser.new("", "", false, {'api.pure' => nil})
+            parser = Lrama::Parser.new("", "", false, false, {'api.pure' => nil})
             yydebug = parser.instance_variable_get(:@yydebug)
             expect(yydebug).to be_falsey
           end
@@ -91,11 +91,27 @@ RSpec.describe Lrama::Parser do
 
         context 'with `parse.trace`' do
           it '@yydebug is true' do
-            parser = Lrama::Parser.new("", "", false, {'parse.trace' => nil})
+            parser = Lrama::Parser.new("", "", false, false, {'parse.trace' => nil})
             yydebug = parser.instance_variable_get(:@yydebug)
             expect(yydebug).to be_truthy
           end
         end
+      end
+    end
+
+    context 'when locations is true' do
+      it '@locations is true' do
+        parser = Lrama::Parser.new("", "", false, true)
+        locations = parser.instance_variable_get(:@locations)
+        expect(locations).to be_truthy
+      end
+    end
+
+    context 'when locations is false' do
+      it '@locations is false' do
+        parser = Lrama::Parser.new("", "", false, false)
+        locations = parser.instance_variable_get(:@locations)
+        expect(locations).to be_falsey
       end
     end
   end


### PR DESCRIPTION
```
❯ bison -h
Usage: bison [OPTION]... FILE
Generate a deterministic LR or generalized LR (GLR) parser employing
: (snip)
Tuning the Parser:
  -L, --language=LANGUAGE          specify the output programming language
  -S, --skeleton=FILE              specify the skeleton to use
  -t, --debug                      instrument the parser for tracing
                                   same as '-Dparse.trace'
      --locations                  enable location support
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```