### PR TITLE
Use `StateItem#type` for shortest path search method

### DIFF
--- a/lib/lrama/counterexamples.rb
+++ b/lib/lrama/counterexamples.rb
@@ -168,7 +168,7 @@ module Lrama
           break
         end
 
-        if target_state_item.item.beginning_of_rule?
+        if target_state_item.type == :production
           queue = [] #: Array[Array[StateItem]]
           queue << [target_state_item]
 
@@ -185,7 +185,7 @@ module Lrama
               break
             end
 
-            if si.item.beginning_of_rule?
+            if si.type == :production
               # @type var key: [State, Grammar::Symbol]
               key = [si.state, si.item.lhs]
               @reverse_productions[key].each do |item|


### PR DESCRIPTION
Using `StateItem#type` makes intention clear when searching shortest path from other path.