### PR TITLE
Add validation for ASCII characters in Token::Char and implement symbol validation

### DIFF
--- a/lib/lrama/grammar/symbol.rb
+++ b/lib/lrama/grammar/symbol.rb
@@ -5,7 +5,6 @@
 # `number` is both for nterm and term
 # `token_id` is tokentype for term, internal sequence number for nterm
 #
-# TODO: Add validation for ASCII code range for Token::Char
 
 module Lrama
   class Grammar

--- a/lib/lrama/grammar/symbols/resolver.rb
+++ b/lib/lrama/grammar/symbols/resolver.rb
@@ -217,6 +217,7 @@ module Lrama
         def validate!
           validate_number_uniqueness!
           validate_alias_name_uniqueness!
+          validate_symbols!
         end
 
         private
@@ -345,6 +346,15 @@ module Lrama
           return if invalid.empty?
 
           raise "Symbol alias name is duplicated. #{invalid}"
+        end
+
+        # @rbs () -> void
+        def validate_symbols!
+          symbols.each { |sym| sym.id.validate }
+          errors = symbols.map { |sym| sym.id.errors }.flatten.compact
+          return if errors.empty?
+
+          raise errors.join("\n")
         end
       end
     end

--- a/lib/lrama/lexer/token.rb
+++ b/lib/lrama/lexer/token.rb
@@ -14,6 +14,7 @@ module Lrama
       attr_reader :location #: Location
       attr_accessor :alias_name #: String
       attr_accessor :referred #: bool
+      attr_reader :errors #: Array[String]
 
       # @rbs (s_value: String, ?alias_name: String, ?location: Location) -> void
       def initialize(s_value:, alias_name: nil, location: nil)
@@ -21,6 +22,7 @@ module Lrama
         @s_value = s_value
         @alias_name = alias_name
         @location = location
+        @errors = []
       end
 
       # @rbs () -> String
@@ -64,6 +66,11 @@ module Lrama
       def invalid_ref(ref, message)
         location = self.location.partial_location(ref.first_column, ref.last_column)
         raise location.generate_error_message(message)
+      end
+
+      # @rbs () -> bool
+      def validate
+        true
       end
     end
   end

--- a/lib/lrama/lexer/token/char.rb
+++ b/lib/lrama/lexer/token/char.rb
@@ -5,6 +5,19 @@ module Lrama
   class Lexer
     class Token
       class Char < Token
+        # @rbs () -> void
+        def validate
+          validate_ascii_code_range
+        end
+
+        private
+
+        # @rbs () -> void
+        def validate_ascii_code_range
+          unless s_value.ascii_only?
+            errors << "Invalid character: `#{s_value}`. Only ASCII characters are allowed."
+          end
+        end
       end
     end
   end

--- a/sig/generated/lrama/grammar/symbols/resolver.rbs
+++ b/sig/generated/lrama/grammar/symbols/resolver.rbs
@@ -122,6 +122,9 @@ module Lrama
 
         # @rbs () -> void
         def validate_alias_name_uniqueness!: () -> void
+
+        # @rbs () -> void
+        def validate_symbols!: () -> void
       end
     end
   end

--- a/sig/generated/lrama/lexer/token.rbs
+++ b/sig/generated/lrama/lexer/token.rbs
@@ -11,6 +11,8 @@ module Lrama
 
       attr_accessor referred: bool
 
+      attr_reader errors: Array[String]
+
       # @rbs (s_value: String, ?alias_name: String, ?location: Location) -> void
       def initialize: (s_value: String, ?alias_name: String, ?location: Location) -> void
 
@@ -41,6 +43,9 @@ module Lrama
 
       # @rbs (Lrama::Grammar::Reference ref, String message) -> bot
       def invalid_ref: (Lrama::Grammar::Reference ref, String message) -> bot
+
+      # @rbs () -> bool
+      def validate: () -> bool
     end
   end
 end

--- a/sig/generated/lrama/lexer/token/char.rbs
+++ b/sig/generated/lrama/lexer/token/char.rbs
@@ -4,6 +4,13 @@ module Lrama
   class Lexer
     class Token
       class Char < Token
+        # @rbs () -> void
+        def validate: () -> void
+
+        private
+
+        # @rbs () -> void
+        def validate_ascii_code_range: () -> void
       end
     end
   end

--- a/spec/lrama/grammar/symbols/resolver_spec.rb
+++ b/spec/lrama/grammar/symbols/resolver_spec.rb
@@ -236,5 +236,10 @@ RSpec.describe Lrama::Grammar::Symbols::Resolver do
       term2.number = 2
       expect { resolver.validate! }.to raise_error(/Symbol alias name is duplicated./)
     end
+
+    it "validates symbols" do
+      resolver.add_term(id: Lrama::Lexer::Token::Char.new(s_value: "🦙"))
+      expect { resolver.validate! }.to raise_error(/Invalid character: `🦙`. Only ASCII characters are allowed./)
+    end
   end
 end


### PR DESCRIPTION
Source:
```
%%
program : '🦙'
        ;
%%
```

Occur Error:
```
❯ exe/lrama sample/parse.y
Invalid character: `'🦙'`. Only ASCII characters are allowed.
```