### PR TITLE
Add support for reporting Rule Usage Frequency

### DIFF
--- a/lib/lrama/grammar/symbol.rb
+++ b/lib/lrama/grammar/symbol.rb
@@ -136,13 +136,13 @@ module Lrama
           alias_name
         when (term? && 0 < token_id && token_id < 128)
           # YYSYMBOL_3_backslash_, YYSYMBOL_14_
-          alias_name || name
+          display_name
         when midrule?
           # YYSYMBOL_21_1
           name
         else
           # YYSYMBOL_keyword_class, YYSYMBOL_strings_1
-          alias_name || name
+          display_name
         end
       end
     end

--- a/lib/lrama/grammar/symbol.rb
+++ b/lib/lrama/grammar/symbol.rb
@@ -112,7 +112,7 @@ module Lrama
           name = number.to_s + display_name
         when term? && id.is_a?(Lrama::Lexer::Token::Ident)
           name = id.s_value
-        when nterm? && (id.s_value.include?("$") || id.s_value.include?("@"))
+        when midrule?
           name = number.to_s + id.s_value
         when nterm?
           name = id.s_value
@@ -137,7 +137,7 @@ module Lrama
         when (term? && 0 < token_id && token_id < 128)
           # YYSYMBOL_3_backslash_, YYSYMBOL_14_
           alias_name || id.s_value
-        when id.s_value.include?("$") || id.s_value.include?("@")
+        when midrule?
           # YYSYMBOL_21_1
           id.s_value
         else

--- a/lib/lrama/grammar/symbol.rb
+++ b/lib/lrama/grammar/symbol.rb
@@ -84,7 +84,7 @@ module Lrama
       def midrule?
         return false if term?
 
-        id.s_value.include?("$") || id.s_value.include?("@")
+        name.include?("$") || name.include?("@")
       end
 
       # @rbs () -> String
@@ -105,22 +105,22 @@ module Lrama
       def enum_name
         case
         when accept_symbol?
-          name = "YYACCEPT"
+          res = "YYACCEPT"
         when eof_symbol?
-          name = "YYEOF"
+          res = "YYEOF"
         when term? && id.is_a?(Lrama::Lexer::Token::Char)
-          name = number.to_s + display_name
+          res = number.to_s + display_name
         when term? && id.is_a?(Lrama::Lexer::Token::Ident)
-          name = id.s_value
+          res = name
         when midrule?
-          name = number.to_s + id.s_value
+          res = number.to_s + name
         when nterm?
-          name = id.s_value
+          res = name
         else
           raise "Unexpected #{self}"
         end
 
-        "YYSYMBOL_" + name.gsub(/\W+/, "_")
+        "YYSYMBOL_" + res.gsub(/\W+/, "_")
       end
 
       # comment for yysymbol_kind_t
@@ -130,19 +130,19 @@ module Lrama
         case
         when accept_symbol?
           # YYSYMBOL_YYACCEPT
-          id.s_value
+          name
         when eof_symbol?
           # YYEOF
           alias_name
         when (term? && 0 < token_id && token_id < 128)
           # YYSYMBOL_3_backslash_, YYSYMBOL_14_
-          alias_name || id.s_value
+          alias_name || name
         when midrule?
           # YYSYMBOL_21_1
-          id.s_value
+          name
         else
           # YYSYMBOL_keyword_class, YYSYMBOL_strings_1
-          alias_name || id.s_value
+          alias_name || name
         end
       end
     end

--- a/lib/lrama/grammar/symbol.rb
+++ b/lib/lrama/grammar/symbol.rb
@@ -80,9 +80,21 @@ module Lrama
         !!@accept_symbol
       end
 
+      # @rbs () -> bool
+      def midrule?
+        return false if term?
+
+        id.s_value.include?("$") || id.s_value.include?("@")
+      end
+
+      # @rbs () -> String
+      def name
+        id.s_value
+      end
+
       # @rbs () -> String
       def display_name
-        alias_name || id.s_value
+        alias_name || name
       end
 
       # name for yysymbol_kind_t

--- a/lib/lrama/reporter/rules.rb
+++ b/lib/lrama/reporter/rules.rb
@@ -15,6 +15,17 @@ module Lrama
 
         used_rules = states.rules.flat_map(&:rhs)
 
+        unless used_rules.empty?
+          io << "Rule Usage Frequency\n\n"
+          frequency_counts = used_rules.each_with_object(Hash.new(0)) { |rule, counts| counts[rule] += 1 }
+
+          frequency_counts
+            .select { |rule,| !rule.midrule? }
+            .sort_by { |rule, count| [-count, rule.name] }
+            .each_with_index { |(rule, count), i| io << sprintf("%5d %s (%d times)", i, rule.name, count) << "\n" }
+          io << "\n\n"
+        end
+
         unused_rules = states.rules.map(&:lhs).select do |rule|
           !used_rules.include?(rule) && rule.token_id != 0
         end

--- a/sig/generated/lrama/grammar/symbol.rbs
+++ b/sig/generated/lrama/grammar/symbol.rbs
@@ -64,6 +64,12 @@ module Lrama
       # @rbs () -> bool
       def accept_symbol?: () -> bool
 
+      # @rbs () -> bool
+      def midrule?: () -> bool
+
+      # @rbs () -> String
+      def name: () -> String
+
       # @rbs () -> String
       def display_name: () -> String
 

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -15,6 +15,26 @@ RSpec.describe Lrama::States do
       Lrama::Reporter.new(grammar: true, rules: true, terms: true, states: true, itemsets: true, lookaheads: true).report(io, states)
 
       expect(io.string).to eq(<<~STR)
+        Rule Usage Frequency
+
+            0 tSTRING (4 times)
+            1 keyword_class (3 times)
+            2 keyword_end (3 times)
+            3 '+' (2 times)
+            4 string (2 times)
+            5 string_1 (2 times)
+            6 '!' (1 times)
+            7 '-' (1 times)
+            8 '?' (1 times)
+            9 EOI (1 times)
+           10 class (1 times)
+           11 program (1 times)
+           12 string_2 (1 times)
+           13 strings_1 (1 times)
+           14 strings_2 (1 times)
+           15 tNUMBER (1 times)
+
+
         1 Unused Rules
 
             0 unused


### PR DESCRIPTION
This PR adds support for reporting Rule Usage Frequency.
I find this useful when taking a Report as a statistic.
I hope that knowing what terminators and non-terminators are used in the generation rules will give you some insight into the nature of the language.

```
Rule Usage Frequency

    0 tSTRING (4 times)
    1 keyword_class (3 times)
    2 keyword_end (3 times)
    3 '+' (2 times)
    4 string (2 times)
    5 string_1 (2 times)
    6 '!' (1 times)
    7 '-' (1 times)
    8 '?' (1 times)
    9 EOI (1 times)
   10 class (1 times)
   11 program (1 times)
   12 string_2 (1 times)
   13 strings_1 (1 times)
   14 strings_2 (1 times)
   15 tNUMBER (1 times)
```