### PR TITLE
Make error messages more understandable

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -514,7 +514,7 @@ module Lrama
       @rules.each do |rule|
         next if rule.lhs.precedence.nil?
 
-        errors << "[BUG] Precedence of #{rule.lhs.name} (line: #{rule.lhs.precedence.lineno}) is not term. It should be term."
+        errors << "[BUG] Precedence #{rule.lhs.name} (line: #{rule.lhs.precedence.lineno}) is defined for nonterminal (line: #{rule.lineno}). Precedence can be defined for only terminal symbol."
       end
 
       return if errors.empty?

--- a/spec/lrama/grammar_spec.rb
+++ b/spec/lrama/grammar_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Lrama::Grammar do
 
       it 'raises error with message' do
         expect { grammar.validate! }
-          .to raise_error('[BUG] Precedence of expression (line: 10) is not term. It should be term.')
+          .to raise_error('[BUG] Precedence expression (line: 10) is defined for nonterminal (line: 1). Precedence can be defined for only terminal symbol.')
       end
     end
 
@@ -91,8 +91,8 @@ RSpec.describe Lrama::Grammar do
       end
 
       it 'raises error with all messages joined' do
-        expected_message = "[BUG] Precedence of expression (line: 10) is not term. It should be term.\n" \
-                           '[BUG] Precedence of statement (line: 20) is not term. It should be term.'
+        expected_message = "[BUG] Precedence expression (line: 10) is defined for nonterminal (line: 1). Precedence can be defined for only terminal symbol.\n" \
+                           '[BUG] Precedence statement (line: 20) is defined for nonterminal (line: 2). Precedence can be defined for only terminal symbol.'
 
         expect { grammar.validate! }.to raise_error(expected_message)
       end


### PR DESCRIPTION
Before:
```
[BUG] Precedence of expression (line: 10) is not term. It should be term.
```

After:
```
[BUG] Precedence expression (line: 10) is defined for nonterminal (line: 1). Precedence can be defined for only terminal symbol.
```