### PR TITLE
Update minimum BASERUBY version to 3.1 in workflow configuration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -173,8 +173,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # '3.0' is the oldest living ruby version and minimal BASERUBY version
-        baseruby: ['head', '3.0']
+        # '3.1' is the oldest living ruby version and minimal BASERUBY version
+        baseruby: ['head', '3.1']
         ruby_branch: ['master']
     defaults:
       run:


### PR DESCRIPTION
Refs: https://github.com/ruby/ruby/pull/13321