### PR TITLE
Optimize `compute_ielr`

### DIFF
--- a/lib/lrama/state/inadequacy_annotation.rb
+++ b/lib/lrama/state/inadequacy_annotation.rb
@@ -9,10 +9,10 @@ module Lrama
 
       attr_accessor :state #: State
       attr_accessor :token #: Grammar::Symbol
-      attr_accessor :actions #: Array[action]
-      attr_accessor :contribution_matrix #: Hash[action, Hash[States::Item, bool]]
+      attr_accessor :actions #: Array[Action::Shift | Action::Reduce]
+      attr_accessor :contribution_matrix #: Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]]
 
-      # @rbs (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[States::Item, bool]] contribution_matrix) -> void
+      # @rbs (State state, Grammar::Symbol token, Array[Action::Shift | Action::Reduce] actions, Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]] contribution_matrix) -> void
       def initialize(state, token, actions, contribution_matrix)
         @state = state
         @token = token
@@ -25,7 +25,7 @@ module Lrama
         @contribution_matrix.any? {|action, contributions| !contributions.nil? && contributions[item] }
       end
 
-      # @rbs (Array[Hash[action, Hash[States::Item, bool]]] another_matrixes) -> void
+      # @rbs (Array[Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]]] another_matrixes) -> void
       def merge_matrix(another_matrixes)
         another_matrixes.each do |another_matrix|
           @contribution_matrix.merge!(another_matrix) {|action, contributions, another_contributions|
@@ -37,6 +37,7 @@ module Lrama
         end
       end
 
+      # @rbs () -> bool
       def only_always_or_never?
         @contribution_matrix.all? {|_, contributions|
           contributions.nil? || contributions.all? {|_, contributed| !contributed }
@@ -45,7 +46,7 @@ module Lrama
 
       # Definition 3.42 (dominant_contribution)
       #
-      # @rbs (State::lookahead_set lookaheads) -> Array[action]?
+      # @rbs (Hash[States::Item, Array[Grammar::Symbol]] lookaheads) -> Array[Action::Shift | Action::Reduce]?
       def dominant_contribution(lookaheads)
         actions = @actions.select {|action|
           contribution_matrix[action].nil? || contribution_matrix[action].any? {|item, contributed| contributed && lookaheads[item].include?(@token) }
@@ -55,6 +56,7 @@ module Lrama
         resolve_conflict(actions)
       end
 
+      # @rbs (Array[Action::Shift | Action::Reduce] actions) -> Array[Action::Shift | Action::Reduce]
       def resolve_conflict(actions)
         # @type var shifts: Array[Action::Shift]
         # @type var reduces: Array[Action::Reduce]

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -763,11 +763,13 @@ module Lrama
         s.lookaheads_recomputed = true
         s.item_lookahead_set = propagating_lookaheads
       else
-        state.update_transition(transition, s)
         merge_lookaheads(s, propagating_lookaheads)
-        compute_follow_kernel_items
-        compute_always_follows
-        compute_goto_follows
+        if state.items_to_state[transition.to_items].id != s.id
+          state.update_transition(transition, s)
+          compute_follow_kernel_items
+          compute_always_follows
+          compute_goto_follows
+        end
       end
     end
 

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -134,6 +134,7 @@ module Lrama
       report_duration(:compute_predecessors) { compute_predecessors }
       report_duration(:compute_follow_kernel_items) { compute_follow_kernel_items }
       report_duration(:compute_always_follows) { compute_always_follows }
+      report_duration(:compute_goto_follows) { compute_goto_follows }
       # Phase 2
       report_duration(:compute_inadequacy_annotations) { compute_inadequacy_annotations }
       # Phase 3
@@ -613,10 +614,15 @@ module Lrama
 
     # @rbs () -> Hash[State::Action::Goto, Array[State::Action::Goto]]
     def compute_goto_internal_relation
-      nterm_transitions.map {|goto1|
-        related_gotos = nterm_transitions.select {|goto2| has_internal_relation?(goto1, goto2) }
-        [goto1, related_gotos]
-      }.to_h
+      relations = {}
+
+      @states.each do |state|
+        state.nterm_transitions.each do |goto|
+          relations[goto] = state.internal_dependencies(goto)
+        end
+      end
+
+      relations
     end
 
     # @rbs () -> Hash[State::Action::Goto, bitmap]
@@ -635,18 +641,21 @@ module Lrama
       relation = compute_goto_successor_or_internal_relation
       base_function = compute_transition_bitmaps
       Digraph.new(set, relation, base_function).compute.each do |goto, always_follows_bitmap|
-        state, nterm = goto.from_state, goto.next_sym
-        transition = state.nterm_transitions.find {|goto| goto.next_sym == nterm }
-        state.always_follows[transition] = bitmap_to_terms(always_follows_bitmap)
+        goto.from_state.always_follows[goto] = bitmap_to_terms(always_follows_bitmap)
       end
     end
 
     # @rbs () -> Hash[State::Action::Goto, Array[State::Action::Goto]]
     def compute_goto_successor_or_internal_relation
-      nterm_transitions.map {|goto1|
-        related_gotos = nterm_transitions.select {|goto2| has_internal_relation?(goto1, goto2) || has_successor_relation?(goto1, goto2) }
-        [goto1, related_gotos]
-      }.to_h
+      relations = {}
+
+      @states.each do |state|
+        state.nterm_transitions.each do |goto|
+          relations[goto] = state.successor_dependencies(goto) + state.internal_dependencies(goto)
+        end
+      end
+
+      relations
     end
 
     # @rbs () -> Hash[State::Action::Goto, bitmap]
@@ -656,22 +665,35 @@ module Lrama
       }.to_h
     end
 
-    # Definition 3.8 (Goto Follows Internal Relation)
-    #
-    # @rbs (State::Action::Goto goto1, State::Action::Goto goto2) -> bool
-    def has_internal_relation?(goto1, goto2)
-      state1, sym1 = goto1.from_state, goto1.next_sym
-      state2, sym2 = goto2.from_state, goto2.next_sym
-      state1 == state2 && state1.items.any? {|item|
-        item.next_sym == sym1 && item.lhs == sym2 && item.symbols_after_transition.all?(&:nullable)
-      }
+    def compute_goto_follows
+      set = nterm_transitions
+      relation = compute_goto_internal_or_predecessor_dependencies
+      base_function = compute_always_follows_bitmaps
+      Digraph.new(set, relation, base_function).compute.each do |goto, goto_follows_bitmap|
+        goto.from_state.goto_follows[goto] = bitmap_to_terms(goto_follows_bitmap)
+      end
     end
 
-    # Definition 3.5 (Goto Follows Successor Relation)
+    # Definition 3.24 (goto_follows, via always_follows)
     #
-    # @rbs (State::Action::Goto goto1, State::Action::Goto goto2) -> bool
-    def has_successor_relation?(goto1, goto2)
-      goto1.to_state == goto2.from_state && goto2.next_sym.nullable
+    # @rbs () -> Hash[State::Action::Goto, Array[State::Action::Goto]]
+    def compute_goto_internal_or_predecessor_dependencies
+      relations = {}
+
+      @states.each do |state|
+        state.nterm_transitions.each do |goto|
+          relations[goto] = state.internal_dependencies(goto) + state.predecessor_dependencies(goto)
+        end
+      end
+
+      relations
+    end
+
+    # @rbs () -> Hash[State::Action::Goto, bitmap]
+    def compute_always_follows_bitmaps
+      nterm_transitions.map {|goto|
+        [goto, Bitmap.from_array(goto.from_state.always_follows[goto].map(&:number))]
+      }.to_h
     end
 
     # @rbs () -> void
@@ -736,6 +758,7 @@ module Lrama
         state.update_transition(transition, new_state)
         compute_follow_kernel_items
         compute_always_follows
+        compute_goto_follows
       elsif(!s.lookaheads_recomputed)
         s.lookaheads_recomputed = true
         s.item_lookahead_set = propagating_lookaheads
@@ -744,6 +767,7 @@ module Lrama
         merge_lookaheads(s, propagating_lookaheads)
         compute_follow_kernel_items
         compute_always_follows
+        compute_goto_follows
       end
     end
 

--- a/sig/generated/lrama/state.rbs
+++ b/sig/generated/lrama/state.rbs
@@ -56,6 +56,8 @@ module Lrama
 
     attr_reader predecessors: Array[State]
 
+    attr_reader items_to_state: Hash[Array[States::Item], State]
+
     attr_accessor _transitions: Array[[ Grammar::Symbol, Array[States::Item] ]]
 
     attr_accessor reduces: Array[Action::Reduce]
@@ -74,6 +76,8 @@ module Lrama
 
     # @rbs (Integer id, Grammar::Symbol accessing_symbol, Array[States::Item] kernels) -> void
     def initialize: (Integer id, Grammar::Symbol accessing_symbol, Array[States::Item] kernels) -> void
+
+    def ==: (untyped other) -> untyped
 
     # @rbs (Array[States::Item] closure) -> void
     def closure=: (Array[States::Item] closure) -> void
@@ -160,6 +164,9 @@ module Lrama
     #
     # @rbs (State predecessor) -> void
     def annotate_predecessor: (State predecessor) -> void
+
+    # @rbs (State predecessor) -> void
+    def append_annotation_list: (State predecessor) -> void
 
     # Definition 3.31 (compute_lhs_contributions)
     #

--- a/sig/generated/lrama/state.rbs
+++ b/sig/generated/lrama/state.rbs
@@ -70,6 +70,8 @@ module Lrama
 
     attr_accessor always_follows: Hash[Action::Goto, Array[Grammar::Symbol]]
 
+    attr_accessor goto_follows: Hash[Action::Goto, Array[Grammar::Symbol]]
+
     # @rbs (Integer id, Grammar::Symbol accessing_symbol, Array[States::Item] kernels) -> void
     def initialize: (Integer id, Grammar::Symbol accessing_symbol, Array[States::Item] kernels) -> void
 
@@ -102,6 +104,9 @@ module Lrama
 
     # @rbs () -> void
     def clear_transitions_cache: () -> void
+
+    # @rbs () -> void
+    def clear_relations_cache: () -> void
 
     # @rbs () -> Array[Action::Shift]
     def selected_term_transitions: () -> Array[Action::Shift]
@@ -179,11 +184,6 @@ module Lrama
     #
     # @rbs (Grammar::Symbol nterm_token) -> Array[Grammar::Symbol]
     def goto_follow_set: (Grammar::Symbol nterm_token) -> Array[Grammar::Symbol]
-
-    # Definition 3.24 (goto_follows, via always_follows)
-    #
-    # @rbs (Action::Goto goto) -> Array[Grammar::Symbol]
-    def goto_follows: (Action::Goto goto) -> Array[Grammar::Symbol]
 
     # Definition 3.8 (Goto Follows Internal Relation)
     #

--- a/sig/generated/lrama/state/inadequacy_annotation.rbs
+++ b/sig/generated/lrama/state/inadequacy_annotation.rbs
@@ -9,23 +9,29 @@ module Lrama
 
       attr_accessor token: Grammar::Symbol
 
-      attr_accessor actions: Array[action]
+      attr_accessor actions: Array[Action::Shift | Action::Reduce]
 
-      attr_accessor contribution_matrix: Hash[action, Hash[States::Item, bool]]
+      attr_accessor contribution_matrix: Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]]
 
-      # @rbs (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[States::Item, bool]] contribution_matrix) -> void
-      def initialize: (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[States::Item, bool]] contribution_matrix) -> void
+      # @rbs (State state, Grammar::Symbol token, Array[Action::Shift | Action::Reduce] actions, Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]] contribution_matrix) -> void
+      def initialize: (State state, Grammar::Symbol token, Array[Action::Shift | Action::Reduce] actions, Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]] contribution_matrix) -> void
 
       # @rbs (States::Item item) -> bool
       def contributed?: (States::Item item) -> bool
 
-      # @rbs (Hash[action, Hash[States::Item, bool]] another_matrix) -> void
-      def merge_matrix: (Hash[action, Hash[States::Item, bool]] another_matrix) -> void
+      # @rbs (Array[Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]]] another_matrixes) -> void
+      def merge_matrix: (Array[Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]]] another_matrixes) -> void
+
+      # @rbs () -> bool
+      def only_always_or_never?: () -> bool
 
       # Definition 3.42 (dominant_contribution)
       #
-      # @rbs (State::lookahead_set lookaheads) -> Array[action]?
-      def dominant_contribution: (State::lookahead_set lookaheads) -> Array[action]?
+      # @rbs (Hash[States::Item, Array[Grammar::Symbol]] lookaheads) -> Array[Action::Shift | Action::Reduce]?
+      def dominant_contribution: (Hash[States::Item, Array[Grammar::Symbol]] lookaheads) -> Array[Action::Shift | Action::Reduce]?
+
+      # @rbs (Array[Action::Shift | Action::Reduce] actions) -> Array[Action::Shift | Action::Reduce]
+      def resolve_conflict: (Array[Action::Shift | Action::Reduce] actions) -> Array[Action::Shift | Action::Reduce]
 
       # @rbs () -> String
       def to_s: () -> String

--- a/sig/generated/lrama/states.rbs
+++ b/sig/generated/lrama/states.rbs
@@ -175,15 +175,15 @@ module Lrama
     # @rbs () -> Hash[State::Action::Goto, bitmap]
     def compute_transition_bitmaps: () -> Hash[State::Action::Goto, bitmap]
 
-    # Definition 3.8 (Goto Follows Internal Relation)
-    #
-    # @rbs (State::Action::Goto goto1, State::Action::Goto goto2) -> bool
-    def has_internal_relation?: (State::Action::Goto goto1, State::Action::Goto goto2) -> bool
+    def compute_goto_follows: () -> untyped
 
-    # Definition 3.5 (Goto Follows Successor Relation)
+    # Definition 3.24 (goto_follows, via always_follows)
     #
-    # @rbs (State::Action::Goto goto1, State::Action::Goto goto2) -> bool
-    def has_successor_relation?: (State::Action::Goto goto1, State::Action::Goto goto2) -> bool
+    # @rbs () -> Hash[State::Action::Goto, Array[State::Action::Goto]]
+    def compute_goto_internal_or_predecessor_dependencies: () -> Hash[State::Action::Goto, Array[State::Action::Goto]]
+
+    # @rbs () -> Hash[State::Action::Goto, bitmap]
+    def compute_always_follows_bitmaps: () -> Hash[State::Action::Goto, bitmap]
 
     # @rbs () -> void
     def split_states: () -> void


### PR DESCRIPTION
Optimizing compute_ielr.
When I ran it in my local environment as a test, the execution time was reduced to about 6-7 minutes.

```
$ time bundle exec lrama -D lr.type=ielr parse.y
bundle exec lrama -D lr.type=ielr parse.y  377.91s user 0.67s system 99% cpu 6:18.84 total
```