### PR TITLE
Fix confusing error messages when specifying non-terminators for `%precedence`

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -161,24 +161,24 @@ module Lrama
       @types << Type.new(id: id, tag: tag)
     end
 
-    # @rbs (Grammar::Symbol sym, Integer precedence) -> Precedence
-    def add_nonassoc(sym, precedence)
-      set_precedence(sym, Precedence.new(type: :nonassoc, precedence: precedence))
+    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    def add_nonassoc(sym, precedence, lineno)
+      set_precedence(sym, Precedence.new(type: :nonassoc, precedence: precedence, lineno: lineno))
     end
 
-    # @rbs (Grammar::Symbol sym, Integer precedence) -> Precedence
-    def add_left(sym, precedence)
-      set_precedence(sym, Precedence.new(type: :left, precedence: precedence))
+    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    def add_left(sym, precedence, lineno)
+      set_precedence(sym, Precedence.new(type: :left, precedence: precedence, lineno: lineno))
     end
 
-    # @rbs (Grammar::Symbol sym, Integer precedence) -> Precedence
-    def add_right(sym, precedence)
-      set_precedence(sym, Precedence.new(type: :right, precedence: precedence))
+    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    def add_right(sym, precedence, lineno)
+      set_precedence(sym, Precedence.new(type: :right, precedence: precedence, lineno: lineno))
     end
 
-    # @rbs (Grammar::Symbol sym, Integer precedence) -> Precedence
-    def add_precedence(sym, precedence)
-      set_precedence(sym, Precedence.new(type: :precedence, precedence: precedence))
+    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    def add_precedence(sym, precedence, lineno)
+      set_precedence(sym, Precedence.new(type: :precedence, precedence: precedence, lineno: lineno))
     end
 
     # @rbs (Grammar::Symbol sym, Precedence precedence) -> (Precedence | bot)
@@ -253,6 +253,7 @@ module Lrama
     # @rbs () -> void
     def validate!
       @symbols_resolver.validate!
+      validate_precedence_is_term!
       validate_rule_lhs_is_nterm!
     end
 
@@ -505,6 +506,21 @@ module Lrama
         @sym_to_rules[key] ||= []
         @sym_to_rules[key] << rule
       end
+    end
+
+    # @rbs () -> void
+    def validate_precedence_is_term!
+      errors = [] #: Array[String]
+
+      @rules.each do |rule|
+        next if rule.lhs.precedence.nil?
+
+        errors << "[BUG] Precedence of #{rule.lhs.name} (line: #{rule.lhs.precedence.lineno}) is not term. It should be term."
+      end
+
+      return if errors.empty?
+
+      raise errors.join("\n")
     end
 
     # @rbs () -> void

--- a/lib/lrama/grammar/precedence.rb
+++ b/lib/lrama/grammar/precedence.rb
@@ -3,13 +3,14 @@
 
 module Lrama
   class Grammar
-    class Precedence < Struct.new(:type, :precedence, keyword_init: true)
+    class Precedence < Struct.new(:type, :precedence, :lineno, keyword_init: true)
       include Comparable
       # @rbs!
       #   attr_accessor type: ::Symbol
       #   attr_accessor precedence: Integer
+      #   attr_accessor lineno: Integer
       #
-      #   def initialize: (?type: ::Symbol, ?precedence: Integer) -> void
+      #   def initialize: (?type: ::Symbol, ?precedence: Integer, ?lineno: Integer) -> void
 
       # @rbs (Precedence other) -> Integer
       def <=>(other)

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -1598,7 +1598,7 @@ module_eval(<<'.,.,', 'parser.y', 156)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_left(sym, @precedence_number)
+              @grammar.add_left(sym, @precedence_number, @lexer.line)
             }
           }
           @precedence_number += 1
@@ -1612,7 +1612,7 @@ module_eval(<<'.,.,', 'parser.y', 166)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_right(sym, @precedence_number)
+              @grammar.add_right(sym, @precedence_number, @lexer.line)
             }
           }
           @precedence_number += 1
@@ -1626,7 +1626,7 @@ module_eval(<<'.,.,', 'parser.y', 176)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_precedence(sym, @precedence_number)
+              @grammar.add_precedence(sym, @precedence_number, sym.id.first_line)
             }
           }
           @precedence_number += 1
@@ -1640,7 +1640,7 @@ module_eval(<<'.,.,', 'parser.y', 186)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_nonassoc(sym, @precedence_number)
+              @grammar.add_nonassoc(sym, @precedence_number, @lexer.line)
             }
           }
           @precedence_number += 1

--- a/parser.y
+++ b/parser.y
@@ -157,7 +157,7 @@ rule
           val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_left(sym, @precedence_number)
+              @grammar.add_left(sym, @precedence_number, @lexer.line)
             }
           }
           @precedence_number += 1
@@ -167,7 +167,7 @@ rule
           val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_right(sym, @precedence_number)
+              @grammar.add_right(sym, @precedence_number, @lexer.line)
             }
           }
           @precedence_number += 1
@@ -177,7 +177,7 @@ rule
           val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_precedence(sym, @precedence_number)
+              @grammar.add_precedence(sym, @precedence_number, sym.id.first_line)
             }
           }
           @precedence_number += 1
@@ -187,7 +187,7 @@ rule
           val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_nonassoc(sym, @precedence_number)
+              @grammar.add_nonassoc(sym, @precedence_number, @lexer.line)
             }
           }
           @precedence_number += 1

--- a/sig/generated/lrama/grammar.rbs
+++ b/sig/generated/lrama/grammar.rbs
@@ -149,17 +149,17 @@ module Lrama
     # @rbs (id: Lexer::Token, tag: Lexer::Token::Tag) -> Array[Type]
     def add_type: (id: Lexer::Token, tag: Lexer::Token::Tag) -> Array[Type]
 
-    # @rbs (Grammar::Symbol sym, Integer precedence) -> Precedence
-    def add_nonassoc: (Grammar::Symbol sym, Integer precedence) -> Precedence
+    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    def add_nonassoc: (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
 
-    # @rbs (Grammar::Symbol sym, Integer precedence) -> Precedence
-    def add_left: (Grammar::Symbol sym, Integer precedence) -> Precedence
+    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    def add_left: (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
 
-    # @rbs (Grammar::Symbol sym, Integer precedence) -> Precedence
-    def add_right: (Grammar::Symbol sym, Integer precedence) -> Precedence
+    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    def add_right: (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
 
-    # @rbs (Grammar::Symbol sym, Integer precedence) -> Precedence
-    def add_precedence: (Grammar::Symbol sym, Integer precedence) -> Precedence
+    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    def add_precedence: (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
 
     # @rbs (Grammar::Symbol sym, Precedence precedence) -> (Precedence | bot)
     def set_precedence: (Grammar::Symbol sym, Precedence precedence) -> (Precedence | bot)
@@ -256,6 +256,9 @@ module Lrama
 
     # @rbs () -> Array[Rule]
     def fill_sym_to_rules: () -> Array[Rule]
+
+    # @rbs () -> void
+    def validate_precedence_is_term!: () -> void
 
     # @rbs () -> void
     def validate_rule_lhs_is_nterm!: () -> void

--- a/sig/generated/lrama/grammar/precedence.rbs
+++ b/sig/generated/lrama/grammar/precedence.rbs
@@ -9,7 +9,9 @@ module Lrama
 
       attr_accessor precedence: Integer
 
-      def initialize: (?type: ::Symbol, ?precedence: Integer) -> void
+      attr_accessor lineno: Integer
+
+      def initialize: (?type: ::Symbol, ?precedence: Integer, ?lineno: Integer) -> void
 
       # @rbs (Precedence other) -> Integer
       def <=>: (Precedence other) -> Integer

--- a/spec/lrama/grammar_spec.rb
+++ b/spec/lrama/grammar_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+RSpec.describe Lrama::Grammar do
+  let(:rule_counter) { Lrama::Grammar::Counter.new(0) }
+  let(:grammar) { described_class.new(rule_counter, false, {}) }
+
+  describe '#validate!' do
+    context 'when all rules have valid precedence' do
+      before do
+        lhs1 = Lrama::Grammar::Symbol.new(id: Lrama::Lexer::Token::Ident.new(s_value: 'expr'), term: false)
+        lhs2 = Lrama::Grammar::Symbol.new(id: Lrama::Lexer::Token::Ident.new(s_value: 'term'), term: false)
+        rule1 = Lrama::Grammar::Rule.new(
+          id: 1,
+          _lhs: Lrama::Lexer::Token::Ident.new(s_value: 'expr'),
+          _rhs: [],
+          token_code: nil,
+          lineno: 1
+        )
+        rule1.lhs = lhs1
+        rule2 = Lrama::Grammar::Rule.new(
+          id: 2,
+          _lhs: Lrama::Lexer::Token::Ident.new(s_value: 'term'),
+          _rhs: [],
+          token_code: nil,
+          lineno: 2
+        )
+        rule2.lhs = lhs2
+        grammar.rules = [rule1, rule2]
+      end
+
+      it 'does not raise error' do
+        expect { grammar.validate! }.not_to raise_error
+      end
+    end
+
+    context 'when a rule has precedence on lhs (which should be term)' do
+      before do
+        lhs_with_precedence = Lrama::Grammar::Symbol.new(
+          id: Lrama::Lexer::Token::Ident.new(s_value: 'expression'),
+          term: false
+        )
+        lhs_with_precedence.precedence = Lrama::Grammar::Precedence.new(type: :left, precedence: 1, lineno: 10)
+
+        rule = Lrama::Grammar::Rule.new(
+          id: 1,
+          _lhs: Lrama::Lexer::Token::Ident.new(s_value: 'expression'),
+          _rhs: [],
+          token_code: nil,
+          lineno: 1
+        )
+        rule.lhs = lhs_with_precedence
+
+        grammar.rules = [rule]
+      end
+
+      it 'raises error with message' do
+        expect { grammar.validate! }
+          .to raise_error('[BUG] Precedence of expression (line: 10) is not term. It should be term.')
+      end
+    end
+
+    context 'when multiple rules have precedence on lhs' do
+      before do
+        lhs1 = Lrama::Grammar::Symbol.new(
+          id: Lrama::Lexer::Token::Ident.new(s_value: 'expression'),
+          term: false
+        )
+        lhs2 = Lrama::Grammar::Symbol.new(
+          id: Lrama::Lexer::Token::Ident.new(s_value: 'statement'),
+          term: false
+        )
+        rule1 = Lrama::Grammar::Rule.new(
+          id: 1,
+          _lhs: Lrama::Lexer::Token::Ident.new(s_value: 'expression'),
+          _rhs: [],
+          token_code: nil,
+          lineno: 1
+        )
+        rule2 = Lrama::Grammar::Rule.new(
+          id: 2,
+          _lhs: Lrama::Lexer::Token::Ident.new(s_value: 'statement'),
+          _rhs: [],
+          token_code: nil,
+          lineno: 2
+        )
+        lhs1.precedence = Lrama::Grammar::Precedence.new(type: :left, precedence: 1, lineno: 10)
+        lhs2.precedence = Lrama::Grammar::Precedence.new(type: :right, precedence: 2, lineno: 20)
+        rule1.lhs = lhs1
+        rule2.lhs = lhs2
+        grammar.rules = [rule1, rule2]
+      end
+
+      it 'raises error with all messages joined' do
+        expected_message = "[BUG] Precedence of expression (line: 10) is not term. It should be term.\n" \
+                           '[BUG] Precedence of statement (line: 20) is not term. It should be term.'
+
+        expect { grammar.validate! }.to raise_error(expected_message)
+      end
+    end
+  end
+
+  context 'when a rule has term as lhs' do
+    before do
+      lhs_term = Lrama::Grammar::Symbol.new(
+        id: Lrama::Lexer::Token::Ident.new(s_value: '+'),
+        term: true
+      )
+      rule = Lrama::Grammar::Rule.new(
+        id: 1,
+        _lhs: Lrama::Lexer::Token::Ident.new(s_value: '+'),
+        _rhs: [],
+        rhs: [],
+        token_code: nil,
+        lineno: 15
+      )
+      rule.lhs = lhs_term
+      grammar.rules = [rule]
+    end
+
+    it 'raises error with message' do
+      expect { grammar.send(:validate!) }
+        .to raise_error('[BUG] LHS of + -> ε (line: 15) is term. It should be nterm.')
+    end
+  end
+
+  context 'when multiple rules have term as lhs' do
+    before do
+      lhs1 = Lrama::Grammar::Symbol.new(id: Lrama::Lexer::Token::Ident.new(s_value: '+'), term: true)
+      lhs2 = Lrama::Grammar::Symbol.new(id: Lrama::Lexer::Token::Ident.new(s_value: 'expr'), term: false)
+      lhs3 = Lrama::Grammar::Symbol.new(id: Lrama::Lexer::Token::Ident.new(s_value: '-'), term: true)
+      rule1 = Lrama::Grammar::Rule.new(
+        id: 1,
+        _lhs: Lrama::Lexer::Token::Ident.new(s_value: '+'),
+        rhs: [],
+        token_code: nil,
+        lineno: 15
+      )
+      rule2 = Lrama::Grammar::Rule.new(
+        id: 2,
+        _lhs: Lrama::Lexer::Token::Ident.new(s_value: 'expr'),
+        rhs: [],
+        token_code: nil,
+        lineno: 20
+      )
+      rule3 = Lrama::Grammar::Rule.new(
+        id: 3,
+        _lhs: Lrama::Lexer::Token::Ident.new(s_value: '-'),
+        rhs: [],
+        token_code: nil,
+        lineno: 25
+      )
+      rule1.lhs = lhs1
+      rule2.lhs = lhs2
+      rule3.lhs = lhs3
+
+      grammar.rules = [rule1, rule2, rule3]
+    end
+
+    it 'raises error with all messages joined' do
+      expected_message = "[BUG] LHS of + -> ε (line: 15) is term. It should be nterm.\n" \
+                          '[BUG] LHS of - -> ε (line: 25) is term. It should be nterm.'
+
+      expect { grammar.validate! }
+        .to raise_error(expected_message)
+    end
+  end
+
+  context 'when rules array is empty' do
+    it 'does not raise error' do
+      grammar.rules = []
+
+      expect { grammar.validate! }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Before:

```
❯ exe/lrama sample/json.y
[BUG] LHS of object -> '{' option_members '}' (line: 38) is term. It should be nterm.
```

After:

```
❯ exe/lrama sample/json.y
[BUG] Precedence of object (line: 28) is not term. It should be term.
```