### PR TITLE
Update transition caches instead of clearing

### DIFF
--- a/lib/lrama/state.rb
+++ b/lib/lrama/state.rb
@@ -158,14 +158,25 @@ module Lrama
     def update_transition(transition, next_state)
       set_items_to_state(transition.to_items, next_state)
       next_state.append_predecessor(self)
-      clear_transitions_cache
+      update_transitions_caches(transition)
     end
 
     # @rbs () -> void
-    def clear_transitions_cache
+    def update_transitions_caches(transition)
+      new_transition =
+        if transition.next_sym.term?
+          Action::Shift.new(self, transition.next_sym, transition.to_items, @items_to_state[transition.to_items])
+        else
+          Action::Goto.new(self, transition.next_sym, transition.to_items, @items_to_state[transition.to_items])
+        end
+
+      @transitions.delete(transition)
+      @transitions << new_transition
       @nterm_transitions = nil
       @term_transitions = nil
-      @transitions = nil
+
+      @follow_kernel_items[new_transition] = @follow_kernel_items.delete(transition)
+      @always_follows[new_transition] = @always_follows.delete(transition)
     end
 
     # @rbs () -> Array[Action::Shift]

--- a/sig/generated/lrama/state.rbs
+++ b/sig/generated/lrama/state.rbs
@@ -108,7 +108,7 @@ module Lrama
     def update_transition: (Action::Shift | Action::Goto transition, State next_state) -> void
 
     # @rbs () -> void
-    def clear_transitions_cache: () -> void
+    def update_transitions_caches: () -> void
 
     # @rbs () -> Array[Action::Shift]
     def selected_term_transitions: () -> Array[Action::Shift]


### PR DESCRIPTION
Clearing the entire cache will adversely affect subsequent fetches of follow_kernel_items, etc.