### PR TITLE
Add output for terms and non-terminals count in report

### DIFF
--- a/lib/lrama/reporter/terms.rb
+++ b/lib/lrama/reporter/terms.rb
@@ -27,6 +27,10 @@ module Lrama
           (look_aheads + next_terms).include?(term)
         end
 
+        io << states.terms.count << " Terms\n\n"
+
+        io << states.nterms.count << " Non-Terminals\n\n"
+
         unless unused_symbols.empty?
           io << "#{unused_symbols.count} Unused Terms\n\n"
           unused_symbols.each_with_index do |term, index|

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Lrama::States do
             0 unused
 
 
+        19 Terms
+
+        13 Non-Terminals
+
         11 Unused Terms
 
             0 YYerror


### PR DESCRIPTION
It would be great if you could add it as it would be useful to get current statistics.

```diff
    0 unused

+19 Terms
+
+13 Non-Terminals
+
11 Unused Terms

    0 YYerror
```