### PR TITLE
Add support for `%define variable {value}`

### DIFF
--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -654,7 +654,7 @@ end
 module Lrama
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 466)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 470)
 
 include Lrama::Tracer::Duration
 
@@ -729,171 +729,175 @@ end
 ##### State transition tables begin ###
 
 racc_action_table = [
-    89,    49,    90,   167,    49,   101,   173,    49,   101,   167,
-    49,   101,   173,     6,   101,    80,    49,    49,    48,    48,
-    41,    76,    76,    49,    49,    48,    48,    42,    76,    76,
-    49,    49,    48,    48,   101,    96,   113,    49,    87,    48,
-   150,   101,    96,   151,    45,   171,   169,   170,   151,   176,
-   170,    91,   169,   170,    81,   176,   170,    23,    24,    25,
-    26,    27,    28,    29,    30,    31,    87,    32,    33,    34,
-    35,    36,    37,    38,    39,    49,     4,    48,     5,   101,
-    96,   181,   182,   183,   128,    23,    24,    25,    26,    27,
-    28,    29,    30,    31,    46,    32,    33,    34,    35,    36,
-    37,    38,    39,    10,    11,    12,    13,    14,    15,    16,
-    17,    18,    53,    23,    24,    25,    26,    27,    28,    29,
-    30,    31,    53,    32,    33,    34,    35,    36,    37,    38,
-    39,    10,    11,    12,    13,    14,    15,    16,    17,    18,
-    44,    23,    24,    25,    26,    27,    28,    29,    30,    31,
-    53,    32,    33,    34,    35,    36,    37,    38,    39,    49,
-     4,    48,     5,   101,    96,    49,    49,    48,    48,   101,
-   101,    49,    49,    48,    48,   101,   101,    49,    49,    48,
-   197,   101,   101,    49,    49,   197,    48,   101,   101,    49,
-    49,   197,    48,   101,   181,   182,   183,   128,   204,   210,
-   217,   205,   205,   205,    49,    49,    48,    48,    49,    49,
-    48,    48,    49,    49,    48,    48,   181,   182,   183,   116,
-   117,    56,    53,    53,    53,    53,    53,    62,    63,    64,
-    65,    66,    68,    68,    68,    82,    53,    53,   104,   108,
-   108,   115,   122,   123,   125,   128,   129,   133,   139,   140,
-   141,   142,   144,   145,   101,   154,   139,   157,   154,   161,
-   162,    68,   164,   165,   172,   177,   154,   184,   128,   188,
-   154,   190,   128,   154,   199,   154,   128,    68,   165,   206,
-   165,    68,    68,   215,   128,    68 ]
+    90,    90,    91,    91,    80,   153,     6,    49,   154,   170,
+    89,   102,    49,    49,   176,   170,   102,   102,    49,   173,
+   176,    49,   102,    48,   173,   173,    76,    49,    41,    48,
+   173,    49,    76,    48,    42,    49,    76,    48,    45,    49,
+    76,    48,    46,   102,    97,    81,    87,   174,   117,   118,
+   154,    92,    92,    49,   172,    48,    53,   102,    97,   179,
+   172,    49,    53,    48,    87,   179,   114,    23,    24,    25,
+    26,    27,    28,    29,    30,    31,    53,    32,    33,    34,
+    35,    36,    37,    38,    39,    23,    24,    25,    26,    27,
+    28,    29,    30,    31,    56,    32,    33,    34,    35,    36,
+    37,    38,    39,    10,    11,    53,    53,    12,    13,    14,
+    15,    16,    17,    18,    53,    23,    24,    25,    26,    27,
+    28,    29,    30,    31,    53,    32,    33,    34,    35,    36,
+    37,    38,    39,    10,    11,    53,    62,    12,    13,    14,
+    15,    16,    17,    18,    44,    23,    24,    25,    26,    27,
+    28,    29,    30,    31,    63,    32,    33,    34,    35,    36,
+    37,    38,    39,    49,     4,    48,     5,   102,    97,    49,
+     4,    48,     5,   102,    97,    49,    49,    48,    48,   102,
+   102,    49,    49,    48,    48,   102,   102,    49,    49,    48,
+   200,   102,   102,    49,    49,   200,    48,   102,   102,    49,
+    49,   200,    48,   102,   184,   185,   186,   129,   184,   185,
+   186,   129,   207,   213,   220,   208,   208,   208,    49,    49,
+    48,    48,    49,    49,    48,    48,    49,    49,    48,    48,
+   184,   185,   186,    64,    65,    66,    68,    68,    68,    82,
+    53,    53,   105,   109,   109,   116,   123,   124,   126,   129,
+   131,   135,   141,   142,   143,   144,   146,   147,   148,   102,
+   157,   141,   160,   157,   164,   165,    68,   167,   168,   175,
+   180,   157,   187,   129,   191,   157,   193,   129,   157,   202,
+   157,   129,    68,   168,   209,   168,    68,    68,   218,   129,
+    68 ]
 
 racc_action_check = [
-    47,   153,    47,   153,   159,   153,   159,   178,   159,   178,
-   189,   178,   189,     1,   189,    39,    35,    36,    35,    36,
-     5,    35,    36,    37,    38,    37,    38,     6,    37,    38,
-    59,    74,    59,    74,    59,    59,    74,    60,    45,    60,
-   138,    60,    60,   138,     9,   156,   153,   153,   156,   159,
-   159,    47,   178,   178,    39,   189,   189,    45,    45,    45,
-    45,    45,    45,    45,    45,    45,    83,    45,    45,    45,
-    45,    45,    45,    45,    45,    61,     0,    61,     0,    61,
-    61,   166,   166,   166,   166,    83,    83,    83,    83,    83,
-    83,    83,    83,    83,    10,    83,    83,    83,    83,    83,
-    83,    83,    83,     3,     3,     3,     3,     3,     3,     3,
-     3,     3,    12,     3,     3,     3,     3,     3,     3,     3,
-     3,     3,    13,     3,     3,     3,     3,     3,     3,     3,
-     3,     8,     8,     8,     8,     8,     8,     8,     8,     8,
+    47,    89,    47,    89,    39,   140,     1,   156,   140,   156,
+    47,   156,   162,   181,   162,   181,   162,   181,   192,   156,
+   192,    35,   192,    35,   162,   181,    35,    36,     5,    36,
+   192,    37,    36,    37,     6,    38,    37,    38,     9,    59,
+    38,    59,    10,    59,    59,    39,    45,   159,    81,    81,
+   159,    47,    89,    60,   156,    60,    12,    60,    60,   162,
+   181,    74,    13,    74,    83,   192,    74,    45,    45,    45,
+    45,    45,    45,    45,    45,    45,    14,    45,    45,    45,
+    45,    45,    45,    45,    45,    83,    83,    83,    83,    83,
+    83,    83,    83,    83,    15,    83,    83,    83,    83,    83,
+    83,    83,    83,     3,     3,    16,    23,     3,     3,     3,
+     3,     3,     3,     3,    24,     3,     3,     3,     3,     3,
+     3,     3,     3,     3,    25,     3,     3,     3,     3,     3,
+     3,     3,     3,     8,     8,    26,    27,     8,     8,     8,
      8,     8,     8,     8,     8,     8,     8,     8,     8,     8,
-    14,     8,     8,     8,     8,     8,     8,     8,     8,    97,
-     2,    97,     2,    97,    97,    71,   108,    71,   108,    71,
-   108,   109,   169,   109,   169,   109,   169,   176,   184,   176,
-   184,   176,   184,   190,   205,   190,   205,   190,   205,   206,
-    11,   206,    11,   206,   174,   174,   174,   174,   196,   201,
-   214,   196,   201,   214,    69,    76,    69,    76,   104,   105,
-   104,   105,   111,   113,   111,   113,   198,   198,   198,    81,
-    81,    15,    16,    23,    24,    25,    26,    27,    28,    29,
-    30,    31,    32,    33,    34,    40,    51,    56,    67,    70,
-    72,    80,    84,    85,    86,    87,    93,   107,   115,   116,
-   117,   118,   127,   128,   134,   140,   141,   143,   144,   145,
-   146,   150,   151,   152,   158,   163,   165,   167,   168,   171,
-   172,   173,   175,   177,   187,   188,   192,   193,   195,   197,
-   200,   202,   204,   209,   210,   216 ]
+     8,     8,     8,     8,    28,     8,     8,     8,     8,     8,
+     8,     8,     8,    61,     0,    61,     0,    61,    61,    98,
+     2,    98,     2,    98,    98,    71,   109,    71,   109,    71,
+   109,   110,   172,   110,   172,   110,   172,   179,   187,   179,
+   187,   179,   187,   193,   208,   193,   208,   193,   208,   209,
+    11,   209,    11,   209,   169,   169,   169,   169,   177,   177,
+   177,   177,   199,   204,   217,   199,   204,   217,    69,    76,
+    69,    76,   105,   106,   105,   106,   112,   114,   112,   114,
+   201,   201,   201,    29,    30,    31,    32,    33,    34,    40,
+    51,    56,    67,    70,    72,    80,    84,    85,    86,    87,
+    94,   108,   116,   117,   118,   119,   128,   129,   130,   136,
+   142,   143,   145,   146,   147,   149,   153,   154,   155,   161,
+   166,   168,   170,   171,   174,   175,   176,   178,   180,   190,
+   191,   195,   196,   198,   200,   203,   205,   207,   212,   213,
+   219 ]
 
 racc_action_pointer = [
-    66,    13,   150,    90,   nil,    13,    27,   nil,   118,    35,
-    88,   187,    63,    73,   101,   216,   173,   nil,   nil,   nil,
-   nil,   nil,   nil,   174,   175,   176,   177,   222,   223,   224,
-   225,   226,   224,   225,   226,    13,    14,    20,    21,    10,
-   233,   nil,   nil,   nil,   nil,    34,   nil,    -5,   nil,   nil,
-   nil,   187,   nil,   nil,   nil,   nil,   188,   nil,   nil,    27,
-    34,    72,   nil,   nil,   nil,   nil,   nil,   230,   nil,   201,
-   231,   162,   232,   nil,    28,   nil,   202,   nil,   nil,   nil,
-   200,   215,   nil,    62,   233,   221,   222,   191,   nil,   nil,
-   nil,   nil,   nil,   244,   nil,   nil,   nil,   156,   nil,   nil,
-   nil,   nil,   nil,   nil,   205,   206,   nil,   241,   163,   168,
-   nil,   209,   nil,   210,   nil,   243,   206,   209,   240,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,   209,   248,   nil,
-   nil,   nil,   nil,   nil,   247,   nil,   nil,   nil,    -2,   nil,
-   208,   251,   nil,   255,   211,   204,   210,   nil,   nil,   nil,
-   253,   257,   217,    -2,   nil,   nil,     3,   nil,   218,     1,
-   nil,   nil,   nil,   222,   nil,   219,    30,   226,   214,   169,
-   nil,   226,   223,   230,   143,   218,   174,   226,     4,   nil,
-   nil,   nil,   nil,   nil,   175,   nil,   nil,   272,   228,     7,
-   180,   nil,   222,   269,   nil,   232,   156,   238,   165,   nil,
-   234,   157,   273,   nil,   274,   181,   186,   nil,   nil,   233,
-   230,   nil,   nil,   nil,   158,   nil,   277,   nil,   nil ]
+   154,     6,   160,    90,   nil,    21,    34,   nil,   120,    29,
+    36,   197,    41,    47,    61,    89,    90,   nil,   nil,   nil,
+   nil,   nil,   nil,    91,    99,   109,   120,   131,   149,   228,
+   229,   230,   228,   229,   230,    18,    24,    28,    32,    -1,
+   237,   nil,   nil,   nil,   nil,    42,   nil,    -5,   nil,   nil,
+   nil,   225,   nil,   nil,   nil,   nil,   226,   nil,   nil,    36,
+    50,   160,   nil,   nil,   nil,   nil,   nil,   234,   nil,   215,
+   235,   172,   236,   nil,    58,   nil,   216,   nil,   nil,   nil,
+   202,    44,   nil,    60,   237,   223,   224,   195,   nil,    -4,
+   nil,   nil,   nil,   nil,   248,   nil,   nil,   nil,   166,   nil,
+   nil,   nil,   nil,   nil,   nil,   219,   220,   nil,   245,   173,
+   178,   nil,   223,   nil,   224,   nil,   247,   208,   211,   244,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   211,   252,
+   242,   nil,   nil,   nil,   nil,   nil,   252,   nil,   nil,   nil,
+   -39,   nil,   211,   256,   nil,   260,   214,   209,   nil,   249,
+   nil,   nil,   nil,   258,   262,   220,     4,   nil,   nil,     3,
+   nil,   221,     9,   nil,   nil,   nil,   225,   nil,   222,   153,
+   229,   219,   179,   nil,   229,   226,   233,   157,   223,   184,
+   229,    10,   nil,   nil,   nil,   nil,   nil,   185,   nil,   nil,
+   277,   231,    15,   190,   nil,   227,   274,   nil,   235,   168,
+   241,   179,   nil,   237,   169,   278,   nil,   279,   191,   196,
+   nil,   nil,   272,   235,   nil,   nil,   nil,   170,   nil,   282,
+   nil,   nil ]
 
 racc_action_default = [
-    -1,  -128,    -1,    -3,   -10,  -128,  -128,    -2,    -3,  -128,
-  -128,  -128,  -128,  -128,  -128,  -128,  -128,   -23,   -24,   -25,
-   -31,   -32,   -33,  -128,  -128,  -128,  -128,  -128,  -128,  -128,
-  -128,  -128,   -50,   -50,   -50,  -128,  -128,  -128,  -128,  -128,
-  -128,   -13,   219,    -4,   -26,  -128,   -16,  -123,   -93,   -94,
-  -122,   -14,   -18,   -85,   -19,   -20,  -128,   -22,   -34,  -128,
-  -128,  -128,   -38,   -39,   -40,   -41,   -42,   -43,   -51,  -128,
-   -44,  -128,   -45,   -46,   -88,   -90,  -128,   -47,   -48,   -49,
-  -128,  -128,   -11,    -5,    -7,   -95,  -128,   -68,   -17,  -124,
-  -125,  -126,   -15,  -128,   -21,   -27,   -28,   -29,   -35,   -83,
-   -84,  -127,   -36,   -37,  -128,   -52,   -54,   -56,  -128,   -79,
-   -81,   -88,   -89,  -128,   -91,  -128,  -128,  -128,  -128,    -6,
-    -8,    -9,  -120,   -96,   -97,   -98,   -69,  -128,  -128,   -86,
-   -30,   -55,   -53,   -57,   -76,   -82,   -80,   -92,  -128,   -62,
-   -66,  -128,   -12,  -128,   -66,  -128,  -128,   -58,   -77,   -78,
-   -50,  -128,   -60,   -64,   -67,   -70,  -128,  -121,   -99,  -100,
-  -102,  -119,   -87,  -128,   -63,   -66,   -68,   -93,   -68,  -128,
-  -116,  -128,   -66,   -93,   -68,   -68,  -128,   -66,   -65,   -71,
-   -72,  -108,  -109,  -110,  -128,   -74,   -75,  -128,   -66,  -101,
-  -128,  -103,   -68,   -50,  -107,   -59,  -128,   -93,  -111,  -117,
-   -61,  -128,   -50,  -106,   -50,  -128,  -128,  -112,  -113,  -128,
-   -68,  -104,   -73,  -114,  -128,  -118,   -50,  -115,  -105 ]
+    -1,  -129,    -1,    -3,   -10,  -129,  -129,    -2,    -3,  -129,
+  -129,  -129,  -129,  -129,  -129,  -129,  -129,   -24,   -25,   -26,
+   -32,   -33,   -34,  -129,  -129,  -129,  -129,  -129,  -129,  -129,
+  -129,  -129,   -51,   -51,   -51,  -129,  -129,  -129,  -129,  -129,
+  -129,   -13,   222,    -4,   -27,  -129,   -16,  -124,   -94,   -95,
+  -123,   -14,   -19,   -86,   -20,   -21,  -129,   -23,   -35,  -129,
+  -129,  -129,   -39,   -40,   -41,   -42,   -43,   -44,   -52,  -129,
+   -45,  -129,   -46,   -47,   -89,   -91,  -129,   -48,   -49,   -50,
+  -129,  -129,   -11,    -5,    -7,   -96,  -129,   -69,   -17,  -124,
+  -125,  -126,  -127,   -15,  -129,   -22,   -28,   -29,   -30,   -36,
+   -84,   -85,  -128,   -37,   -38,  -129,   -53,   -55,   -57,  -129,
+   -80,   -82,   -89,   -90,  -129,   -92,  -129,  -129,  -129,  -129,
+    -6,    -8,    -9,  -121,   -97,   -98,   -99,   -70,  -129,  -129,
+  -129,   -87,   -31,   -56,   -54,   -58,   -77,   -83,   -81,   -93,
+  -129,   -63,   -67,  -129,   -12,  -129,   -67,  -129,   -18,  -129,
+   -59,   -78,   -79,   -51,  -129,   -61,   -65,   -68,   -71,  -129,
+  -122,  -100,  -101,  -103,  -120,   -88,  -129,   -64,   -67,   -69,
+   -94,   -69,  -129,  -117,  -129,   -67,   -94,   -69,   -69,  -129,
+   -67,   -66,   -72,   -73,  -109,  -110,  -111,  -129,   -75,   -76,
+  -129,   -67,  -102,  -129,  -104,   -69,   -51,  -108,   -60,  -129,
+   -94,  -112,  -118,   -62,  -129,   -51,  -107,   -51,  -129,  -129,
+  -113,  -114,  -129,   -69,  -105,   -74,  -115,  -129,  -119,   -51,
+  -116,  -106 ]
 
 racc_goto_table = [
-    69,   109,    50,   152,    57,   127,    52,    54,    55,    84,
-    86,    58,    59,    60,    61,   112,   175,   114,    98,   102,
-   103,   110,   160,   180,     1,   159,    74,    74,    74,    74,
-   120,   192,     9,   106,     3,   138,     7,    43,   109,   109,
-   195,    70,    72,   121,    94,    92,   175,   119,    86,    40,
-   160,   200,   112,   189,   137,   207,   130,   196,   135,   136,
-   107,   156,   118,   201,    47,   111,    88,   111,   131,   132,
-    73,    77,    78,    79,    67,   147,   134,   178,   148,   214,
-   149,    93,   146,   166,   179,   124,   185,   158,   208,   174,
-   187,   209,   191,   193,   143,   107,   107,   nil,   nil,   186,
-   nil,   nil,   111,   nil,   111,   nil,   194,   nil,   166,   nil,
-   202,   nil,   nil,   nil,   198,   nil,   nil,   nil,   163,   174,
-   198,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   216,   nil,
-   nil,   nil,   nil,   nil,   nil,   213,   198,   nil,   nil,   nil,
+    69,   110,    88,    50,   155,   128,    57,   113,   178,   115,
+    52,    54,    55,    58,    59,    60,    61,    99,   103,   104,
+   111,   163,    84,   183,    86,   162,   199,    74,    74,    74,
+    74,   195,   204,   107,     1,     3,   140,     7,   178,   110,
+   110,   121,   198,   122,   130,   113,    95,   139,   217,    93,
+   163,    40,     9,   203,   192,   210,   132,    43,   137,   138,
+   120,   108,    86,   159,    70,    72,   112,   119,   112,   133,
+   134,    73,    77,    78,    79,    47,    67,   150,   136,   181,
+   151,   152,    94,   149,   125,   161,   169,   182,   211,   188,
+   190,   212,   177,   145,   nil,   194,   196,   108,   108,   nil,
+   nil,   nil,   189,   nil,   112,   nil,   112,   nil,   nil,   197,
+   nil,   169,   nil,   205,   nil,   nil,   nil,   201,   nil,   nil,
+   nil,   166,   177,   201,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   219,   nil,   nil,   nil,   nil,   nil,   nil,   216,   201,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   203,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   211,   nil,   212,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   218 ]
+   nil,   nil,   nil,   nil,   206,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   214,   nil,   215,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   221 ]
 
 racc_goto_check = [
-    27,    20,    29,    33,    14,    40,    16,    16,    16,     8,
-    15,    14,    14,    14,    14,    46,    38,    46,    22,    22,
-    22,    43,    39,    36,     1,    50,    29,    29,    29,    29,
-     5,    36,     7,    28,     6,    32,     6,     7,    20,    20,
-    33,    24,    24,     9,    14,    16,    38,     8,    15,    10,
-    39,    33,    46,    50,    46,    36,    22,    37,    43,    43,
-    29,    32,    11,    37,    12,    29,    13,    29,    28,    28,
-    25,    25,    25,    25,    23,    30,    31,    34,    41,    37,
-    42,    44,    45,    20,    40,    48,    40,    49,    51,    20,
-    52,    53,    40,    40,    54,    29,    29,   nil,   nil,    20,
-   nil,   nil,    29,   nil,    29,   nil,    20,   nil,    20,   nil,
-    40,   nil,   nil,   nil,    20,   nil,   nil,   nil,    27,    20,
-    20,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    40,   nil,
-   nil,   nil,   nil,   nil,   nil,    20,    20,   nil,   nil,   nil,
+    27,    20,    13,    29,    33,    40,    14,    46,    38,    46,
+    16,    16,    16,    14,    14,    14,    14,    22,    22,    22,
+    43,    39,     8,    36,    15,    50,    37,    29,    29,    29,
+    29,    36,    37,    28,     1,     6,    32,     6,    38,    20,
+    20,     5,    33,     9,    13,    46,    14,    46,    37,    16,
+    39,    10,     7,    33,    50,    36,    22,     7,    43,    43,
+     8,    29,    15,    32,    24,    24,    29,    11,    29,    28,
+    28,    25,    25,    25,    25,    12,    23,    30,    31,    34,
+    41,    42,    44,    45,    48,    49,    20,    40,    51,    40,
+    52,    53,    20,    54,   nil,    40,    40,    29,    29,   nil,
+   nil,   nil,    20,   nil,    29,   nil,    29,   nil,   nil,    20,
+   nil,    20,   nil,    40,   nil,   nil,   nil,    20,   nil,   nil,
+   nil,    27,    20,    20,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,    40,   nil,   nil,   nil,   nil,   nil,   nil,    20,    20,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,    27,   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-    27,   nil,    27,   nil,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,    27 ]
+   nil,   nil,   nil,   nil,    27,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,    27,   nil,    27,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,    27 ]
 
 racc_goto_pointer = [
-   nil,    24,   nil,   nil,   nil,   -54,    34,    29,   -36,   -41,
-    45,   -20,    53,    19,   -12,   -35,    -6,   nil,   nil,   nil,
-   -70,   nil,   -41,    42,     8,    35,   nil,   -32,   -36,    -9,
-   -59,   -31,   -80,  -137,   -88,   nil,  -143,  -127,  -143,  -122,
-   -82,   -56,   -54,   -50,    28,   -47,   -59,   nil,     0,   -57,
-  -119,  -110,   -80,  -108,   -28 ]
+   nil,    34,   nil,   nil,   nil,   -43,    35,    49,   -23,   -41,
+    47,   -15,    64,   -45,   -10,   -21,    -2,   nil,   nil,   nil,
+   -70,   nil,   -42,    44,    31,    36,   nil,   -32,   -36,    -8,
+   -59,   -30,   -80,  -138,   -89,   nil,  -146,  -161,  -154,  -125,
+   -82,   -56,   -55,   -51,    29,   -48,   -67,   nil,    -1,   -61,
+  -121,  -113,   -83,  -111,   -30 ]
 
 racc_goto_default = [
    nil,   nil,     2,     8,    83,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,    51,    19,   nil,    20,    21,    22,
-    95,    97,   nil,   nil,   nil,   nil,   105,    71,   nil,    99,
-   nil,   nil,   nil,   nil,   153,   126,   nil,   nil,   168,   155,
-   nil,   100,   nil,   nil,   nil,   nil,    75,    85,   nil,   nil,
+    96,    98,   nil,   nil,   nil,   nil,   106,    71,   nil,   100,
+   nil,   nil,   nil,   nil,   156,   127,   nil,   nil,   171,   158,
+   nil,   101,   nil,   nil,   nil,   nil,    75,    85,   nil,   nil,
    nil,   nil,   nil,   nil,   nil ]
 
 racc_reduce_table = [
@@ -915,120 +919,121 @@ racc_reduce_table = [
   2, 73, :_reduce_15,
   2, 60, :_reduce_16,
   3, 60, :_reduce_17,
+  5, 60, :_reduce_18,
   2, 60, :_reduce_none,
-  2, 60, :_reduce_19,
   2, 60, :_reduce_20,
-  3, 60, :_reduce_21,
-  2, 60, :_reduce_22,
-  1, 60, :_reduce_23,
+  2, 60, :_reduce_21,
+  3, 60, :_reduce_22,
+  2, 60, :_reduce_23,
   1, 60, :_reduce_24,
+  1, 60, :_reduce_25,
   1, 60, :_reduce_none,
   2, 60, :_reduce_none,
-  1, 78, :_reduce_27,
   1, 78, :_reduce_28,
-  1, 79, :_reduce_29,
-  2, 79, :_reduce_30,
+  1, 78, :_reduce_29,
+  1, 79, :_reduce_30,
+  2, 79, :_reduce_31,
   1, 72, :_reduce_none,
   1, 72, :_reduce_none,
   1, 72, :_reduce_none,
-  2, 72, :_reduce_34,
-  3, 72, :_reduce_35,
+  2, 72, :_reduce_35,
   3, 72, :_reduce_36,
   3, 72, :_reduce_37,
-  2, 72, :_reduce_38,
+  3, 72, :_reduce_38,
   2, 72, :_reduce_39,
   2, 72, :_reduce_40,
   2, 72, :_reduce_41,
   2, 72, :_reduce_42,
+  2, 72, :_reduce_43,
   2, 74, :_reduce_none,
-  2, 74, :_reduce_44,
   2, 74, :_reduce_45,
   2, 74, :_reduce_46,
   2, 74, :_reduce_47,
   2, 74, :_reduce_48,
   2, 74, :_reduce_49,
+  2, 74, :_reduce_50,
   0, 84, :_reduce_none,
   1, 84, :_reduce_none,
-  1, 85, :_reduce_52,
-  2, 85, :_reduce_53,
-  2, 80, :_reduce_54,
-  3, 80, :_reduce_55,
+  1, 85, :_reduce_53,
+  2, 85, :_reduce_54,
+  2, 80, :_reduce_55,
+  3, 80, :_reduce_56,
   0, 88, :_reduce_none,
   1, 88, :_reduce_none,
-  3, 83, :_reduce_58,
-  8, 75, :_reduce_59,
-  5, 76, :_reduce_60,
-  8, 76, :_reduce_61,
-  1, 89, :_reduce_62,
-  3, 89, :_reduce_63,
-  1, 90, :_reduce_64,
-  3, 90, :_reduce_65,
+  3, 83, :_reduce_59,
+  8, 75, :_reduce_60,
+  5, 76, :_reduce_61,
+  8, 76, :_reduce_62,
+  1, 89, :_reduce_63,
+  3, 89, :_reduce_64,
+  1, 90, :_reduce_65,
+  3, 90, :_reduce_66,
   0, 96, :_reduce_none,
   1, 96, :_reduce_none,
   0, 97, :_reduce_none,
   1, 97, :_reduce_none,
-  1, 91, :_reduce_70,
-  3, 91, :_reduce_71,
+  1, 91, :_reduce_71,
   3, 91, :_reduce_72,
-  6, 91, :_reduce_73,
-  3, 91, :_reduce_74,
+  3, 91, :_reduce_73,
+  6, 91, :_reduce_74,
   3, 91, :_reduce_75,
+  3, 91, :_reduce_76,
   0, 99, :_reduce_none,
   1, 99, :_reduce_none,
-  1, 87, :_reduce_78,
-  1, 100, :_reduce_79,
-  2, 100, :_reduce_80,
-  2, 81, :_reduce_81,
-  3, 81, :_reduce_82,
+  1, 87, :_reduce_79,
+  1, 100, :_reduce_80,
+  2, 100, :_reduce_81,
+  2, 81, :_reduce_82,
+  3, 81, :_reduce_83,
   1, 77, :_reduce_none,
   1, 77, :_reduce_none,
-  0, 101, :_reduce_85,
-  0, 102, :_reduce_86,
-  5, 71, :_reduce_87,
-  1, 103, :_reduce_88,
-  2, 103, :_reduce_89,
-  1, 82, :_reduce_90,
-  2, 82, :_reduce_91,
-  3, 82, :_reduce_92,
-  1, 86, :_reduce_93,
+  0, 101, :_reduce_86,
+  0, 102, :_reduce_87,
+  5, 71, :_reduce_88,
+  1, 103, :_reduce_89,
+  2, 103, :_reduce_90,
+  1, 82, :_reduce_91,
+  2, 82, :_reduce_92,
+  3, 82, :_reduce_93,
   1, 86, :_reduce_94,
+  1, 86, :_reduce_95,
   0, 105, :_reduce_none,
   1, 105, :_reduce_none,
   2, 61, :_reduce_none,
   2, 61, :_reduce_none,
-  4, 104, :_reduce_99,
-  1, 106, :_reduce_100,
-  3, 106, :_reduce_101,
-  1, 107, :_reduce_102,
-  3, 107, :_reduce_103,
-  5, 107, :_reduce_104,
-  7, 107, :_reduce_105,
-  4, 107, :_reduce_106,
-  3, 107, :_reduce_107,
-  1, 93, :_reduce_108,
+  4, 104, :_reduce_100,
+  1, 106, :_reduce_101,
+  3, 106, :_reduce_102,
+  1, 107, :_reduce_103,
+  3, 107, :_reduce_104,
+  5, 107, :_reduce_105,
+  7, 107, :_reduce_106,
+  4, 107, :_reduce_107,
+  3, 107, :_reduce_108,
   1, 93, :_reduce_109,
   1, 93, :_reduce_110,
+  1, 93, :_reduce_111,
   0, 108, :_reduce_none,
   1, 108, :_reduce_none,
-  2, 94, :_reduce_113,
-  3, 94, :_reduce_114,
-  4, 94, :_reduce_115,
-  0, 109, :_reduce_116,
-  0, 110, :_reduce_117,
-  5, 95, :_reduce_118,
-  3, 92, :_reduce_119,
-  0, 111, :_reduce_120,
-  3, 62, :_reduce_121,
+  2, 94, :_reduce_114,
+  3, 94, :_reduce_115,
+  4, 94, :_reduce_116,
+  0, 109, :_reduce_117,
+  0, 110, :_reduce_118,
+  5, 95, :_reduce_119,
+  3, 92, :_reduce_120,
+  0, 111, :_reduce_121,
+  3, 62, :_reduce_122,
   1, 69, :_reduce_none,
   0, 70, :_reduce_none,
   1, 70, :_reduce_none,
   1, 70, :_reduce_none,
   1, 70, :_reduce_none,
-  1, 98, :_reduce_127 ]
+  1, 98, :_reduce_128 ]
 
-racc_reduce_n = 128
+racc_reduce_n = 129
 
-racc_shift_n = 219
+racc_shift_n = 222
 
 racc_token_table = {
   false => 0,
@@ -1046,42 +1051,42 @@ racc_token_table = {
   "%require" => 12,
   "%expect" => 13,
   "%define" => 14,
-  "%param" => 15,
-  "%lex-param" => 16,
-  "%parse-param" => 17,
-  "%code" => 18,
-  "%initial-action" => 19,
-  "%no-stdlib" => 20,
-  "%locations" => 21,
-  ";" => 22,
-  "%union" => 23,
-  "%destructor" => 24,
-  "%printer" => 25,
-  "%error-token" => 26,
-  "%after-shift" => 27,
-  "%before-reduce" => 28,
-  "%after-reduce" => 29,
-  "%after-shift-error-token" => 30,
-  "%after-pop-stack" => 31,
-  "-temp-group" => 32,
-  "%token" => 33,
-  "%type" => 34,
-  "%nterm" => 35,
-  "%left" => 36,
-  "%right" => 37,
-  "%precedence" => 38,
-  "%nonassoc" => 39,
-  "%rule" => 40,
-  "(" => 41,
-  ")" => 42,
-  ":" => 43,
-  "%inline" => 44,
-  "," => 45,
-  "|" => 46,
-  "%empty" => 47,
-  "%prec" => 48,
-  "{" => 49,
-  "}" => 50,
+  "{" => 15,
+  "}" => 16,
+  "%param" => 17,
+  "%lex-param" => 18,
+  "%parse-param" => 19,
+  "%code" => 20,
+  "%initial-action" => 21,
+  "%no-stdlib" => 22,
+  "%locations" => 23,
+  ";" => 24,
+  "%union" => 25,
+  "%destructor" => 26,
+  "%printer" => 27,
+  "%error-token" => 28,
+  "%after-shift" => 29,
+  "%before-reduce" => 30,
+  "%after-reduce" => 31,
+  "%after-shift-error-token" => 32,
+  "%after-pop-stack" => 33,
+  "-temp-group" => 34,
+  "%token" => 35,
+  "%type" => 36,
+  "%nterm" => 37,
+  "%left" => 38,
+  "%right" => 39,
+  "%precedence" => 40,
+  "%nonassoc" => 41,
+  "%rule" => 42,
+  "(" => 43,
+  ")" => 44,
+  ":" => 45,
+  "%inline" => 46,
+  "," => 47,
+  "|" => 48,
+  "%empty" => 49,
+  "%prec" => 50,
   "?" => 51,
   "+" => 52,
   "*" => 53,
@@ -1126,6 +1131,8 @@ Racc_token_to_s_table = [
   "\"%require\"",
   "\"%expect\"",
   "\"%define\"",
+  "\"{\"",
+  "\"}\"",
   "\"%param\"",
   "\"%lex-param\"",
   "\"%parse-param\"",
@@ -1160,8 +1167,6 @@ Racc_token_to_s_table = [
   "\"|\"",
   "\"%empty\"",
   "\"%prec\"",
-  "\"{\"",
-  "\"}\"",
   "\"?\"",
   "\"+\"",
   "\"*\"",
@@ -1312,14 +1317,14 @@ module_eval(<<'.,.,', 'parser.y', 26)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 71)
+module_eval(<<'.,.,', 'parser.y', 75)
   def _reduce_14(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 71)
+module_eval(<<'.,.,', 'parser.y', 75)
   def _reduce_15(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
@@ -1342,10 +1347,18 @@ module_eval(<<'.,.,', 'parser.y', 36)
   end
 .,.,
 
-# reduce 18 omitted
+module_eval(<<'.,.,', 'parser.y', 40)
+  def _reduce_18(val, _values, result)
+              @grammar.define[val[1].s_value] = val[3]&.s_value
 
-module_eval(<<'.,.,', 'parser.y', 41)
-  def _reduce_19(val, _values, result)
+    result
+  end
+.,.,
+
+# reduce 19 omitted
+
+module_eval(<<'.,.,', 'parser.y', 45)
+  def _reduce_20(val, _values, result)
               val[1].each {|token|
             @grammar.lex_param = Grammar::Code::NoReferenceCode.new(type: :lex_param, token_code: token).token_code.s_value
           }
@@ -1354,8 +1367,8 @@ module_eval(<<'.,.,', 'parser.y', 41)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 47)
-  def _reduce_20(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 51)
+  def _reduce_21(val, _values, result)
               val[1].each {|token|
             @grammar.parse_param = Grammar::Code::NoReferenceCode.new(type: :parse_param, token_code: token).token_code.s_value
           }
@@ -1364,17 +1377,9 @@ module_eval(<<'.,.,', 'parser.y', 47)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 53)
-  def _reduce_21(val, _values, result)
-              @grammar.add_percent_code(id: val[1], code: val[2])
-
-    result
-  end
-.,.,
-
 module_eval(<<'.,.,', 'parser.y', 57)
   def _reduce_22(val, _values, result)
-              @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[1])
+              @grammar.add_percent_code(id: val[1], code: val[2])
 
     result
   end
@@ -1382,7 +1387,7 @@ module_eval(<<'.,.,', 'parser.y', 57)
 
 module_eval(<<'.,.,', 'parser.y', 61)
   def _reduce_23(val, _values, result)
-              @grammar.no_stdlib = true
+              @grammar.initial_action = Grammar::Code::InitialActionCode.new(type: :initial_action, token_code: val[1])
 
     result
   end
@@ -1390,52 +1395,60 @@ module_eval(<<'.,.,', 'parser.y', 61)
 
 module_eval(<<'.,.,', 'parser.y', 65)
   def _reduce_24(val, _values, result)
+              @grammar.no_stdlib = true
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 69)
+  def _reduce_25(val, _values, result)
               @grammar.locations = true
 
     result
   end
 .,.,
 
-# reduce 25 omitted
-
 # reduce 26 omitted
 
-module_eval(<<'.,.,', 'parser.y', 127)
-  def _reduce_27(val, _values, result)
-    result = val
-    result
-  end
-.,.,
+# reduce 27 omitted
 
-module_eval(<<'.,.,', 'parser.y', 127)
+module_eval(<<'.,.,', 'parser.y', 131)
   def _reduce_28(val, _values, result)
     result = val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 127)
+module_eval(<<'.,.,', 'parser.y', 131)
   def _reduce_29(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
+    result = val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 127)
+module_eval(<<'.,.,', 'parser.y', 131)
   def _reduce_30(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-# reduce 31 omitted
+module_eval(<<'.,.,', 'parser.y', 131)
+  def _reduce_31(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
 
 # reduce 32 omitted
 
 # reduce 33 omitted
 
-module_eval(<<'.,.,', 'parser.y', 76)
-  def _reduce_34(val, _values, result)
+# reduce 34 omitted
+
+module_eval(<<'.,.,', 'parser.y', 80)
+  def _reduce_35(val, _values, result)
               @grammar.set_union(
             Grammar::Code::NoReferenceCode.new(type: :union, token_code: val[1]),
             val[1].line
@@ -1445,8 +1458,8 @@ module_eval(<<'.,.,', 'parser.y', 76)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 83)
-  def _reduce_35(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 87)
+  def _reduce_36(val, _values, result)
               @grammar.add_destructor(
             ident_or_tags: val[2].flatten,
             token_code: val[1],
@@ -1457,8 +1470,8 @@ module_eval(<<'.,.,', 'parser.y', 83)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 91)
-  def _reduce_36(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 95)
+  def _reduce_37(val, _values, result)
               @grammar.add_printer(
             ident_or_tags: val[2].flatten,
             token_code: val[1],
@@ -1469,8 +1482,8 @@ module_eval(<<'.,.,', 'parser.y', 91)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 99)
-  def _reduce_37(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 103)
+  def _reduce_38(val, _values, result)
               @grammar.add_error_token(
             ident_or_tags: val[2].flatten,
             token_code: val[1],
@@ -1481,17 +1494,9 @@ module_eval(<<'.,.,', 'parser.y', 99)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 107)
-  def _reduce_38(val, _values, result)
-              @grammar.after_shift = val[1]
-
-    result
-  end
-.,.,
-
 module_eval(<<'.,.,', 'parser.y', 111)
   def _reduce_39(val, _values, result)
-              @grammar.before_reduce = val[1]
+              @grammar.after_shift = val[1]
 
     result
   end
@@ -1499,7 +1504,7 @@ module_eval(<<'.,.,', 'parser.y', 111)
 
 module_eval(<<'.,.,', 'parser.y', 115)
   def _reduce_40(val, _values, result)
-              @grammar.after_reduce = val[1]
+              @grammar.before_reduce = val[1]
 
     result
   end
@@ -1507,7 +1512,7 @@ module_eval(<<'.,.,', 'parser.y', 115)
 
 module_eval(<<'.,.,', 'parser.y', 119)
   def _reduce_41(val, _values, result)
-              @grammar.after_shift_error_token = val[1]
+              @grammar.after_reduce = val[1]
 
     result
   end
@@ -1515,16 +1520,24 @@ module_eval(<<'.,.,', 'parser.y', 119)
 
 module_eval(<<'.,.,', 'parser.y', 123)
   def _reduce_42(val, _values, result)
+              @grammar.after_shift_error_token = val[1]
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 127)
+  def _reduce_43(val, _values, result)
               @grammar.after_pop_stack = val[1]
 
     result
   end
 .,.,
 
-# reduce 43 omitted
+# reduce 44 omitted
 
-module_eval(<<'.,.,', 'parser.y', 130)
-  def _reduce_44(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 134)
+  def _reduce_45(val, _values, result)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               @grammar.add_type(id: id, tag: hash[:tag])
@@ -1535,8 +1548,8 @@ module_eval(<<'.,.,', 'parser.y', 130)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 138)
-  def _reduce_45(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 142)
+  def _reduce_46(val, _values, result)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               if @grammar.find_term_by_s_value(id.s_value)
@@ -1551,8 +1564,8 @@ module_eval(<<'.,.,', 'parser.y', 138)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 150)
-  def _reduce_46(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 154)
+  def _reduce_47(val, _values, result)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id)
@@ -1565,8 +1578,8 @@ module_eval(<<'.,.,', 'parser.y', 150)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 160)
-  def _reduce_47(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 164)
+  def _reduce_48(val, _values, result)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id)
@@ -1579,8 +1592,8 @@ module_eval(<<'.,.,', 'parser.y', 160)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 170)
-  def _reduce_48(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 174)
+  def _reduce_49(val, _values, result)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id)
@@ -1593,8 +1606,8 @@ module_eval(<<'.,.,', 'parser.y', 170)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 180)
-  def _reduce_49(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 184)
+  def _reduce_50(val, _values, result)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id)
@@ -1607,26 +1620,26 @@ module_eval(<<'.,.,', 'parser.y', 180)
   end
 .,.,
 
-# reduce 50 omitted
-
 # reduce 51 omitted
 
-module_eval(<<'.,.,', 'parser.y', 204)
-  def _reduce_52(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
+# reduce 52 omitted
 
-module_eval(<<'.,.,', 'parser.y', 204)
+module_eval(<<'.,.,', 'parser.y', 208)
   def _reduce_53(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 192)
+module_eval(<<'.,.,', 'parser.y', 208)
   def _reduce_54(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 196)
+  def _reduce_55(val, _values, result)
               val[1].each {|token_declaration|
             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[0], replace: true)
           }
@@ -1635,8 +1648,8 @@ module_eval(<<'.,.,', 'parser.y', 192)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 198)
-  def _reduce_55(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 202)
+  def _reduce_56(val, _values, result)
               val[2].each {|token_declaration|
             @grammar.add_term(id: token_declaration[0], alias_name: token_declaration[2], token_id: token_declaration[1], tag: val[1], replace: true)
           }
@@ -1645,19 +1658,19 @@ module_eval(<<'.,.,', 'parser.y', 198)
   end
 .,.,
 
-# reduce 56 omitted
-
 # reduce 57 omitted
 
-module_eval(<<'.,.,', 'parser.y', 203)
-  def _reduce_58(val, _values, result)
+# reduce 58 omitted
+
+module_eval(<<'.,.,', 'parser.y', 207)
+  def _reduce_59(val, _values, result)
      result = val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 208)
-  def _reduce_59(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 212)
+  def _reduce_60(val, _values, result)
               rule = Grammar::Parameterized::Rule.new(val[1].s_value, val[3], val[7], tag: val[5])
           @grammar.add_parameterized_rule(rule)
 
@@ -1665,8 +1678,8 @@ module_eval(<<'.,.,', 'parser.y', 208)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 215)
-  def _reduce_60(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 219)
+  def _reduce_61(val, _values, result)
               rule = Grammar::Parameterized::Rule.new(val[2].s_value, [], val[4], is_inline: true)
           @grammar.add_parameterized_rule(rule)
 
@@ -1674,8 +1687,8 @@ module_eval(<<'.,.,', 'parser.y', 215)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 220)
-  def _reduce_61(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 224)
+  def _reduce_62(val, _values, result)
               rule = Grammar::Parameterized::Rule.new(val[2].s_value, val[4], val[7], is_inline: true)
           @grammar.add_parameterized_rule(rule)
 
@@ -1683,22 +1696,22 @@ module_eval(<<'.,.,', 'parser.y', 220)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 225)
-  def _reduce_62(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 229)
+  def _reduce_63(val, _values, result)
      result = [val[0]]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 226)
-  def _reduce_63(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 230)
+  def _reduce_64(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 231)
-  def _reduce_64(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 235)
+  def _reduce_65(val, _values, result)
               builder = val[0]
           result = [builder]
 
@@ -1706,8 +1719,8 @@ module_eval(<<'.,.,', 'parser.y', 231)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 236)
-  def _reduce_65(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 240)
+  def _reduce_66(val, _values, result)
               builder = val[2]
           result = val[0].append(builder)
 
@@ -1715,16 +1728,16 @@ module_eval(<<'.,.,', 'parser.y', 236)
   end
 .,.,
 
-# reduce 66 omitted
-
 # reduce 67 omitted
 
 # reduce 68 omitted
 
 # reduce 69 omitted
 
-module_eval(<<'.,.,', 'parser.y', 243)
-  def _reduce_70(val, _values, result)
+# reduce 70 omitted
+
+module_eval(<<'.,.,', 'parser.y', 247)
+  def _reduce_71(val, _values, result)
               reset_precs
           result = Grammar::Parameterized::Rhs.new
 
@@ -1732,8 +1745,8 @@ module_eval(<<'.,.,', 'parser.y', 243)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 248)
-  def _reduce_71(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 252)
+  def _reduce_72(val, _values, result)
               token = val[1]
           token.alias_name = val[2]
           builder = val[0]
@@ -1744,8 +1757,8 @@ module_eval(<<'.,.,', 'parser.y', 248)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 256)
-  def _reduce_72(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 260)
+  def _reduce_73(val, _values, result)
               builder = val[0]
           builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], location: @lexer.location, args: [val[1]])
           result = builder
@@ -1754,8 +1767,8 @@ module_eval(<<'.,.,', 'parser.y', 256)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 262)
-  def _reduce_73(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 266)
+  def _reduce_74(val, _values, result)
               builder = val[0]
           builder.symbols << Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[3], lhs_tag: val[5])
           result = builder
@@ -1764,8 +1777,8 @@ module_eval(<<'.,.,', 'parser.y', 262)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 268)
-  def _reduce_74(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 272)
+  def _reduce_75(val, _values, result)
               user_code = val[1]
           user_code.alias_name = val[2]
           builder = val[0]
@@ -1776,8 +1789,8 @@ module_eval(<<'.,.,', 'parser.y', 268)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 276)
-  def _reduce_75(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 280)
+  def _reduce_76(val, _values, result)
               sym = @grammar.find_symbol_by_id!(val[2])
           @prec_seen = true
           builder = val[0]
@@ -1788,33 +1801,33 @@ module_eval(<<'.,.,', 'parser.y', 276)
   end
 .,.,
 
-# reduce 76 omitted
-
 # reduce 77 omitted
 
-module_eval(<<'.,.,', 'parser.y', 283)
-  def _reduce_78(val, _values, result)
+# reduce 78 omitted
+
+module_eval(<<'.,.,', 'parser.y', 287)
+  def _reduce_79(val, _values, result)
      result = val[0].s_value if val[0]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 297)
-  def _reduce_79(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 297)
+module_eval(<<'.,.,', 'parser.y', 301)
   def _reduce_80(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 288)
+module_eval(<<'.,.,', 'parser.y', 301)
   def _reduce_81(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 292)
+  def _reduce_82(val, _values, result)
               result = if val[0]
             [{tag: val[0], tokens: val[1]}]
           else
@@ -1825,28 +1838,20 @@ module_eval(<<'.,.,', 'parser.y', 288)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 294)
-  def _reduce_82(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 298)
+  def _reduce_83(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-# reduce 83 omitted
-
 # reduce 84 omitted
 
-module_eval(<<'.,.,', 'parser.y', 303)
-  def _reduce_85(val, _values, result)
-              begin_c_declaration("}")
-
-    result
-  end
-.,.,
+# reduce 85 omitted
 
 module_eval(<<'.,.,', 'parser.y', 307)
   def _reduce_86(val, _values, result)
-              end_c_declaration
+              begin_c_declaration("}")
 
     result
   end
@@ -1854,62 +1859,68 @@ module_eval(<<'.,.,', 'parser.y', 307)
 
 module_eval(<<'.,.,', 'parser.y', 311)
   def _reduce_87(val, _values, result)
+              end_c_declaration
+
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 315)
+  def _reduce_88(val, _values, result)
               result = val[2]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 320)
-  def _reduce_88(val, _values, result)
-    result = val[1] ? val[1].unshift(val[0]) : val
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parser.y', 320)
+module_eval(<<'.,.,', 'parser.y', 324)
   def _reduce_89(val, _values, result)
     result = val[1] ? val[1].unshift(val[0]) : val
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 315)
+module_eval(<<'.,.,', 'parser.y', 324)
   def _reduce_90(val, _values, result)
+    result = val[1] ? val[1].unshift(val[0]) : val
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parser.y', 319)
+  def _reduce_91(val, _values, result)
      result = [{tag: nil, tokens: val[0]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 316)
-  def _reduce_91(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 320)
+  def _reduce_92(val, _values, result)
      result = [{tag: val[0], tokens: val[1]}]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 317)
-  def _reduce_92(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 321)
+  def _reduce_93(val, _values, result)
      result = val[0].append({tag: val[1], tokens: val[2]})
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 320)
-  def _reduce_93(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 324)
+  def _reduce_94(val, _values, result)
      on_action_error("ident after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 321)
-  def _reduce_94(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 325)
+  def _reduce_95(val, _values, result)
      on_action_error("char after %prec", val[0]) if @prec_seen
     result
   end
 .,.,
-
-# reduce 95 omitted
 
 # reduce 96 omitted
 
@@ -1917,8 +1928,10 @@ module_eval(<<'.,.,', 'parser.y', 321)
 
 # reduce 98 omitted
 
-module_eval(<<'.,.,', 'parser.y', 330)
-  def _reduce_99(val, _values, result)
+# reduce 99 omitted
+
+module_eval(<<'.,.,', 'parser.y', 334)
+  def _reduce_100(val, _values, result)
               lhs = val[0]
           lhs.alias_name = val[1]
           val[3].each do |builder|
@@ -1931,8 +1944,8 @@ module_eval(<<'.,.,', 'parser.y', 330)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 342)
-  def _reduce_100(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 346)
+  def _reduce_101(val, _values, result)
               builder = val[0]
           if !builder.line
             builder.line = @lexer.line - 1
@@ -1943,8 +1956,8 @@ module_eval(<<'.,.,', 'parser.y', 342)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 350)
-  def _reduce_101(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 354)
+  def _reduce_102(val, _values, result)
               builder = val[2]
           if !builder.line
             builder.line = @lexer.line - 1
@@ -1955,8 +1968,8 @@ module_eval(<<'.,.,', 'parser.y', 350)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 360)
-  def _reduce_102(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 364)
+  def _reduce_103(val, _values, result)
               reset_precs
           result = @grammar.create_rule_builder(@rule_counter, @midrule_action_counter)
 
@@ -1964,8 +1977,8 @@ module_eval(<<'.,.,', 'parser.y', 360)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 365)
-  def _reduce_103(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 369)
+  def _reduce_104(val, _values, result)
               token = val[1]
           token.alias_name = val[2]
           builder = val[0]
@@ -1976,8 +1989,8 @@ module_eval(<<'.,.,', 'parser.y', 365)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 373)
-  def _reduce_104(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 377)
+  def _reduce_105(val, _values, result)
               token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[2], alias_name: val[3], location: @lexer.location, args: [val[1]], lhs_tag: val[4])
           builder = val[0]
           builder.add_rhs(token)
@@ -1988,8 +2001,8 @@ module_eval(<<'.,.,', 'parser.y', 373)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 381)
-  def _reduce_105(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 385)
+  def _reduce_106(val, _values, result)
               token = Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, alias_name: val[5], location: @lexer.location, args: val[3], lhs_tag: val[6])
           builder = val[0]
           builder.add_rhs(token)
@@ -2000,8 +2013,8 @@ module_eval(<<'.,.,', 'parser.y', 381)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 389)
-  def _reduce_106(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 393)
+  def _reduce_107(val, _values, result)
               user_code = val[1]
           user_code.alias_name = val[2]
           user_code.tag = val[3]
@@ -2013,8 +2026,8 @@ module_eval(<<'.,.,', 'parser.y', 389)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 398)
-  def _reduce_107(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 402)
+  def _reduce_108(val, _values, result)
               sym = @grammar.find_symbol_by_id!(val[2])
           @prec_seen = true
           builder = val[0]
@@ -2025,33 +2038,33 @@ module_eval(<<'.,.,', 'parser.y', 398)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 406)
-  def _reduce_108(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 410)
+  def _reduce_109(val, _values, result)
      result = "option"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 407)
-  def _reduce_109(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 411)
+  def _reduce_110(val, _values, result)
      result = "nonempty_list"
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 408)
-  def _reduce_110(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 412)
+  def _reduce_111(val, _values, result)
      result = "list"
     result
   end
 .,.,
 
-# reduce 111 omitted
-
 # reduce 112 omitted
 
-module_eval(<<'.,.,', 'parser.y', 413)
-  def _reduce_113(val, _values, result)
+# reduce 113 omitted
+
+module_eval(<<'.,.,', 'parser.y', 417)
+  def _reduce_114(val, _values, result)
               result = if val[1]
             [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[1].s_value, location: @lexer.location, args: val[0])]
           else
@@ -2062,22 +2075,22 @@ module_eval(<<'.,.,', 'parser.y', 413)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 419)
-  def _reduce_114(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 423)
+  def _reduce_115(val, _values, result)
      result = val[0].append(val[2])
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 420)
-  def _reduce_115(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 424)
+  def _reduce_116(val, _values, result)
      result = [Lrama::Lexer::Token::InstantiateRule.new(s_value: val[0].s_value, location: @lexer.location, args: val[2])]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 425)
-  def _reduce_116(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 429)
+  def _reduce_117(val, _values, result)
               if @prec_seen
             on_action_error("multiple User_code after %prec", val[0]) if @code_after_prec
             @code_after_prec = true
@@ -2088,31 +2101,31 @@ module_eval(<<'.,.,', 'parser.y', 425)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 433)
-  def _reduce_117(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 437)
+  def _reduce_118(val, _values, result)
               end_c_declaration
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 437)
-  def _reduce_118(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 441)
+  def _reduce_119(val, _values, result)
               result = val[2]
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 440)
-  def _reduce_119(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 444)
+  def _reduce_120(val, _values, result)
      result = val[1].s_value
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 445)
-  def _reduce_120(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 449)
+  def _reduce_121(val, _values, result)
               begin_c_declaration('\Z')
           @grammar.epilogue_first_lineno = @lexer.line + 1
 
@@ -2120,16 +2133,14 @@ module_eval(<<'.,.,', 'parser.y', 445)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 450)
-  def _reduce_121(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 454)
+  def _reduce_122(val, _values, result)
               end_c_declaration
           @grammar.epilogue = val[2].s_value
 
     result
   end
 .,.,
-
-# reduce 122 omitted
 
 # reduce 123 omitted
 
@@ -2139,8 +2150,10 @@ module_eval(<<'.,.,', 'parser.y', 450)
 
 # reduce 126 omitted
 
-module_eval(<<'.,.,', 'parser.y', 461)
-  def _reduce_127(val, _values, result)
+# reduce 127 omitted
+
+module_eval(<<'.,.,', 'parser.y', 465)
+  def _reduce_128(val, _values, result)
      result = Lrama::Lexer::Token::Ident.new(s_value: val[0])
     result
   end

--- a/parser.y
+++ b/parser.y
@@ -36,6 +36,10 @@ rule
         {
           @grammar.define[val[1].s_value] = val[2]&.s_value
         }
+    | "%define" variable "{" value "}"
+        {
+          @grammar.define[val[1].s_value] = val[3]&.s_value
+        }
     | "%param" param+
     | "%lex-param" param+
         {

--- a/spec/fixtures/common/basic.y
+++ b/spec/fixtures/common/basic.y
@@ -11,6 +11,7 @@
 %expect 0
 %define api.pure
 %define parse.error verbose
+%define api.prefix {prefix}
 
 %printer {
     print_int();

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe Lrama::Lexer do
         expect(lexer.next_token).to eq(['%define', '%define'])
         expect(lexer.next_token).to eq([:IDENTIFIER, token_class::Ident.new(s_value: 'parse.error')])
         expect(lexer.next_token).to eq([:IDENTIFIER, token_class::Ident.new(s_value: 'verbose')])
+        expect(lexer.next_token).to eq(['%define', '%define'])
+        expect(lexer.next_token).to eq([:IDENTIFIER, token_class::Ident.new(s_value: 'api.prefix')])
+        expect(lexer.next_token).to eq(['{', '{'])
+        expect(lexer.next_token).to eq([:IDENTIFIER, token_class::Ident.new(s_value: 'prefix')])
+        expect(lexer.next_token).to eq(['}', '}'])
         expect(lexer.next_token).to eq(['%printer', '%printer'])
         expect(lexer.next_token).to eq(['{', '{'])
 
@@ -37,7 +42,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n    print_int();\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 15, first_column: 10, last_line: 17, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 16, first_column: 10, last_line: 18, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -49,7 +54,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n    print_token();\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 18, first_column: 10, last_line: 20, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 19, first_column: 10, last_line: 21, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -62,7 +67,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: 'struct lex_params *p')])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 22, first_column: 12, last_line: 22, last_column: 32)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 23, first_column: 12, last_line: 23, last_column: 32)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -73,7 +78,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: 'struct parse_params *p')])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 23, first_column: 14, last_line: 23, last_column: 36)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 24, first_column: 14, last_line: 24, last_column: 36)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -84,7 +89,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n    initial_action_func(@$);\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 26, first_column: 1, last_line: 28, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 27, first_column: 1, last_line: 29, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -96,7 +101,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: "\n    int i;\n    long l;\n    char *str;\n")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 30, first_column: 8, last_line: 34, last_column: 0)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 31, first_column: 8, last_line: 35, last_column: 0)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -175,7 +180,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 1 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 63, first_column: 11, last_line: 63, last_column: 19)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 64, first_column: 11, last_line: 64, last_column: 19)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -187,7 +192,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 2 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 64, first_column: 23, last_line: 64, last_column: 31)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 65, first_column: 23, last_line: 65, last_column: 31)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -200,7 +205,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 3 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 64, first_column: 58, last_line: 64, last_column: 66)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 65, first_column: 58, last_line: 65, last_column: 66)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -214,7 +219,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 4 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 65, first_column: 23, last_line: 65, last_column: 31)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 66, first_column: 23, last_line: 66, last_column: 31)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])
@@ -227,7 +232,7 @@ RSpec.describe Lrama::Lexer do
         lexer.end_symbol = '}'
         token = lexer.next_token
         expect(token).to eq([:C_DECLARATION, token_class::UserCode.new(s_value: " code 5 ")])
-        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 65, first_column: 58, last_line: 65, last_column: 66)
+        expect(token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 66, first_column: 58, last_line: 66, last_column: 66)
         lexer.status = :initial
 
         expect(lexer.next_token).to eq(['}', '}'])

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -117,17 +117,17 @@ RSpec.describe Lrama::Parser do
       CODE
 
       expect(grammar.expect).to eq(0)
-      expect(grammar.define).to eq({'api.pure' => nil, 'parse.error' => 'verbose'})
+      expect(grammar.define).to eq({'api.prefix' => 'prefix', 'api.pure' => nil, 'parse.error' => 'verbose'})
       expect(grammar.printers).to eq([
         Printer.new(
           ident_or_tags: [T::Tag.new(s_value: "<int>")],
           token_code: T::UserCode.new(s_value: "\n    print_int();\n"),
-          lineno: 15
+          lineno: 16
         ),
         Printer.new(
           ident_or_tags: [T::Ident.new(s_value: "tNUMBER"), T::Ident.new(s_value: "tSTRING")],
           token_code: T::UserCode.new(s_value: "\n    print_token();\n"),
-          lineno: 18
+          lineno: 19
         ),
       ])
       expect(grammar.lex_param).to eq("struct lex_params *p")
@@ -176,7 +176,7 @@ RSpec.describe Lrama::Parser do
           [
             T::Ident.new(s_value: "class"),
           ],
-          57,
+          58,
         ],
         [
           T::Ident.new(s_value: "program"),
@@ -184,7 +184,7 @@ RSpec.describe Lrama::Parser do
             T::Char.new(s_value: "'+'"),
             T::Ident.new(s_value: "strings_1"),
           ],
-          58,
+          59,
         ],
         [
           T::Ident.new(s_value: "program"),
@@ -192,7 +192,7 @@ RSpec.describe Lrama::Parser do
             T::Char.new(s_value: "'-'"),
             T::Ident.new(s_value: "strings_2"),
           ],
-          59,
+          60,
         ],
         [
           T::Ident.new(s_value: "class"),
@@ -203,7 +203,7 @@ RSpec.describe Lrama::Parser do
             grammar.find_symbol_by_s_value!("tPLUS"),
             T::UserCode.new(s_value: " code 1 "),
           ],
-          62,
+          63,
         ],
         [
           T::Ident.new(s_value: "class"),
@@ -216,7 +216,7 @@ RSpec.describe Lrama::Parser do
             T::UserCode.new(s_value: " code 3 "),
             grammar.find_symbol_by_s_value!("tEQ"),
           ],
-          64,
+          65,
         ],
         [
           T::Ident.new(s_value: "class"),
@@ -229,35 +229,35 @@ RSpec.describe Lrama::Parser do
             T::UserCode.new(s_value: " code 5 "),
             grammar.find_symbol_by_s_value!("'>'"),
           ],
-          65,
+          66,
         ],
         [
           T::Ident.new(s_value: "strings_1"),
           [
             T::Ident.new(s_value: "string_1"),
           ],
-          68,
+          69,
         ],
         [
           T::Ident.new(s_value: "strings_2"),
           [
             T::Ident.new(s_value: "string_1"),
           ],
-          71,
+          72,
         ],
         [
           T::Ident.new(s_value: "strings_2"),
           [
             T::Ident.new(s_value: "string_2"),
           ],
-          72,
+          73,
         ],
         [
           T::Ident.new(s_value: "string_1"),
           [
             T::Ident.new(s_value: "string"),
           ],
-          75,
+          76,
         ],
         [
           T::Ident.new(s_value: "string_2"),
@@ -265,21 +265,21 @@ RSpec.describe Lrama::Parser do
             T::Ident.new(s_value: "string"),
             T::Char.new(s_value: "'+'"),
           ],
-          78,
+          79,
         ],
         [
           T::Ident.new(s_value: "string"),
           [
             T::Ident.new(s_value: "tSTRING")
           ],
-          81,
+          82,
         ],
         [
           T::Ident.new(s_value: "unused"),
           [
             T::Ident.new(s_value: "tNUMBER")
           ],
-          84,
+          85,
         ],
       ])
       expect(grammar.rules).to eq([
@@ -293,7 +293,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("EOI"),
-          lineno: 57,
+          lineno: 58,
         ),
         Rule.new(
           id: 1,
@@ -304,7 +304,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: nil,
-          lineno: 57,
+          lineno: 58,
         ),
         Rule.new(
           id: 2,
@@ -316,7 +316,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("'+'"),
-          lineno: 58,
+          lineno: 59,
         ),
         Rule.new(
           id: 3,
@@ -328,7 +328,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("'-'"),
-          lineno: 59,
+          lineno: 60,
         ),
         Rule.new(
           id: 4,
@@ -341,7 +341,7 @@ RSpec.describe Lrama::Parser do
           token_code: T::UserCode.new(s_value: " code 1 "),
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("tPLUS"),
-          lineno: 62,
+          lineno: 63,
         ),
         Rule.new(
           id: 5,
@@ -351,7 +351,7 @@ RSpec.describe Lrama::Parser do
           position_in_original_rule_rhs: 1,
           nullable: true,
           precedence_sym: nil,
-          lineno: 64,
+          lineno: 65,
         ),
         Rule.new(
           id: 6,
@@ -361,7 +361,7 @@ RSpec.describe Lrama::Parser do
           position_in_original_rule_rhs: 5,
           nullable: true,
           precedence_sym: nil,
-          lineno: 64,
+          lineno: 65,
         ),
         Rule.new(
           id: 7,
@@ -377,7 +377,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("tEQ"),
-          lineno: 64,
+          lineno: 65,
         ),
         Rule.new(
           id: 8,
@@ -387,7 +387,7 @@ RSpec.describe Lrama::Parser do
           position_in_original_rule_rhs: 1,
           nullable: true,
           precedence_sym: nil,
-          lineno: 65,
+          lineno: 66,
         ),
         Rule.new(
           id: 9,
@@ -397,7 +397,7 @@ RSpec.describe Lrama::Parser do
           position_in_original_rule_rhs: 5,
           nullable: true,
           precedence_sym: nil,
-          lineno: 65,
+          lineno: 66,
         ),
         Rule.new(
           id: 10,
@@ -413,7 +413,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("'>'"),
-          lineno: 65,
+          lineno: 66,
         ),
         Rule.new(
           id: 11,
@@ -424,7 +424,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: nil,
-          lineno: 68,
+          lineno: 69,
         ),
         Rule.new(
           id: 12,
@@ -435,7 +435,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: nil,
-          lineno: 71,
+          lineno: 72,
         ),
         Rule.new(
           id: 13,
@@ -446,7 +446,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: nil,
-          lineno: 72,
+          lineno: 73,
         ),
         Rule.new(
           id: 14,
@@ -457,7 +457,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: nil,
-          lineno: 75,
+          lineno: 76,
         ),
         Rule.new(
           id: 15,
@@ -469,7 +469,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("'+'"),
-          lineno: 78,
+          lineno: 79,
         ),
         Rule.new(
           id: 16,
@@ -480,7 +480,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("tSTRING"),
-          lineno: 81,
+          lineno: 82,
         ),
         Rule.new(
           id: 17,
@@ -491,7 +491,7 @@ RSpec.describe Lrama::Parser do
           token_code: nil,
           nullable: false,
           precedence_sym: grammar.find_symbol_by_s_value!("tNUMBER"),
-          lineno: 84,
+          lineno: 85,
         ),
       ])
     end


### PR DESCRIPTION
Fixes: https://github.com/ruby/lrama/issues/671

Add following style %define
```yacc
%define variable {value}
```