### PR TITLE
Add ioption support to the Standard library

### DIFF
--- a/lib/lrama/grammar/stdlib.y
+++ b/lib/lrama/grammar/stdlib.y
@@ -24,6 +24,20 @@
                | X
                ;
 
+
+/*
+ * program: ioption(X)
+ *
+ * =>
+ *
+ * program: %empty
+ * program: X
+ */
+%rule %inline ioption(X)
+                : /* empty */
+                | X
+                ;
+
 // -------------------------------------------------------------------
 // Sequences
 

--- a/spec/fixtures/parameterized/stdlib/ioption.y
+++ b/spec/fixtures/parameterized/stdlib/ioption.y
@@ -1,0 +1,36 @@
+/*
+ * This is comment for this file.
+ */
+
+%{
+// Prologue
+static int yylex(YYSTYPE *val, YYLTYPE *loc);
+static int yyerror(YYLTYPE *loc, const char *str);
+%}
+
+%union {
+    int i;
+}
+
+%token <i> number
+
+%%
+
+program         : ioption(number)
+                ;
+
+%%
+
+static int yylex(YYSTYPE *yylval, YYLTYPE *loc)
+{
+  return 0;
+}
+
+static int yyerror(YYLTYPE *loc, const char *str)
+{
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+}

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -987,6 +987,52 @@ RSpec.describe Lrama::Parser do
           end
         end
 
+        context "when ioption" do
+          let(:path) { "parameterized/stdlib/ioption.y" }
+
+          it "expands parameterized rules" do
+            expect(grammar.nterms.sort_by(&:number)).to match_symbols([
+              Sym.new(id: T::Ident.new(s_value: "$accept"), alias_name: nil, number: 4, tag: nil, term: false, token_id: 0, nullable: false),
+              Sym.new(id: T::Ident.new(s_value: "program"), alias_name: nil, number: 5, tag: nil, term: false, token_id: 1, nullable: true),
+            ])
+
+            expect(grammar.rules).to eq([
+              Rule.new(
+                id: 0,
+                lhs: grammar.find_symbol_by_s_value!("$accept"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("program"),
+                  grammar.find_symbol_by_s_value!("YYEOF"),
+                ],
+                token_code: nil,
+                nullable: false,
+                precedence_sym: grammar.find_symbol_by_s_value!("YYEOF"),
+                lineno: 19,
+              ),
+              Rule.new(
+                id: 1,
+                lhs: grammar.find_symbol_by_s_value!("program"),
+                rhs: [],
+                token_code: nil,
+                nullable: true,
+                precedence_sym: nil,
+                lineno: 19,
+              ),
+              Rule.new(
+                id: 2,
+                lhs: grammar.find_symbol_by_s_value!("program"),
+                rhs: [
+                  grammar.find_symbol_by_s_value!("number"),
+                ],
+                token_code: nil,
+                nullable: false,
+                precedence_sym: grammar.find_symbol_by_s_value!("number"),
+                lineno: 19,
+              ),
+            ])
+          end
+        end
+
         context "when preceded" do
           let(:path) { "parameterized/stdlib/preceded.y" }
 


### PR DESCRIPTION
This is a Rule also provided by Menhir, and is an Inline rule that is deployed inline as follows

```
program: ioption(X)

=>

program: %empty
program: X
```

refs: https://github.com/let-def/menhir/blob/e8ba7bef219acd355798072c42abbd11335ecf09/src/standard.mly#L33-L41