### PR TITLE
Fix some warnings: assigned but unused variable

### DIFF
--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -527,7 +527,7 @@ module Lrama
       relation = compute_goto_internal_relation
       base_function = compute_goto_bitmaps
       Digraph.new(set, relation, base_function).compute.each do |goto, follow_kernel_items|
-        state, nterm, next_state = goto
+        state, nterm, _next_state = goto
         transition = state.nterm_transitions.find {|shift, _| shift.next_sym == nterm }
         state.follow_kernel_items[transition] = state.kernels.map.with_index {|kernel, i|
           [kernel, Bitmap.to_bool_array(follow_kernel_items, state.kernels.count)]
@@ -555,7 +555,7 @@ module Lrama
       relation = compute_goto_successor_or_internal_relation
       base_function = compute_transition_bitmaps
       Digraph.new(set, relation, base_function).compute.each do |goto, always_follows_bitmap|
-        state, nterm, next_state = goto
+        state, nterm, _next_state = goto
         transition = state.nterm_transitions.find {|shift, _| shift.next_sym == nterm }
         state.always_follows[transition] = bitmap_to_terms(always_follows_bitmap)
       end
@@ -578,8 +578,8 @@ module Lrama
 
     # Definition 3.8 (Goto Follows Internal Relation)
     def has_internal_relation?(goto1, goto2)
-      state1, sym1, next_state1 = goto1
-      state2, sym2, next_state2 = goto2
+      state1, sym1, _next_state1 = goto1
+      state2, sym2, _next_state2 = goto2
       state1 == state2 && state1.items.any? {|item|
         item.next_sym == sym1 && item.lhs == sym2 && item.symbols_after_transition.all?(&:nullable)
       }
@@ -587,8 +587,8 @@ module Lrama
 
     # Definition 3.5 (Goto Follows Successor Relation)
     def has_successor_relation?(goto1, goto2)
-      state1, sym1, next_state1 = goto1
-      state2, sym2, next_state2 = goto2
+      _state1, _sym1, next_state1 = goto1
+      state2, sym2, _next_state2 = goto2
       next_state1 == state2 && sym2.nullable
     end
 


### PR DESCRIPTION
Fix following warnings:

```
❯ RUBYOPT=-w bundle exec rake
bundle exec racc parser.y --embedded -o lib/lrama/parser.rb -t --log-file=parser.output
/ydah/.rbenv/versions/3.5-dev/bin/ruby -I/ydah/.rbenv/versions/3.5-dev/lib/ruby/gems/3.5.0+0/gems/rspec-core-3.13.3/lib:/ydah/.rbenv/versions/3.5-dev/lib/ruby/gems/3.5.0+0/gems/rspec-support-3.13.2/lib /ydah/.rbenv/versions/3.5-dev/lib/ruby/gems/3.5.0+0/gems/rspec-core-3.13.3/exe/rspec spec/lrama/bitmap_spec.rb spec/lrama/command_spec.rb spec/lrama/context_spec.rb spec/lrama/counterexamples_spec.rb spec/lrama/diagram_spec.rb spec/lrama/grammar/code_spec.rb spec/lrama/grammar/rule_builder_spec.rb spec/lrama/grammar/symbol_spec.rb spec/lrama/grammar/symbols/resolver_spec.rb spec/lrama/integration_spec.rb spec/lrama/lexer/location_spec.rb spec/lrama/lexer/token/user_code_spec.rb spec/lrama/lexer_spec.rb spec/lrama/option_parser_spec.rb spec/lrama/output_spec.rb spec/lrama/parser_spec.rb spec/lrama/states_spec.rb spec/lrama/trace/actions_spec.rb spec/lrama/trace/closure_spec.rb spec/lrama/trace/only_explicit_rules_spec.rb spec/lrama/trace/rules_spec.rb spec/lrama/trace/state_spec.rb spec/lrama/warnings/conflicts_spec.rb spec/lrama/warnings/redefined_rules_spec.rb spec/lrama/warnings/required_spec.rb spec/lrama/warnings_spec.rb
/ydah/lrama/lib/lrama/states.rb:530: warning: assigned but unused variable - next_state
/ydah/lrama/lib/lrama/states.rb:558: warning: assigned but unused variable - next_state
/ydah/lrama/lib/lrama/states.rb:581: warning: assigned but unused variable - next_state1
/ydah/lrama/lib/lrama/states.rb:582: warning: assigned but unused variable - next_state2
/ydah/lrama/lib/lrama/states.rb:590: warning: assigned but unused variable - state1
/ydah/lrama/lib/lrama/states.rb:590: warning: assigned but unused variable - sym1
/ydah/lrama/lib/lrama/states.rb:591: warning: assigned but unused variable - next_state2
```