### PR TITLE
Add support for precedence handling and warnings for unused precedences

### DIFF
--- a/lib/lrama/warnings.rb
+++ b/lib/lrama/warnings.rb
@@ -4,6 +4,7 @@
 require_relative 'warnings/conflicts'
 require_relative 'warnings/redefined_rules'
 require_relative 'warnings/required'
+require_relative 'warnings/useless_precedence'
 
 module Lrama
   class Warnings
@@ -12,6 +13,7 @@ module Lrama
       @conflicts = Conflicts.new(logger, warnings)
       @redefined_rules = RedefinedRules.new(logger, warnings)
       @required = Required.new(logger, warnings)
+      @useless_precedence = UselessPrecedence.new(logger, warnings)
     end
 
     # @rbs (Lrama::Grammar grammar, Lrama::States states) -> void
@@ -19,6 +21,7 @@ module Lrama
       @conflicts.warn(states)
       @redefined_rules.warn(grammar)
       @required.warn(grammar)
+      @useless_precedence.warn(grammar, states)
     end
   end
 end

--- a/lib/lrama/warnings/useless_precedence.rb
+++ b/lib/lrama/warnings/useless_precedence.rb
@@ -14,12 +14,8 @@ module Lrama
       def warn(grammar, states)
         return unless @warnings
 
-        used_rules = states.rules.flat_map do |state|
-          state.rhs.flat_map { |sym| sym.id.s_value }
-        end.uniq
-
         grammar.precedences.each do |precedence|
-          unless used_rules.include?(precedence.s_value)
+          unless precedence.used_by?
             @logger.warn("Precedence #{precedence.s_value} (line: #{precedence.lineno}) is defined but not used in any rule.")
           end
         end

--- a/lib/lrama/warnings/useless_precedence.rb
+++ b/lib/lrama/warnings/useless_precedence.rb
@@ -1,0 +1,29 @@
+# rbs_inline: enabled
+# frozen_string_literal: true
+
+module Lrama
+  class Warnings
+    class UselessPrecedence
+      # @rbs (Lrama::Logger logger, bool warnings) -> void
+      def initialize(logger, warnings)
+        @logger = logger
+        @warnings = warnings
+      end
+
+      # @rbs (Lrama::Grammar grammar, Lrama::States states) -> void
+      def warn(grammar, states)
+        return unless @warnings
+
+        used_rules = states.rules.flat_map do |state|
+          state.rhs.flat_map { |sym| sym.id.s_value }
+        end.uniq
+
+        grammar.precedences.each do |precedence|
+          unless used_rules.include?(precedence.s_value)
+            @logger.warn("Precedence #{precedence.s_value} (line: #{precedence.lineno}) is defined but not used in any rule.")
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/generated/lrama/warnings/useless_precedence.rbs
+++ b/sig/generated/lrama/warnings/useless_precedence.rbs
@@ -1,0 +1,13 @@
+# Generated from lib/lrama/warnings/useless_precedence.rb with RBS::Inline
+
+module Lrama
+  class Warnings
+    class UselessPrecedence
+      # @rbs (Lrama::Logger logger, bool warnings) -> void
+      def initialize: (Lrama::Logger logger, bool warnings) -> void
+
+      # @rbs (Lrama::Grammar grammar, Lrama::States states) -> void
+      def warn: (Lrama::Grammar grammar, Lrama::States states) -> void
+    end
+  end
+end

--- a/spec/fixtures/states/precedence_unused.y
+++ b/spec/fixtures/states/precedence_unused.y
@@ -1,0 +1,31 @@
+%{
+#include <stdio.h>
+#include <stdlib.h>
+
+int yylex(void);
+void yyerror(const char *s);
+%}
+
+%union {
+    int i;
+}
+
+%token NUMBER
+%precedence PRECEDENCE
+
+%%
+
+program:
+    NUMBER %prec PRECEDENCE
+    ;
+
+%%
+
+int main(void) {
+    printf("Parser ready. Enter expressions:\n");
+    return yyparse();
+}
+
+void yyerror(const char *s) {
+    fprintf(stderr, "Error: %s\n", s);
+}

--- a/spec/fixtures/states/precedence_used.y
+++ b/spec/fixtures/states/precedence_used.y
@@ -1,0 +1,47 @@
+%{
+#include <stdio.h>
+#include <stdlib.h>
+
+int yylex(void);
+void yyerror(const char *s);
+%}
+
+%union {
+    int i;
+}
+
+%token <i> NUMBER
+%token MINUS
+
+%nterm <i> expr
+
+%left MINUS
+%right UMINUS    /* Unary minus */
+
+%%
+
+input:
+    %empty
+    | input line
+    ;
+
+line:
+    expr '\n' { printf("Result: %d\n", $1); }
+    | '\n'
+    ;
+
+expr:
+    NUMBER           { $$ = $1; }
+    | expr MINUS expr { $$ = $1 - $3; }   /* Conflict resolved by precedence */
+    | MINUS expr %prec UMINUS { $$ = -$2; } /* Using %prec to set precedence */
+    ;
+
+%%
+
+int main(void) {
+    return yyparse();
+}
+
+void yyerror(const char *s) {
+    fprintf(stderr, "Error: %s\n", s);
+}

--- a/spec/fixtures/states/precedence_without_prec.y
+++ b/spec/fixtures/states/precedence_without_prec.y
@@ -1,0 +1,31 @@
+%{
+#include <stdio.h>
+#include <stdlib.h>
+
+int yylex(void);
+void yyerror(const char *s);
+%}
+
+%union {
+    int i;
+}
+
+%token NUMBER
+%precedence PRECEDENCE
+
+%%
+
+program:
+    NUMBER
+    ;
+
+%%
+
+int main(void) {
+    printf("Parser ready. Enter expressions:\n");
+    return yyparse();
+}
+
+void yyerror(const char *s) {
+    fprintf(stderr, "Error: %s\n", s);
+}

--- a/spec/lrama/warnings/useless_precedence_spec.rb
+++ b/spec/lrama/warnings/useless_precedence_spec.rb
@@ -2,44 +2,60 @@
 
 RSpec.describe Lrama::Warnings::UselessPrecedence do
   describe "#warn" do
-    let(:y) do
-      <<~STR
-        %{
-        // Prologue
-        %}
-        %union {
-            int i;
-        }
-        %left tSTRING
-        %precedence tNUMBER
-        %right tIDENTIFIER
-        %nonassoc tOPERATOR
-        %precedence tTOKEN
-        %%
-        program: tNUMBER
-                ;
-      STR
-    end
-
     context "when warnings true" do
-      it "has warns for unused precedences" do
-        grammar = Lrama::Parser.new(y, "states/useless_precedence.y").parse
-        grammar.prepare
-        grammar.validate!
-        states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
-        states.compute
-        logger = Lrama::Logger.new
-        allow(logger).to receive(:warn)
-        Lrama::Warnings.new(logger, true).warn(grammar, states)
-        expect(logger).to have_received(:warn).with("Precedence tSTRING (line: 7) is defined but not used in any rule.").once
-        expect(logger).to have_received(:warn).with("Precedence tIDENTIFIER (line: 9) is defined but not used in any rule.").once
-        expect(logger).to have_received(:warn).with("Precedence tOPERATOR (line: 10) is defined but not used in any rule.").once
-        expect(logger).to have_received(:warn).with("Precedence tTOKEN (line: 11) is defined but not used in any rule.").once
+      context "when precedences are used" do
+        it "has not warns for unused precedences" do
+          path = "states/precedence_used.y"
+          y = File.read(fixture_path(path))
+          grammar = Lrama::Parser.new(y, "states/precedence_used.y").parse
+          grammar.prepare
+          grammar.validate!
+          states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+          states.compute
+          logger = Lrama::Logger.new
+          allow(logger).to receive(:warn)
+          Lrama::Warnings.new(logger, true).warn(grammar, states)
+          expect(logger).not_to have_received(:warn)
+        end
+      end
+
+      context "when precedences are unused" do
+        it "has warns for unused precedences" do
+          path = "states/precedence_unused.y"
+          y = File.read(fixture_path(path))
+          grammar = Lrama::Parser.new(y, "states/precedence_unused.y").parse
+          grammar.prepare
+          grammar.validate!
+          states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+          states.compute
+          logger = Lrama::Logger.new
+          allow(logger).to receive(:warn)
+          Lrama::Warnings.new(logger, true).warn(grammar, states)
+          expect(logger).to have_received(:warn).with("Precedence PRECEDENCE (line: 14) is defined but not used in any rule.").once
+        end
+      end
+
+      context "when precedences are defined but not used in any rule" do
+        it "has warns for unused precedences" do
+          path = "states/precedence_without_prec.y"
+          y = File.read(fixture_path(path))
+          grammar = Lrama::Parser.new(y, "states/precedence_without_prec.y").parse
+          grammar.prepare
+          grammar.validate!
+          states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+          states.compute
+          logger = Lrama::Logger.new
+          allow(logger).to receive(:warn)
+          Lrama::Warnings.new(logger, true).warn(grammar, states)
+          expect(logger).to have_received(:warn).with("Precedence PRECEDENCE (line: 14) is defined but not used in any rule.").once
+        end
       end
     end
 
     context "when warnings false" do
       it "has not warns for unused precedences" do
+        path = "states/precedence_unused.y"
+        y = File.read(fixture_path(path))
         grammar = Lrama::Parser.new(y, "states/useless_precedence.y").parse
         grammar.prepare
         grammar.validate!

--- a/spec/lrama/warnings/useless_precedence_spec.rb
+++ b/spec/lrama/warnings/useless_precedence_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe Lrama::Warnings::UselessPrecedence do
+  describe "#warn" do
+    let(:y) do
+      <<~STR
+        %{
+        // Prologue
+        %}
+        %union {
+            int i;
+        }
+        %left tSTRING
+        %precedence tNUMBER
+        %right tIDENTIFIER
+        %nonassoc tOPERATOR
+        %precedence tTOKEN
+        %%
+        program: tNUMBER
+                ;
+      STR
+    end
+
+    context "when warnings true" do
+      it "has warns for unused precedences" do
+        grammar = Lrama::Parser.new(y, "states/useless_precedence.y").parse
+        grammar.prepare
+        grammar.validate!
+        states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+        states.compute
+        logger = Lrama::Logger.new
+        allow(logger).to receive(:warn)
+        Lrama::Warnings.new(logger, true).warn(grammar, states)
+        expect(logger).to have_received(:warn).with("Precedence tSTRING (line: 7) is defined but not used in any rule.").once
+        expect(logger).to have_received(:warn).with("Precedence tIDENTIFIER (line: 9) is defined but not used in any rule.").once
+        expect(logger).to have_received(:warn).with("Precedence tOPERATOR (line: 10) is defined but not used in any rule.").once
+        expect(logger).to have_received(:warn).with("Precedence tTOKEN (line: 11) is defined but not used in any rule.").once
+      end
+    end
+
+    context "when warnings false" do
+      it "has not warns for unused precedences" do
+        grammar = Lrama::Parser.new(y, "states/useless_precedence.y").parse
+        grammar.prepare
+        grammar.validate!
+        states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+        states.compute
+        logger = Lrama::Logger.new
+        allow(logger).to receive(:warn)
+        Lrama::Warnings.new(logger, false).warn(grammar, states)
+        expect(logger).not_to have_received(:warn)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Example1:
```
%{
#include <stdio.h>
#include <stdlib.h>

int yylex(void);
void yyerror(const char *s);
%}

%union {
    int i;
}

%token NUMBER
%precedence PRECEDENCE

%%

program:
    NUMBER %prec PRECEDENCE
    ;

%%

int main(void) {
    printf("Parser ready. Enter expressions:\n");
    return yyparse();
}

void yyerror(const char *s) {
    fprintf(stderr, "Error: %s\n", s);
}

```

Before:
```
❯ exe/lrama -W tmp/example.y

```

After:
```
❯ exe/lrama -W tmp/example.y
Precedence PRECEDENCE (line: 14) is defined but not used in any rule.
```

Example2:
```
%{
#include <stdio.h>
#include <stdlib.h>

int yylex(void);
void yyerror(const char *s);
%}

%union {
    int i;
}

%token NUMBER
%precedence PRECEDENCE

%%

program:
    NUMBER
    ;

%%

int main(void) {
    printf("Parser ready. Enter expressions:\n");
    return yyparse();
}

void yyerror(const char *s) {
    fprintf(stderr, "Error: %s\n", s);
}

```

Before:
```
❯ exe/lrama -W tmp/example.y

```

After:
```
❯ exe/lrama -W tmp/example.y
Precedence PRECEDENCE (line: 14) is defined but not used in any rule.
```