### PR TITLE
Don't create array for each lookahead-sensitive path candidate

### DIFF
--- a/lib/lrama/counterexamples/path.rb
+++ b/lib/lrama/counterexamples/path.rb
@@ -10,10 +10,13 @@ module Lrama
       #   @from_state_item: StateItem?
       #   @to_state_item: StateItem
 
-      # @rbs (StateItem? from_state_item, StateItem to_state_item) -> void
-      def initialize(from_state_item, to_state_item)
+      attr_reader :parent #: path?
+
+      # @rbs (StateItem? from_state_item, StateItem to_state_item, path? parent) -> void
+      def initialize(from_state_item, to_state_item, parent)
         @from_state_item = from_state_item
         @to_state_item = to_state_item
+        @parent = parent
       end
 
       # @rbs () -> StateItem?

--- a/lib/lrama/counterexamples/start_path.rb
+++ b/lib/lrama/counterexamples/start_path.rb
@@ -6,7 +6,7 @@ module Lrama
     class StartPath < Path
       # @rbs (StateItem to_state_item) -> void
       def initialize(to_state_item)
-        super nil, to_state_item
+        super nil, to_state_item, nil
       end
 
       # @rbs () -> :start

--- a/sig/generated/lrama/counterexamples/path.rbs
+++ b/sig/generated/lrama/counterexamples/path.rbs
@@ -9,8 +9,10 @@ module Lrama
 
       @to_state_item: StateItem
 
-      # @rbs (StateItem? from_state_item, StateItem to_state_item) -> void
-      def initialize: (StateItem? from_state_item, StateItem to_state_item) -> void
+      attr_reader parent: path?
+
+      # @rbs (StateItem? from_state_item, StateItem to_state_item, path? parent) -> void
+      def initialize: (StateItem? from_state_item, StateItem to_state_item, path? parent) -> void
 
       # @rbs () -> StateItem?
       def from: () -> StateItem?


### PR DESCRIPTION
Lookahead-sensitive path candidate was managed by array of `Path`. It needed to create array every time when new candidate was found. This was one of bottlenecks of `Lrama::Counterexamples#shortest_path`. This commit adds `parent` field to `Path` so that list of paths can be iterated by `parent`.