### PR TITLE
Remove unused `from_state_item` from `Path`

### DIFF
--- a/lib/lrama/counterexamples.rb
+++ b/lib/lrama/counterexamples.rb
@@ -239,9 +239,9 @@ module Lrama
         when prev_si.nil?
           StartPath.new(si)
         when si.item.beginning_of_rule?
-          ProductionPath.new(prev_si, si, nil)
+          ProductionPath.new(si, nil)
         else
-          TransitionPath.new(prev_si, si, nil)
+          TransitionPath.new(si, nil)
         end
       end
     end
@@ -310,7 +310,7 @@ module Lrama
           t = Triple.new(next_state_item, triple.l)
           unless visited[t]
             visited[t] = true
-            queue << [t, TransitionPath.new(triple.state_item, t.state_item, path)]
+            queue << [t, TransitionPath.new(t.state_item, path)]
           end
         end
 
@@ -323,7 +323,7 @@ module Lrama
           t = Triple.new(StateItem.new(triple.state, item), l)
           unless visited[t]
             visited[t] = true
-            queue << [t, ProductionPath.new(triple.state_item, t.state_item, path)]
+            queue << [t, ProductionPath.new(t.state_item, path)]
           end
         end
       end

--- a/lib/lrama/counterexamples/path.rb
+++ b/lib/lrama/counterexamples/path.rb
@@ -7,21 +7,14 @@ module Lrama
       # @rbs!
       #   type path = StartPath | TransitionPath | ProductionPath
       #
-      #   @from_state_item: StateItem?
       #   @to_state_item: StateItem
 
       attr_reader :parent #: path?
 
-      # @rbs (StateItem? from_state_item, StateItem to_state_item, path? parent) -> void
-      def initialize(from_state_item, to_state_item, parent)
-        @from_state_item = from_state_item
+      # @rbs (StateItem to_state_item, path? parent) -> void
+      def initialize(to_state_item, parent)
         @to_state_item = to_state_item
         @parent = parent
-      end
-
-      # @rbs () -> StateItem?
-      def from
-        @from_state_item
       end
 
       # @rbs () -> StateItem

--- a/lib/lrama/counterexamples/start_path.rb
+++ b/lib/lrama/counterexamples/start_path.rb
@@ -6,7 +6,7 @@ module Lrama
     class StartPath < Path
       # @rbs (StateItem to_state_item) -> void
       def initialize(to_state_item)
-        super nil, to_state_item, nil
+        super to_state_item, nil
       end
 
       # @rbs () -> :start

--- a/sig/generated/lrama/counterexamples/path.rbs
+++ b/sig/generated/lrama/counterexamples/path.rbs
@@ -5,17 +5,12 @@ module Lrama
     class Path
       type path = StartPath | TransitionPath | ProductionPath
 
-      @from_state_item: StateItem?
-
       @to_state_item: StateItem
 
       attr_reader parent: path?
 
-      # @rbs (StateItem? from_state_item, StateItem to_state_item, path? parent) -> void
-      def initialize: (StateItem? from_state_item, StateItem to_state_item, path? parent) -> void
-
-      # @rbs () -> StateItem?
-      def from: () -> StateItem?
+      # @rbs (StateItem to_state_item, path? parent) -> void
+      def initialize: (StateItem to_state_item, path? parent) -> void
 
       # @rbs () -> StateItem
       def to: () -> StateItem


### PR DESCRIPTION
Previous state is accessible via `parent`.