### PR TITLE
Save call stack profile result even if an exception is raised

### DIFF
--- a/lib/lrama/reporter/profile/call_stack.rb
+++ b/lib/lrama/reporter/profile/call_stack.rb
@@ -12,8 +12,16 @@ module Lrama
         # @rbs return: StackProf::result | void
         def self.report(enabled)
           if enabled && require_stackprof
+            ex = nil #: Exception?
+
             StackProf.run(mode: :cpu, raw: true, out: 'tmp/stackprof-cpu-myapp.dump') do
               yield
+            rescue Exception => e
+              ex = e
+            end
+
+            if ex
+              raise ex
             end
           else
             yield


### PR DESCRIPTION
When parser generation process takes too long time, I interrupt the process. This commit saves call stack profile result even if the process is interrupted.