### PR TITLE
Update railroad_diagrams gem version to 0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rspec"
 gem "simplecov", require: false
 gem "stackprof", platforms: [:ruby] # stackprof doesn't support Windows
 gem "memory_profiler"
-gem "railroad_diagrams", "0.2.1"
+gem "railroad_diagrams", "0.3.0"
 
 # Recent steep requires Ruby >= 3.0.0.
 # Then skip install on some CI jobs.


### PR DESCRIPTION
The following commands were executed to confirm that there were no differences:

```
❯ exe/lrama tmp/parse.tmp.y --diagram
```