### PR TITLE
Make `ReduceReduceConflict` to be plain object

### DIFF
--- a/lib/lrama/state/reduce_reduce_conflict.rb
+++ b/lib/lrama/state/reduce_reduce_conflict.rb
@@ -3,13 +3,17 @@
 
 module Lrama
   class State
-    class ReduceReduceConflict < Struct.new(:symbols, :reduce1, :reduce2, keyword_init: true)
-      # @rbs!
-      #   attr_accessor symbols: Array[Grammar::Symbol]
-      #   attr_accessor reduce1: State::Action::Reduce
-      #   attr_accessor reduce2: State::Action::Reduce
-      #
-      #   def initialize: (?symbols: Array[Grammar::Symbol], ?reduce1: State::Action::Reduce, ?reduce2: State::Action::Reduce) -> void
+    class ReduceReduceConflict
+      attr_reader :symbols #: Array[Grammar::Symbol]
+      attr_reader :reduce1 #: State::Action::Reduce
+      attr_reader :reduce2 #: State::Action::Reduce
+
+      # @rbs (symbols: Array[Grammar::Symbol], reduce1: State::Action::Reduce, reduce2: State::Action::Reduce) -> void
+      def initialize(symbols:, reduce1:, reduce2:)
+        @symbols = symbols
+        @reduce1 = reduce1
+        @reduce2 = reduce2
+      end
 
       # @rbs () -> :reduce_reduce
       def type

--- a/sig/generated/lrama/state/reduce_reduce_conflict.rbs
+++ b/sig/generated/lrama/state/reduce_reduce_conflict.rbs
@@ -3,13 +3,14 @@
 module Lrama
   class State
     class ReduceReduceConflict
-      attr_accessor symbols: Array[Grammar::Symbol]
+      attr_reader symbols: Array[Grammar::Symbol]
 
-      attr_accessor reduce1: State::Action::Reduce
+      attr_reader reduce1: State::Action::Reduce
 
-      attr_accessor reduce2: State::Action::Reduce
+      attr_reader reduce2: State::Action::Reduce
 
-      def initialize: (?symbols: Array[Grammar::Symbol], ?reduce1: State::Action::Reduce, ?reduce2: State::Action::Reduce) -> void
+      # @rbs (symbols: Array[Grammar::Symbol], reduce1: State::Action::Reduce, reduce2: State::Action::Reduce) -> void
+      def initialize: (symbols: Array[Grammar::Symbol], reduce1: State::Action::Reduce, reduce2: State::Action::Reduce) -> void
 
       # @rbs () -> :reduce_reduce
       def type: () -> :reduce_reduce


### PR DESCRIPTION
So that we can change `symbols`, `reduce1` and `reduce2` to be a mandatory argument.