### PR TITLE
Make `ShiftReduceConflict` to be plain object

### DIFF
--- a/lib/lrama/state/shift_reduce_conflict.rb
+++ b/lib/lrama/state/shift_reduce_conflict.rb
@@ -3,13 +3,17 @@
 
 module Lrama
   class State
-    class ShiftReduceConflict < Struct.new(:symbols, :shift, :reduce, keyword_init: true)
-      # @rbs!
-      #   attr_accessor symbols: Array[Grammar::Symbol]
-      #   attr_accessor shift: State::Action::Shift
-      #   attr_accessor reduce: State::Action::Reduce
-      #
-      #   def initialize: (?symbols: Array[Grammar::Symbol], ?shift: State::Action::Shift, ?reduce: State::Action::Reduce) -> void
+    class ShiftReduceConflict
+      attr_reader :symbols #: Array[Grammar::Symbol]
+      attr_reader :shift #: State::Action::Shift
+      attr_reader :reduce #: State::Action::Reduce
+
+      # @rbs (symbols: Array[Grammar::Symbol], shift: State::Action::Shift, reduce: State::Action::Reduce) -> void
+      def initialize(symbols:, shift:, reduce:)
+        @symbols = symbols
+        @shift = shift
+        @reduce = reduce
+      end
 
       # @rbs () -> :shift_reduce
       def type

--- a/sig/generated/lrama/state/shift_reduce_conflict.rbs
+++ b/sig/generated/lrama/state/shift_reduce_conflict.rbs
@@ -3,13 +3,14 @@
 module Lrama
   class State
     class ShiftReduceConflict
-      attr_accessor symbols: Array[Grammar::Symbol]
+      attr_reader symbols: Array[Grammar::Symbol]
 
-      attr_accessor shift: State::Action::Shift
+      attr_reader shift: State::Action::Shift
 
-      attr_accessor reduce: State::Action::Reduce
+      attr_reader reduce: State::Action::Reduce
 
-      def initialize: (?symbols: Array[Grammar::Symbol], ?shift: State::Action::Shift, ?reduce: State::Action::Reduce) -> void
+      # @rbs (symbols: Array[Grammar::Symbol], shift: State::Action::Shift, reduce: State::Action::Reduce) -> void
+      def initialize: (symbols: Array[Grammar::Symbol], shift: State::Action::Shift, reduce: State::Action::Reduce) -> void
 
       # @rbs () -> :shift_reduce
       def type: () -> :shift_reduce


### PR DESCRIPTION
So that we can change `symbols`, `shift` and `reduce` to be a mandatory argument.