### PR TITLE
Create StateItem in advance for optimization

### DIFF
--- a/lib/lrama/counterexamples.rb
+++ b/lib/lrama/counterexamples.rb
@@ -25,11 +25,11 @@ module Lrama
     #   @exceed_cumulative_time_limit: bool
     #   @transitions: Hash[[StateItem, Grammar::Symbol], StateItem]
     #   @reverse_transitions: Hash[[StateItem, Grammar::Symbol], Set[StateItem]]
-    #   @productions: Hash[StateItem, Set[States::Item]]
+    #   @productions: Hash[StateItem, Set[StateItem]]
     #   @reverse_productions: Hash[[State, Grammar::Symbol], Set[States::Item]] # Grammar::Symbol is nterm
 
     attr_reader :transitions #: Hash[[StateItem, Grammar::Symbol], StateItem]
-    attr_reader :productions #: Hash[StateItem, Set[States::Item]]
+    attr_reader :productions #: Hash[StateItem, Set[StateItem]]
 
     # @rbs (States states) -> void
     def initialize(states)
@@ -111,13 +111,13 @@ module Lrama
 
       @states.states.each do |state|
         # Grammar::Symbol is LHS
-        h = {} #: Hash[Grammar::Symbol, Set[States::Item]]
+        h = {} #: Hash[Grammar::Symbol, Set[StateItem]]
 
         state.closure.each do |item|
           sym = item.lhs
 
           h[sym] ||= Set.new
-          h[sym] << item
+          h[sym] << StateItem.new(state, item)
         end
 
         state.items.each do |item|
@@ -333,8 +333,7 @@ module Lrama
         end
 
         # production step
-        @productions[triple.state_item]&.each do |item|
-          si = StateItem.new(triple.state, item)
+        @productions[triple.state_item]&.each do |si|
           next unless reachable.include?(si)
 
           l = follow_l(triple.item, triple.l)

--- a/lib/lrama/counterexamples/example.rb
+++ b/lib/lrama/counterexamples/example.rb
@@ -135,9 +135,8 @@ module Lrama
           end
 
           if next_sym.nterm? && next_sym.first_set.include?(sym)
-            @counterexamples.productions[si].each do |next_item|
-              next if next_item.empty_rule?
-              next_si = StateItem.new(si.state, next_item)
+            @counterexamples.productions[si].each do |next_si|
+              next if next_si.item.empty_rule?
               next if sis.include?(next_si)
               queue << (sis + [next_si])
             end

--- a/sig/generated/lrama/counterexamples.rbs
+++ b/sig/generated/lrama/counterexamples.rbs
@@ -20,13 +20,13 @@ module Lrama
 
     @reverse_transitions: Hash[[ StateItem, Grammar::Symbol ], Set[StateItem]]
 
-    @productions: Hash[StateItem, Set[States::Item]]
+    @productions: Hash[StateItem, Set[StateItem]]
 
     @reverse_productions: Hash[[ State, Grammar::Symbol ], Set[States::Item]]
 
     attr_reader transitions: Hash[[ StateItem, Grammar::Symbol ], StateItem]
 
-    attr_reader productions: Hash[StateItem, Set[States::Item]]
+    attr_reader productions: Hash[StateItem, Set[StateItem]]
 
     # @rbs (States states) -> void
     def initialize: (States states) -> void


### PR DESCRIPTION
This change increases 3% - 25% iteration count of reduce conflict path search for ruby parse.y size grammar on my machine.

Before:

```
Counterexamples calculation for state 97 #shortest_path: timeout of 10 sec exceeded with 477252 iteration
Counterexamples calculation for state 238 #shortest_path: timeout of 10 sec exceeded with 473998 iteration
Counterexamples calculation for state 247 #shortest_path: timeout of 10 sec exceeded with 420291 iteration
Counterexamples calculation for state 248 #shortest_path: timeout of 10 sec exceeded with 439425 iteration
Counterexamples calculation for state 250 #shortest_path: timeout of 10 sec exceeded with 509429 iteration
```

After:

```
Counterexamples calculation for state 97 #shortest_path: timeout of 10 sec exceeded with 546866 iteration
Counterexamples calculation for state 238 #shortest_path: timeout of 10 sec exceeded with 556603 iteration
Counterexamples calculation for state 247 #shortest_path: timeout of 10 sec exceeded with 435745 iteration
Counterexamples calculation for state 248 #shortest_path: timeout of 10 sec exceeded with 553304 iteration
Counterexamples calculation for state 250 #shortest_path: timeout of 10 sec exceeded with 567514 iteration
```