### PR TITLE
Fix tracer class type declarations

### DIFF
--- a/lib/lrama/tracer.rb
+++ b/lib/lrama/tracer.rb
@@ -10,7 +10,7 @@ require_relative "tracer/state"
 
 module Lrama
   class Tracer
-    # @rbs (IO io, **Hash[Symbol, bool] options) -> void
+    # @rbs (IO io, **bool options) -> void
     def initialize(io, **options)
       @io = io
       @options = options

--- a/lib/lrama/tracer/actions.rb
+++ b/lib/lrama/tracer/actions.rb
@@ -4,7 +4,7 @@
 module Lrama
   class Tracer
     class Actions
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?actions: bool, **bool options) -> void
       def initialize(io, actions: false, **options)
         @io = io
         @actions = actions

--- a/lib/lrama/tracer/closure.rb
+++ b/lib/lrama/tracer/closure.rb
@@ -4,7 +4,7 @@
 module Lrama
   class Tracer
     class Closure
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?automaton: bool, ?closure: bool, **bool) -> void
       def initialize(io, automaton: false, closure: false, **_)
         @io = io
         @closure = automaton || closure

--- a/lib/lrama/tracer/only_explicit_rules.rb
+++ b/lib/lrama/tracer/only_explicit_rules.rb
@@ -4,7 +4,7 @@
 module Lrama
   class Tracer
     class OnlyExplicitRules
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?only_explicit: bool, **bool) -> void
       def initialize(io, only_explicit: false, **_)
         @io = io
         @only_explicit = only_explicit

--- a/lib/lrama/tracer/rules.rb
+++ b/lib/lrama/tracer/rules.rb
@@ -4,7 +4,7 @@
 module Lrama
   class Tracer
     class Rules
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?rules: bool, ?only_explicit: bool, **bool) -> void
       def initialize(io, rules: false, only_explicit: false, **_)
         @io = io
         @rules = rules

--- a/lib/lrama/tracer/state.rb
+++ b/lib/lrama/tracer/state.rb
@@ -4,7 +4,7 @@
 module Lrama
   class Tracer
     class State
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?automaton: bool, ?closure: bool, **bool) -> void
       def initialize(io, automaton: false, closure: false, **_)
         @io = io
         @state = automaton || closure

--- a/sig/generated/lrama/tracer.rbs
+++ b/sig/generated/lrama/tracer.rbs
@@ -2,8 +2,8 @@
 
 module Lrama
   class Tracer
-    # @rbs (IO io, **Hash[Symbol, bool] options) -> void
-    def initialize: (IO io, **Hash[Symbol, bool] options) -> void
+    # @rbs (IO io, **bool options) -> void
+    def initialize: (IO io, **bool options) -> void
 
     # @rbs (Lrama::Grammar grammar) -> void
     def trace: (Lrama::Grammar grammar) -> void

--- a/sig/generated/lrama/tracer/actions.rbs
+++ b/sig/generated/lrama/tracer/actions.rbs
@@ -3,8 +3,8 @@
 module Lrama
   class Tracer
     class Actions
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
-      def initialize: (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?actions: bool, **bool options) -> void
+      def initialize: (IO io, ?actions: bool, **bool options) -> void
 
       # @rbs (Lrama::Grammar grammar) -> void
       def trace: (Lrama::Grammar grammar) -> void

--- a/sig/generated/lrama/tracer/closure.rbs
+++ b/sig/generated/lrama/tracer/closure.rbs
@@ -3,8 +3,8 @@
 module Lrama
   class Tracer
     class Closure
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
-      def initialize: (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?automaton: bool, ?closure: bool, **bool) -> void
+      def initialize: (IO io, ?automaton: bool, ?closure: bool, **bool) -> void
 
       # @rbs (Lrama::State state) -> void
       def trace: (Lrama::State state) -> void

--- a/sig/generated/lrama/tracer/only_explicit_rules.rbs
+++ b/sig/generated/lrama/tracer/only_explicit_rules.rbs
@@ -3,8 +3,8 @@
 module Lrama
   class Tracer
     class OnlyExplicitRules
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
-      def initialize: (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?only_explicit: bool, **bool) -> void
+      def initialize: (IO io, ?only_explicit: bool, **bool) -> void
 
       # @rbs (Lrama::Grammar grammar) -> void
       def trace: (Lrama::Grammar grammar) -> void

--- a/sig/generated/lrama/tracer/rules.rbs
+++ b/sig/generated/lrama/tracer/rules.rbs
@@ -3,8 +3,8 @@
 module Lrama
   class Tracer
     class Rules
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
-      def initialize: (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?rules: bool, ?only_explicit: bool, **bool) -> void
+      def initialize: (IO io, ?rules: bool, ?only_explicit: bool, **bool) -> void
 
       # @rbs (Lrama::Grammar grammar) -> void
       def trace: (Lrama::Grammar grammar) -> void

--- a/sig/generated/lrama/tracer/state.rbs
+++ b/sig/generated/lrama/tracer/state.rbs
@@ -3,8 +3,8 @@
 module Lrama
   class Tracer
     class State
-      # @rbs (IO io, **Hash[Symbol, bool]) -> void
-      def initialize: (IO io, **Hash[Symbol, bool]) -> void
+      # @rbs (IO io, ?automaton: bool, ?closure: bool, **bool) -> void
+      def initialize: (IO io, ?automaton: bool, ?closure: bool, **bool) -> void
 
       # @rbs (Lrama::State state) -> void
       def trace: (Lrama::State state) -> void


### PR DESCRIPTION
This PR include two kind of fixes.

1. Fix type of rest keyword parameter `**Type` means type of keyword parameter value. Then `**Hash[Symbol, bool]` means `Symbol: Hash[Symbol, bool]`. What these methods expect is `Symbol: bool` so `**bool` is correct.

2. Declare optional keyword with `?key: bool` This correct way to declare optional keyword parameter.