### PR TITLE
Fix ArgumentError

### DIFF
--- a/lib/lrama/state.rb
+++ b/lib/lrama/state.rb
@@ -334,7 +334,7 @@ module Lrama
       terms = always_follows[[shift, next_state]]
       until queue.empty?
         st, sh, next_st = queue.pop
-        terms |= st.always_follows(sh, next_st)
+        terms |= st.always_follows[[sh, next_st]]
         st.internal_dependencies(sh, next_st).each {|v| queue << v }
         st.predecessor_dependencies(sh, next_st).each {|v| queue << v }
       end

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -2316,5 +2316,254 @@ RSpec.describe Lrama::States do
 
       STR
     end
+
+    it 'recompute states' do
+      y = <<~INPUT
+        %{
+        // Prologue
+        %}
+
+        %token a
+        %token b
+        %token c
+
+        %precedence tLOWEST
+        %precedence a
+        %precedence tHIGHEST
+
+        %%
+
+        S: S2
+         ;
+
+        S2: a A B a
+          | b A B b
+          ;
+
+        A: a C D E
+         ;
+
+        B: c
+         | // empty
+         ;
+
+        C: D
+         ;
+
+        D: a
+         ;
+
+        E: a
+         | %prec tHIGHEST // empty
+         ;
+
+        %%
+      INPUT
+      grammar = Lrama::Parser.new(y, "states/ArgumentError_on_goto_follows.y").parse
+      grammar.prepare
+      grammar.validate!
+      states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+      states.compute
+      expect { states.compute_ielr }.not_to raise_error
+
+      io = StringIO.new
+      Lrama::Reporter.new(states: true).report(io, states)
+
+      expect(io.string).to eq(<<~STR)
+        State 0
+
+            0 $accept: • S "end of file"
+
+            a  shift, and go to state 1
+            b  shift, and go to state 2
+
+            S   go to state 3
+            S2  go to state 4
+
+
+        State 1
+
+            2 S2: a • A B a
+
+            a  shift, and go to state 5
+
+            A  go to state 6
+
+
+        State 2
+
+            3 S2: b • A B b
+
+            a  shift, and go to state 20
+
+            A  go to state 7
+
+
+        State 3
+
+            0 $accept: S • "end of file"
+
+            "end of file"  shift, and go to state 8
+
+
+        State 4
+
+            1 S: S2 •
+
+            $default  reduce using rule 1 (S)
+
+
+        State 5
+
+            4 A: a • C D E
+
+            a  shift, and go to state 9
+
+            C  go to state 10
+            D  go to state 11
+
+
+        State 6
+
+            2 S2: a A • B a
+
+            c  shift, and go to state 12
+
+            $default  reduce using rule 6 (B)
+
+            B  go to state 13
+
+
+        State 7
+
+            3 S2: b A • B b
+
+            c  shift, and go to state 12
+
+            $default  reduce using rule 6 (B)
+
+            B  go to state 14
+
+
+        State 8
+
+            0 $accept: S "end of file" •
+
+            $default  accept
+
+
+        State 9
+
+            8 D: a •
+
+            $default  reduce using rule 8 (D)
+
+
+        State 10
+
+            4 A: a C • D E
+
+            a  shift, and go to state 9
+
+            D  go to state 15
+
+
+        State 11
+
+            7 C: D •
+
+            $default  reduce using rule 7 (C)
+
+
+        State 12
+
+            5 B: c •
+
+            $default  reduce using rule 5 (B)
+
+
+        State 13
+
+            2 S2: a A B • a
+
+            a  shift, and go to state 16
+
+
+        State 14
+
+            3 S2: b A B • b
+
+            b  shift, and go to state 17
+
+
+        State 15
+
+            4 A: a C D • E
+
+            $default  reduce using rule 10 (E)
+
+            E  go to state 19
+
+
+        State 16
+
+            2 S2: a A B a •
+
+            $default  reduce using rule 2 (S2)
+
+
+        State 17
+
+            3 S2: b A B b •
+
+            $default  reduce using rule 3 (S2)
+
+
+        State 18
+
+            9 E: a •
+
+            $default  reduce using rule 9 (E)
+
+
+        State 19
+
+            4 A: a C D E •
+
+            $default  reduce using rule 4 (A)
+
+
+        State 20
+
+            4 A: a • C D E
+
+            a  shift, and go to state 9
+
+            C  go to state 21
+            D  go to state 11
+
+
+        State 21
+
+            4 A: a C • D E
+
+            a  shift, and go to state 9
+
+            D  go to state 22
+
+
+        State 22
+
+            4 A: a C D • E
+
+            a  shift, and go to state 18
+
+            $default  reduce using rule 10 (E)
+
+            E  go to state 19
+
+
+      STR
+    end
   end
 end


### PR DESCRIPTION
`#<ArgumentError: wrong number of arguments (given 2, expected 0)>` is raised from `#goto_follows` when `#item_lookahead_set` is called for a state

* whose `kernel.position` is 1
* previous state has internal dependencies or predecessor dependencies

In an added test case, state 0 is a previous state of state 2 and state 0 has an internal dependency on state 4.

Backtraces of failed test case is

```
  1) Lrama::States#compute_ielr recompute states
     Failure/Error: expect { states.compute_ielr }.not_to raise_error

       expected no Exception, got #<ArgumentError: wrong number of arguments (given 2, expected 0)> with backtrace:
         # ./lib/lrama/state.rb:337:in `goto_follows'
         # ./lib/lrama/state.rb:295:in `block in item_lookahead_set'
         # ./lib/lrama/state.rb:285:in `map'
         # ./lib/lrama/state.rb:285:in `item_lookahead_set'
         # ./lib/lrama/state.rb:276:in `block in lhs_contributions'
         # ./lib/lrama/state.rb:276:in `map'
         # ./lib/lrama/state.rb:276:in `lhs_contributions'
         # ./lib/lrama/state.rb:249:in `block (3 levels) in annotate_predecessor'
         # ./lib/lrama/state.rb:249:in `any?'
         # ./lib/lrama/state.rb:249:in `block (2 levels) in annotate_predecessor'
         # ./lib/lrama/state.rb:246:in `each'
         # ./lib/lrama/state.rb:246:in `map'
         # ./lib/lrama/state.rb:246:in `block in annotate_predecessor'
         # ./lib/lrama/state.rb:245:in `each'
         # ./lib/lrama/state.rb:245:in `annotate_predecessor'
         # ./lib/lrama/states.rb:617:in `block (2 levels) in compute_inadequacy_annotations'
         # ./lib/lrama/states.rb:615:in `each'
         # ./lib/lrama/states.rb:615:in `block in compute_inadequacy_annotations'
         # ./lib/lrama/states.rb:612:in `each'
         # ./lib/lrama/states.rb:612:in `compute_inadequacy_annotations'
         # ./lib/lrama/states.rb:598:in `split_states'
         # ./lib/lrama/states.rb:104:in `block in compute_ielr'
         # ./lib/lrama/tracer/duration.rb:26:in `report_duration'
         # ./lib/lrama/states.rb:104:in `compute_ielr'
         # ./spec/lrama/states_spec.rb:2367:in `block (4 levels) in <top (required)>'
         # ./spec/lrama/states_spec.rb:2367:in `block (3 levels) in <top (required)>'
     # ./spec/lrama/states_spec.rb:2367:in `block (3 levels) in <top (required)>'
```