### PR TITLE
Change to raise an error if `%precedence` is set more than once for the same terminal symbol

### DIFF
--- a/lib/lrama/grammar/precedence.rb
+++ b/lib/lrama/grammar/precedence.rb
@@ -3,14 +3,15 @@
 
 module Lrama
   class Grammar
-    class Precedence < Struct.new(:type, :precedence, :lineno, keyword_init: true)
+    class Precedence < Struct.new(:type, :precedence, :s_value, :lineno, keyword_init: true)
       include Comparable
       # @rbs!
       #   attr_accessor type: ::Symbol
       #   attr_accessor precedence: Integer
+      #   attr_accessor s_value: String
       #   attr_accessor lineno: Integer
       #
-      #   def initialize: (?type: ::Symbol, ?precedence: Integer, ?lineno: Integer) -> void
+      #   def initialize: (?type: ::Symbol, ?precedence: Integer, ?s_value: ::String, ?lineno: Integer) -> void
 
       # @rbs (Precedence other) -> Integer
       def <=>(other)

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -1598,7 +1598,7 @@ module_eval(<<'.,.,', 'parser.y', 156)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_left(sym, @precedence_number, @lexer.line)
+              @grammar.add_left(sym, @precedence_number, id.s_value, id.first_line)
             }
           }
           @precedence_number += 1
@@ -1612,7 +1612,7 @@ module_eval(<<'.,.,', 'parser.y', 166)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_right(sym, @precedence_number, @lexer.line)
+              @grammar.add_right(sym, @precedence_number, id.s_value, id.first_line)
             }
           }
           @precedence_number += 1
@@ -1626,7 +1626,7 @@ module_eval(<<'.,.,', 'parser.y', 176)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_precedence(sym, @precedence_number, sym.id.first_line)
+              @grammar.add_precedence(sym, @precedence_number, id.s_value, id.first_line)
             }
           }
           @precedence_number += 1
@@ -1640,7 +1640,7 @@ module_eval(<<'.,.,', 'parser.y', 186)
               val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_nonassoc(sym, @precedence_number, @lexer.line)
+              @grammar.add_nonassoc(sym, @precedence_number, id.s_value, id.first_line)
             }
           }
           @precedence_number += 1

--- a/parser.y
+++ b/parser.y
@@ -157,7 +157,7 @@ rule
           val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_left(sym, @precedence_number, @lexer.line)
+              @grammar.add_left(sym, @precedence_number, id.s_value, id.first_line)
             }
           }
           @precedence_number += 1
@@ -167,7 +167,7 @@ rule
           val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_right(sym, @precedence_number, @lexer.line)
+              @grammar.add_right(sym, @precedence_number, id.s_value, id.first_line)
             }
           }
           @precedence_number += 1
@@ -177,7 +177,7 @@ rule
           val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_precedence(sym, @precedence_number, sym.id.first_line)
+              @grammar.add_precedence(sym, @precedence_number, id.s_value, id.first_line)
             }
           }
           @precedence_number += 1
@@ -187,7 +187,7 @@ rule
           val[1].each {|hash|
             hash[:tokens].each {|id|
               sym = @grammar.add_term(id: id, tag: hash[:tag])
-              @grammar.add_nonassoc(sym, @precedence_number, @lexer.line)
+              @grammar.add_nonassoc(sym, @precedence_number, id.s_value, id.first_line)
             }
           }
           @precedence_number += 1

--- a/sig/generated/lrama/grammar.rbs
+++ b/sig/generated/lrama/grammar.rbs
@@ -70,6 +70,8 @@ module Lrama
 
     @union: Union
 
+    @precedences: Array[Precedence]
+
     extend Forwardable
 
     attr_reader percent_codes: Array[PercentCode]
@@ -85,6 +87,8 @@ module Lrama
     attr_reader aux: Auxiliary
 
     attr_reader parameterized_resolver: Parameterized::Resolver
+
+    attr_reader precedences: Array[Precedence]
 
     attr_accessor union: Union
 
@@ -149,17 +153,17 @@ module Lrama
     # @rbs (id: Lexer::Token, tag: Lexer::Token::Tag) -> Array[Type]
     def add_type: (id: Lexer::Token, tag: Lexer::Token::Tag) -> Array[Type]
 
-    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
-    def add_nonassoc: (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    # @rbs (Grammar::Symbol sym, Integer precedence, String s_value, Integer lineno) -> Precedence
+    def add_nonassoc: (Grammar::Symbol sym, Integer precedence, String s_value, Integer lineno) -> Precedence
 
-    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
-    def add_left: (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    # @rbs (Grammar::Symbol sym, Integer precedence, String s_value, Integer lineno) -> Precedence
+    def add_left: (Grammar::Symbol sym, Integer precedence, String s_value, Integer lineno) -> Precedence
 
-    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
-    def add_right: (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    # @rbs (Grammar::Symbol sym, Integer precedence, String s_value, Integer lineno) -> Precedence
+    def add_right: (Grammar::Symbol sym, Integer precedence, String s_value, Integer lineno) -> Precedence
 
-    # @rbs (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
-    def add_precedence: (Grammar::Symbol sym, Integer precedence, Integer lineno) -> Precedence
+    # @rbs (Grammar::Symbol sym, Integer precedence, String s_value, Integer lineno) -> Precedence
+    def add_precedence: (Grammar::Symbol sym, Integer precedence, String s_value, Integer lineno) -> Precedence
 
     # @rbs (Grammar::Symbol sym, Precedence precedence) -> (Precedence | bot)
     def set_precedence: (Grammar::Symbol sym, Precedence precedence) -> (Precedence | bot)
@@ -262,6 +266,9 @@ module Lrama
 
     # @rbs () -> void
     def validate_rule_lhs_is_nterm!: () -> void
+
+    # # @rbs () -> void
+    def validate_duplicated_precedence!: () -> untyped
 
     # @rbs () -> void
     def set_locations: () -> void

--- a/sig/generated/lrama/grammar/precedence.rbs
+++ b/sig/generated/lrama/grammar/precedence.rbs
@@ -9,9 +9,11 @@ module Lrama
 
       attr_accessor precedence: Integer
 
+      attr_accessor s_value: String
+
       attr_accessor lineno: Integer
 
-      def initialize: (?type: ::Symbol, ?precedence: Integer, ?lineno: Integer) -> void
+      def initialize: (?type: ::Symbol, ?precedence: Integer, ?s_value: ::String, ?lineno: Integer) -> void
 
       # @rbs (Precedence other) -> Integer
       def <=>: (Precedence other) -> Integer


### PR DESCRIPTION
Example:
```
%{
// Prologue
%}
%union {
    int i;
}
%left tSTRING tNUMBER
%precedence tSTRING
%right tIDENTIFIER
%nonassoc tSTRING tNUMBER
%%
program: tNUMBER
        ;
```

Before:
```
$ exe/lrama example.y

```

After:
```
❯ exe/lrama tmp/a.y
[BUG] %precedence redeclaration for tSTRING (line: 8) previous declaration was %left (line: 7)
[BUG] %nonassoc redeclaration for tSTRING (line: 10) previous declaration was %left (line: 7)
[BUG] %nonassoc redeclaration for tNUMBER (line: 10) previous declaration was %left (line: 7)
```