### PR TITLE
Optimize Counterexamples

### DIFF
--- a/lib/lrama/counterexamples.rb
+++ b/lib/lrama/counterexamples.rb
@@ -24,7 +24,7 @@ module Lrama
     #   @total_duration: Float
     #   @exceed_cumulative_time_limit: bool
     #   @state_items: Hash[[State, States::Item], StateItem]
-    #   @triples: Hash[[StateItem, Bitmap::bitmap], Triple]
+    #   @triples: Hash[Integer, Triple]
     #   @transitions: Hash[[StateItem, Grammar::Symbol], StateItem]
     #   @reverse_transitions: Hash[[StateItem, Grammar::Symbol], Set[StateItem]]
     #   @productions: Hash[StateItem, Set[StateItem]]
@@ -88,12 +88,16 @@ module Lrama
     # @rbs () -> void
     def setup_state_items
       @state_items = {}
+      count = 0
 
       @states.states.each do |state|
         state.items.each do |item|
-          @state_items[[state, item]] = StateItem.new(state, item)
+          @state_items[[state, item]] = StateItem.new(count, state, item)
+          count += 1
         end
       end
+
+      @state_item_shift = Math.log(count, 2).ceil
     end
 
     # @rbs () -> void
@@ -167,7 +171,8 @@ module Lrama
     #
     # @rbs (StateItem state_item, Bitmap::bitmap precise_lookahead_set) -> Triple
     def get_triple(state_item, precise_lookahead_set)
-      @triples[[state_item, precise_lookahead_set]] ||= Triple.new(state_item, precise_lookahead_set)
+      key = (precise_lookahead_set << @state_item_shift) | state_item.id
+      @triples[key] ||= Triple.new(state_item, precise_lookahead_set)
     end
 
     # @rbs (State conflict_state, State::ShiftReduceConflict conflict) -> Example

--- a/lib/lrama/counterexamples/state_item.rb
+++ b/lib/lrama/counterexamples/state_item.rb
@@ -3,12 +3,15 @@
 
 module Lrama
   class Counterexamples
-    class StateItem < Struct.new(:state, :item)
-      # @rbs!
-      #   attr_accessor state: State
-      #   attr_accessor item: States::Item
-      #
-      #   def initialize: (State state, States::Item item) -> void
+    class StateItem
+      attr_reader :state #: State
+      attr_reader :item #: States::Item
+
+      # @rbs (State state, States::Item item) -> void
+      def initialize(state, item)
+        @state = state
+        @item = item
+      end
 
       # @rbs () -> (:start | :transition | :production)
       def type

--- a/lib/lrama/counterexamples/state_item.rb
+++ b/lib/lrama/counterexamples/state_item.rb
@@ -4,11 +4,13 @@
 module Lrama
   class Counterexamples
     class StateItem
+      attr_reader :id #: Integer
       attr_reader :state #: State
       attr_reader :item #: States::Item
 
-      # @rbs (State state, States::Item item) -> void
-      def initialize(state, item)
+      # @rbs (Integer id, State state, States::Item item) -> void
+      def initialize(id, state, item)
+        @id = id
         @state = state
         @item = item
       end

--- a/lib/lrama/counterexamples/triple.rb
+++ b/lib/lrama/counterexamples/triple.rb
@@ -14,19 +14,6 @@ module Lrama
         @precise_lookahead_set = precise_lookahead_set
       end
 
-      # @rbs () -> Integer
-      def hash
-        [state.id, item.hash, @precise_lookahead_set].hash
-      end
-
-      # @rbs (Triple other) -> bool
-      def eql?(other)
-        self.class == other.class &&
-        self.state.id == other.state.id &&
-        self.item == other.item &&
-        self.precise_lookahead_set == other.precise_lookahead_set
-      end
-
       # @rbs () -> State
       def state
         @state_item.state

--- a/sig/generated/lrama/counterexamples.rbs
+++ b/sig/generated/lrama/counterexamples.rbs
@@ -18,7 +18,7 @@ module Lrama
 
     @state_items: Hash[[ State, States::Item ], StateItem]
 
-    @triples: Hash[[ StateItem, Bitmap::bitmap ], Triple]
+    @triples: Hash[Integer, Triple]
 
     @transitions: Hash[[ StateItem, Grammar::Symbol ], StateItem]
 

--- a/sig/generated/lrama/counterexamples.rbs
+++ b/sig/generated/lrama/counterexamples.rbs
@@ -18,6 +18,8 @@ module Lrama
 
     @state_items: Hash[[ State, States::Item ], StateItem]
 
+    @triples: Hash[[ StateItem, Bitmap::bitmap ], Triple]
+
     @transitions: Hash[[ StateItem, Grammar::Symbol ], StateItem]
 
     @reverse_transitions: Hash[[ StateItem, Grammar::Symbol ], Set[StateItem]]
@@ -46,6 +48,11 @@ module Lrama
     # @rbs (State state, States::Item item) -> StateItem
     def get_state_item: (State state, States::Item item) -> StateItem
 
+    # For optimization, create all StateItem in advance
+    # and use them by fetching an instance from `@state_items`.
+    # Do not create new StateItem instance in the shortest path search process
+    # to avoid miss hash lookup.
+    #
     # @rbs () -> void
     def setup_state_items: () -> void
 
@@ -54,6 +61,13 @@ module Lrama
 
     # @rbs () -> void
     def setup_productions: () -> void
+
+    # For optimization, use same Triple if it's already created.
+    # Do not create new Triple instance anywhere else
+    # to avoid miss hash lookup.
+    #
+    # @rbs (StateItem state_item, Bitmap::bitmap precise_lookahead_set) -> Triple
+    def get_triple: (StateItem state_item, Bitmap::bitmap precise_lookahead_set) -> Triple
 
     # @rbs (State conflict_state, State::ShiftReduceConflict conflict) -> Example
     def shift_reduce_example: (State conflict_state, State::ShiftReduceConflict conflict) -> Example

--- a/sig/generated/lrama/counterexamples.rbs
+++ b/sig/generated/lrama/counterexamples.rbs
@@ -16,6 +16,8 @@ module Lrama
 
     @exceed_cumulative_time_limit: bool
 
+    @state_items: Hash[[ State, States::Item ], StateItem]
+
     @transitions: Hash[[ StateItem, Grammar::Symbol ], StateItem]
 
     @reverse_transitions: Hash[[ StateItem, Grammar::Symbol ], Set[StateItem]]
@@ -40,6 +42,12 @@ module Lrama
     def compute: (State conflict_state) -> Array[Example]
 
     private
+
+    # @rbs (State state, States::Item item) -> StateItem
+    def get_state_item: (State state, States::Item item) -> StateItem
+
+    # @rbs () -> void
+    def setup_state_items: () -> void
 
     # @rbs () -> void
     def setup_transitions: () -> void

--- a/sig/generated/lrama/counterexamples/state_item.rbs
+++ b/sig/generated/lrama/counterexamples/state_item.rbs
@@ -3,12 +3,14 @@
 module Lrama
   class Counterexamples
     class StateItem
+      attr_reader id: Integer
+
       attr_reader state: State
 
       attr_reader item: States::Item
 
-      # @rbs (State state, States::Item item) -> void
-      def initialize: (State state, States::Item item) -> void
+      # @rbs (Integer id, State state, States::Item item) -> void
+      def initialize: (Integer id, State state, States::Item item) -> void
 
       # @rbs () -> (:start | :transition | :production)
       def type: () -> (:start | :transition | :production)

--- a/sig/generated/lrama/counterexamples/state_item.rbs
+++ b/sig/generated/lrama/counterexamples/state_item.rbs
@@ -3,10 +3,11 @@
 module Lrama
   class Counterexamples
     class StateItem
-      attr_accessor state: State
+      attr_reader state: State
 
-      attr_accessor item: States::Item
+      attr_reader item: States::Item
 
+      # @rbs (State state, States::Item item) -> void
       def initialize: (State state, States::Item item) -> void
 
       # @rbs () -> (:start | :transition | :production)

--- a/sig/generated/lrama/counterexamples/triple.rbs
+++ b/sig/generated/lrama/counterexamples/triple.rbs
@@ -10,12 +10,6 @@ module Lrama
       # @rbs (StateItem state_item, Bitmap::bitmap precise_lookahead_set) -> void
       def initialize: (StateItem state_item, Bitmap::bitmap precise_lookahead_set) -> void
 
-      # @rbs () -> Integer
-      def hash: () -> Integer
-
-      # @rbs (Triple other) -> bool
-      def eql?: (Triple other) -> bool
-
       # @rbs () -> State
       def state: () -> State
 


### PR DESCRIPTION
Before:

```
Counterexamples calculation for state 97 #shortest_path: timeout of 10 sec exceeded with 517532 iteration
Counterexamples calculation for state 239 #shortest_path: timeout of 10 sec exceeded with 538239 iteration
Counterexamples calculation for state 248 #shortest_path: timeout of 10 sec exceeded with 554314 iteration
Counterexamples calculation for state 249 #shortest_path: timeout of 10 sec exceeded with 517987 iteration
Counterexamples calculation for state 251 #shortest_path: timeout of 10 sec exceeded with 546731 iteration
```

After:

4 of 5 are not timeout anymore.

```
Counterexamples calculation for state 97 #shortest_path: timeout of 10 sec exceeded with 907481 iteration
```
