### PR TITLE
Use `term_transitions` instead of `transitions`

### DIFF
--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -572,7 +572,7 @@ module Lrama
         # Do not set, if conflict exist
         next unless state.conflicts.empty?
         # Do not set, if shift with `error` exists.
-        next if state.transitions.map {|transition| transition.next_sym }.include?(@grammar.error_symbol)
+        next if state.term_transitions.map {|shift| shift.next_sym }.include?(@grammar.error_symbol)
 
         state.default_reduction_rule = state.reduces.map do |r|
           [r.rule, r.rule.id, (r.look_ahead || []).count]


### PR DESCRIPTION
`error_symbol` is a terminal symbol then no need to check gotos.