### PR TITLE
Remove unnecessary raise statement in set_precedence method

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -183,7 +183,6 @@ module Lrama
 
     # @rbs (Grammar::Symbol sym, Precedence precedence) -> (Precedence | bot)
     def set_precedence(sym, precedence)
-      raise "" if sym.nterm?
       sym.precedence = precedence
     end
 


### PR DESCRIPTION
I don't think this raise can happen. Maybe you still have a debug raise?

For example, I tried the following test case, but this if statement never turned out to be true:

case1:
```
%precedence object
%%
json: object
    ;
object: '{' members? '}'
      ;
```

case2:
```
%type <str> object
%precedence object
%%
json: object
    ;
object: '{' members? '}'
      ;
```