### PR TITLE
Include grammar file name into the duration report labels

### DIFF
--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -660,6 +660,7 @@ module_eval(<<'...end parser.y/module_eval...', 'parser.y', 472)
 include Lrama::Tracer::Duration
 
 def initialize(text, path, debug = false, locations = false, define = {})
+  @path = path
   @grammar_file = Lrama::Lexer::GrammarFile.new(path, text)
   @yydebug = debug || define.key?('parse.trace')
   @rule_counter = Lrama::Grammar::Counter.new(0)
@@ -669,7 +670,8 @@ def initialize(text, path, debug = false, locations = false, define = {})
 end
 
 def parse
-  report_duration(:parse) do
+  message = "parse '#{File.basename(@path)}'"
+  report_duration(message) do
     @lexer = Lrama::Lexer.new(@grammar_file)
     @grammar = Lrama::Grammar.new(@rule_counter, @locations, @define)
     @precedence_number = 0

--- a/parser.y
+++ b/parser.y
@@ -473,6 +473,7 @@ end
 include Lrama::Tracer::Duration
 
 def initialize(text, path, debug = false, locations = false, define = {})
+  @path = path
   @grammar_file = Lrama::Lexer::GrammarFile.new(path, text)
   @yydebug = debug || define.key?('parse.trace')
   @rule_counter = Lrama::Grammar::Counter.new(0)
@@ -482,7 +483,8 @@ def initialize(text, path, debug = false, locations = false, define = {})
 end
 
 def parse
-  report_duration(:parse) do
+  message = "parse '#{File.basename(@path)}'"
+  report_duration(message) do
     @lexer = Lrama::Lexer.new(@grammar_file)
     @grammar = Lrama::Grammar.new(@rule_counter, @locations, @define)
     @precedence_number = 0


### PR DESCRIPTION
Before:

```
$ bundle exec exe/lrama --trace=time sample/calc.y
parse    0.00224 s
parse    0.00414 s
...
```

After:

```
$ bundle exec exe/lrama --trace=time sample/calc.y
parse 'calc.y'    0.00234 s
parse 'stdlib.y'    0.00439 s
...
```