### PR TITLE
Optimize `split_states`

### DIFF
--- a/lib/lrama/state.rb
+++ b/lib/lrama/state.rb
@@ -157,9 +157,7 @@ module Lrama
     def update_transition(transition, next_state)
       set_items_to_state(transition.to_items, next_state)
       next_state.append_predecessor(self)
-      clear_relations_cache
       clear_transitions_cache
-      predecessors.each {|p| p.clear_relations_cache }
     end
 
     # @rbs () -> void
@@ -167,12 +165,6 @@ module Lrama
       @nterm_transitions = nil
       @term_transitions = nil
       @transitions = nil
-    end
-
-    # @rbs () -> void
-    def clear_relations_cache
-      @internal_dependencies.clear
-      @successor_dependencies.clear
     end
 
     # @rbs () -> Array[Action::Shift]
@@ -275,7 +267,7 @@ module Lrama
     #
     # @rbs () -> lookahead_set
     def lookahead_set_filters
-      kernels.map {|kernel|
+      @lookahead_set_filters ||= kernels.map {|kernel|
         [kernel, @lalr_isocore.annotation_list.select {|annotation| annotation.contributed?(kernel) }.map(&:token)]
       }.to_h
     end

--- a/lib/lrama/state/inadequacy_annotation.rb
+++ b/lib/lrama/state/inadequacy_annotation.rb
@@ -37,13 +37,6 @@ module Lrama
         end
       end
 
-      # @rbs () -> bool
-      def only_always_or_never?
-        @contribution_matrix.all? {|_, contributions|
-          contributions.nil? || contributions.all? {|_, contributed| !contributed }
-        }
-      end
-
       # Definition 3.42 (dominant_contribution)
       #
       # @rbs (Hash[States::Item, Array[Grammar::Symbol]] lookaheads) -> Array[Action::Shift | Action::Reduce]?

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -756,20 +756,12 @@ module Lrama
         new_state.lookaheads_recomputed = true
         new_state.item_lookahead_set = propagating_lookaheads
         state.update_transition(transition, new_state)
-        compute_follow_kernel_items
-        compute_always_follows
-        compute_goto_follows
       elsif(!s.lookaheads_recomputed)
         s.lookaheads_recomputed = true
         s.item_lookahead_set = propagating_lookaheads
       else
         merge_lookaheads(s, propagating_lookaheads)
-        if state.items_to_state[transition.to_items].id != s.id
-          state.update_transition(transition, s)
-          compute_follow_kernel_items
-          compute_always_follows
-          compute_goto_follows
-        end
+        state.update_transition(transition, s) if state.items_to_state[transition.to_items].id != s.id
       end
     end
 

--- a/sig/generated/lrama/state.rbs
+++ b/sig/generated/lrama/state.rbs
@@ -109,9 +109,6 @@ module Lrama
     # @rbs () -> void
     def clear_transitions_cache: () -> void
 
-    # @rbs () -> void
-    def clear_relations_cache: () -> void
-
     # @rbs () -> Array[Action::Shift]
     def selected_term_transitions: () -> Array[Action::Shift]
 

--- a/sig/generated/lrama/state/inadequacy_annotation.rbs
+++ b/sig/generated/lrama/state/inadequacy_annotation.rbs
@@ -22,9 +22,6 @@ module Lrama
       # @rbs (Array[Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]]] another_matrixes) -> void
       def merge_matrix: (Array[Hash[Action::Shift | Action::Reduce, Hash[States::Item, bool]]] another_matrixes) -> void
 
-      # @rbs () -> bool
-      def only_always_or_never?: () -> bool
-
       # Definition 3.42 (dominant_contribution)
       #
       # @rbs (Hash[States::Item, Array[Grammar::Symbol]] lookaheads) -> Array[Action::Shift | Action::Reduce]?


### PR DESCRIPTION
- Remove unnecessary re-computation
    - `compute_follow_kernel_items`
    - `compute_always_follows`
    - `compute_goto_follows`
- Check if the contribution matrix is potential before propagation

```sh
$ time bundle exec lrama --trace=time -D lr.type=ielr parse.y
parse    0.43902 s
parse    0.00316 s
compute_lr0_states    0.40920 s
compute_direct_read_sets    0.07128 s
compute_reads_relation    0.01224 s
compute_read_sets    0.02581 s
compute_includes_relation    0.11171 s
compute_lookback_relation    0.23253 s
compute_follow_sets    0.08286 s
compute_look_ahead_sets    0.86599 s
compute_conflicts    0.00491 s
compute_default_reduction    0.00237 s
compute_predecessors    0.11527 s
compute_follow_kernel_items    0.47898 s
compute_always_follows    0.41872 s
compute_goto_follows    1.12686 s
compute_inadequacy_annotations   46.91071 s
split_states    2.11387 s
compute_direct_read_sets    0.02702 s
compute_reads_relation    0.00805 s
compute_read_sets    0.03454 s
compute_includes_relation    0.12045 s
compute_lookback_relation    0.23710 s
compute_follow_sets    0.15189 s
compute_look_ahead_sets    1.62029 s
compute_conflicts    0.00534 s
compute_default_reduction    0.00251 s
compute_yydefact    0.06543 s
compute_yydefgoto    0.00893 s
sort_actions    0.00624 s
compute_packed_table    0.33528 s
render    0.07173 s
bundle exec lrama --trace=time -D lr.type=ielr parse.y  56.52s user 0.23s system 99% cpu 57.030 total
```