### PR TITLE
Clear conflicts information of states before IELR computation

### DIFF
--- a/lib/lrama/state.rb
+++ b/lib/lrama/state.rb
@@ -235,6 +235,22 @@ module Lrama
       end
     end
 
+    # Clear information related to conflicts.
+    # IELR computation re-calculates conflicts and default reduction of states
+    # after LALR computation.
+    # Call this method before IELR computation to avoid duplicated conflicts information
+    # is stored.
+    #
+    # @rbs () -> void
+    def clear_conflicts
+      @conflicts = []
+      @resolved_conflicts = []
+      @default_reduction_rule = nil
+
+      term_transitions.each(&:clear_conflicts)
+      reduces.each(&:clear_conflicts)
+    end
+
     # Definition 3.40 (propagate_lookaheads)
     #
     # @rbs (State next_state) -> lookahead_set

--- a/lib/lrama/state/action/reduce.rb
+++ b/lib/lrama/state/action/reduce.rb
@@ -50,6 +50,12 @@ module Lrama
             []
           end
         end
+
+        # @rbs () -> void
+        def clear_conflicts
+          @not_selected_symbols = []
+          @default_reduction = nil
+        end
       end
     end
   end

--- a/lib/lrama/state/action/shift.rb
+++ b/lib/lrama/state/action/shift.rb
@@ -27,6 +27,11 @@ module Lrama
           @to_items = to_items
           @to_state = to_state
         end
+
+        # @rbs () -> void
+        def clear_conflicts
+          @not_selected = nil
+        end
       end
     end
   end

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -129,6 +129,8 @@ module Lrama
 
     # @rbs () -> void
     def compute_ielr
+      # Preparation
+      report_duration(:clear_conflicts) { clear_conflicts }
       # Phase 1
       report_duration(:compute_predecessors) { compute_predecessors }
       report_duration(:compute_follow_kernel_items) { compute_follow_kernel_items }
@@ -575,6 +577,11 @@ module Lrama
           [-count, rule_id]
         end.first
       end
+    end
+
+    # @rbs () -> void
+    def clear_conflicts
+      states.each(&:clear_conflicts)
     end
 
     # Definition 3.15 (Predecessors)

--- a/sig/generated/lrama/state.rbs
+++ b/sig/generated/lrama/state.rbs
@@ -133,6 +133,15 @@ module Lrama
     # @rbs () -> Array[conflict]
     def rr_conflicts: () -> Array[conflict]
 
+    # Clear information related to conflicts.
+    # IELR computation re-calculates conflicts and default reduction of states
+    # after LALR computation.
+    # Call this method before IELR computation to avoid duplicated conflicts information
+    # is stored.
+    #
+    # @rbs () -> void
+    def clear_conflicts: () -> void
+
     # Definition 3.40 (propagate_lookaheads)
     #
     # @rbs (State next_state) -> lookahead_set

--- a/sig/generated/lrama/state/action/reduce.rbs
+++ b/sig/generated/lrama/state/action/reduce.rbs
@@ -33,6 +33,9 @@ module Lrama
 
         # @rbs () -> (::Array[Grammar::Symbol?])
         def selected_look_ahead: () -> ::Array[Grammar::Symbol?]
+
+        # @rbs () -> void
+        def clear_conflicts: () -> void
       end
     end
   end

--- a/sig/generated/lrama/state/action/shift.rbs
+++ b/sig/generated/lrama/state/action/shift.rbs
@@ -24,6 +24,9 @@ module Lrama
 
         # @rbs (State from_state, Grammar::Symbol next_sym, Array[States::Item] to_items, State to_state) -> void
         def initialize: (State from_state, Grammar::Symbol next_sym, Array[States::Item] to_items, State to_state) -> void
+
+        # @rbs () -> void
+        def clear_conflicts: () -> void
       end
     end
   end

--- a/sig/generated/lrama/states.rbs
+++ b/sig/generated/lrama/states.rbs
@@ -146,6 +146,9 @@ module Lrama
     # @rbs () -> void
     def compute_default_reduction: () -> void
 
+    # @rbs () -> void
+    def clear_conflicts: () -> void
+
     # Definition 3.15 (Predecessors)
     #
     # @rbs () -> void

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -2096,7 +2096,6 @@ RSpec.describe Lrama::States do
             4     | expr "==" expr •
 
             "=="  error (nonassociative)
-            "=="  error (nonassociative)
 
             $default  reduce using rule 4 (expr)
 


### PR DESCRIPTION
IELR computation re-calculates conflicts and default reduction of states after LALR computation.
Clear these information before IELR computation to avoid duplicated conflicts information is stored into states.