### PR TITLE
Describe where conflicted tokens come from on the output file

### DIFF
--- a/lib/lrama/state.rb
+++ b/lib/lrama/state.rb
@@ -146,6 +146,15 @@ module Lrama
       reduce.look_ahead = look_ahead
     end
 
+    # @rbs (Grammar::Rule rule, Hash[Grammar::Symbol, Array[Action::Goto]] sources) -> void
+    def set_look_ahead_sources(rule, sources)
+      reduce = reduces.find do |r|
+        r.rule == rule
+      end
+
+      reduce.look_ahead_sources = sources
+    end
+
     # @rbs () -> Array[Action::Goto]
     def nterm_transitions # steep:ignore
       @nterm_transitions ||= transitions.select {|transition| transition.is_a?(Action::Goto) }

--- a/lib/lrama/state/action/reduce.rb
+++ b/lib/lrama/state/action/reduce.rb
@@ -12,10 +12,12 @@ module Lrama
         # @rbs!
         #   @item: States::Item
         #   @look_ahead: Array[Grammar::Symbol]?
+        #   @look_ahead_sources: Hash[Grammar::Symbol, Array[Action::Goto]]?
         #   @not_selected_symbols: Array[Grammar::Symbol]
 
         attr_reader :item #: States::Item
         attr_reader :look_ahead #: Array[Grammar::Symbol]?
+        attr_reader :look_ahead_sources #: Hash[Grammar::Symbol, Array[Action::Goto]]?
         attr_reader :not_selected_symbols #: Array[Grammar::Symbol]
 
         # https://www.gnu.org/software/bison/manual/html_node/Default-Reductions.html
@@ -25,6 +27,7 @@ module Lrama
         def initialize(item)
           @item = item
           @look_ahead = nil
+          @look_ahead_sources = nil
           @not_selected_symbols = []
         end
 
@@ -36,6 +39,11 @@ module Lrama
         # @rbs (Array[Grammar::Symbol] look_ahead) -> Array[Grammar::Symbol]
         def look_ahead=(look_ahead)
           @look_ahead = look_ahead.freeze
+        end
+
+        # @rbs (Hash[Grammar::Symbol, Array[Action::Goto]] sources) -> Hash[Grammar::Symbol, Array[Action::Goto]]
+        def look_ahead_sources=(sources)
+          @look_ahead_sources = sources.freeze
         end
 
         # @rbs (Grammar::Symbol sym) -> Array[Grammar::Symbol]

--- a/sig/generated/lrama/state.rbs
+++ b/sig/generated/lrama/state.rbs
@@ -100,6 +100,9 @@ module Lrama
     # @rbs (Grammar::Rule rule, Array[Grammar::Symbol] look_ahead) -> void
     def set_look_ahead: (Grammar::Rule rule, Array[Grammar::Symbol] look_ahead) -> void
 
+    # @rbs (Grammar::Rule rule, Hash[Grammar::Symbol, Array[Action::Goto]] sources) -> void
+    def set_look_ahead_sources: (Grammar::Rule rule, Hash[Grammar::Symbol, Array[Action::Goto]] sources) -> void
+
     # @rbs () -> Array[Action::Goto]
     def nterm_transitions: () -> Array[Action::Goto]
 

--- a/sig/generated/lrama/state/action/reduce.rbs
+++ b/sig/generated/lrama/state/action/reduce.rbs
@@ -8,11 +8,15 @@ module Lrama
 
         @look_ahead: Array[Grammar::Symbol]?
 
+        @look_ahead_sources: Hash[Grammar::Symbol, Array[Action::Goto]]?
+
         @not_selected_symbols: Array[Grammar::Symbol]
 
         attr_reader item: States::Item
 
         attr_reader look_ahead: Array[Grammar::Symbol]?
+
+        attr_reader look_ahead_sources: Hash[Grammar::Symbol, Array[Action::Goto]]?
 
         attr_reader not_selected_symbols: Array[Grammar::Symbol]
 
@@ -27,6 +31,9 @@ module Lrama
 
         # @rbs (Array[Grammar::Symbol] look_ahead) -> Array[Grammar::Symbol]
         def look_ahead=: (Array[Grammar::Symbol] look_ahead) -> Array[Grammar::Symbol]
+
+        # @rbs (Hash[Grammar::Symbol, Array[Action::Goto]] sources) -> Hash[Grammar::Symbol, Array[Action::Goto]]
+        def look_ahead_sources=: (Hash[Grammar::Symbol, Array[Action::Goto]] sources) -> Hash[Grammar::Symbol, Array[Action::Goto]]
 
         # @rbs (Grammar::Symbol sym) -> Array[Grammar::Symbol]
         def add_not_selected_symbol: (Grammar::Symbol sym) -> Array[Grammar::Symbol]

--- a/sig/generated/lrama/states.rbs
+++ b/sig/generated/lrama/states.rbs
@@ -79,6 +79,8 @@ module Lrama
     # @rbs (Logger logger) -> void
     def validate!: (Logger logger) -> void
 
+    def compute_la_sources: () -> untyped
+
     private
 
     # @rbs (Grammar::Symbol accessing_symbol, Array[Item] kernels, Hash[Array[Item], State] states_created) -> [State, bool]

--- a/spec/lrama/reporter/states_spec.rb
+++ b/spec/lrama/reporter/states_spec.rb
@@ -126,6 +126,8 @@ RSpec.describe Lrama::Reporter::States do
             2     | expr "plus" expr •  ["end of file", "plus"]
 
             Conflict on "plus". shift/reduce(expr)
+              "plus" comes from state 0 goto by expr
+              "plus" comes from state 5 goto by expr
 
             "plus"  shift, and go to state 5
 

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -125,8 +125,12 @@ RSpec.describe Lrama::States do
            10 class: keyword_class • $@3 tSTRING '?' "end" $@4
 
             Conflict on tSTRING. shift/reduce($@1)
+              tSTRING comes from state 1 goto by $@1
             Conflict on tSTRING. shift/reduce($@3)
+              tSTRING comes from state 1 goto by $@3
             Conflict on tSTRING. reduce($@1)/reduce($@3)
+              tSTRING comes from state 1 goto by $@1
+              tSTRING comes from state 1 goto by $@3
 
             tSTRING  shift, and go to state 6
 
@@ -417,6 +421,7 @@ RSpec.describe Lrama::States do
             4 B: ε •
 
             Conflict on a. shift/reduce(B)
+              a comes from state 6 goto by D
 
             a  shift, and go to state 1
 
@@ -605,6 +610,7 @@ RSpec.describe Lrama::States do
             4 B: ε •
 
             Conflict on a. shift/reduce(B)
+              a comes from state 6 goto by D
 
             a  shift, and go to state 1
 
@@ -1432,6 +1438,9 @@ RSpec.describe Lrama::States do
               3     | expr • '*' expr
 
               Conflict on '+'. shift/reduce(expr)
+                '+' comes from state 0 goto by expr
+                '+' comes from state 5 goto by expr
+                '+' comes from state 6 goto by expr
 
               '+'  shift, and go to state 5
               '*'  shift, and go to state 6
@@ -1450,6 +1459,9 @@ RSpec.describe Lrama::States do
               3     | expr '*' expr •
 
               Conflict on '*'. shift/reduce(expr)
+                '*' comes from state 0 goto by expr
+                '*' comes from state 5 goto by expr
+                '*' comes from state 6 goto by expr
 
               '*'  shift, and go to state 6
 


### PR DESCRIPTION
For example, for the grammar file like below

```
%%

program: expr
       ;

expr: expr '+' expr
    | tNUMBER
    ;

%%
```

Lrama generates describes where `"plus"` (`'+'`)
look ahead tokens come from:

```
State 6

    2 expr: expr • "plus" expr
    2     | expr "plus" expr •  ["end of file", "plus"]

    Conflict on "plus". shift/reduce(expr)
      "plus" comes from state 0 goto by expr
      "plus" comes from state 5 goto by expr
```

state 0 and state 5 look like below:

```
State 0

    0 $accept: • program "end of file"
    1 program: • expr
    2 expr: • expr "plus" expr
    3     | • tNUMBER

    tNUMBER  shift, and go to state 1

    program  go to state 2
    expr     go to state 3

State 5

    2 expr: • expr "plus" expr
    2     | expr "plus" • expr
    3     | • tNUMBER

    tNUMBER  shift, and go to state 1

    expr  go to state 6
```