### PR TITLE
Move `Item` from `States` to `State`

### DIFF
--- a/lib/lrama/counterexamples.rb
+++ b/lib/lrama/counterexamples.rb
@@ -23,7 +23,7 @@ module Lrama
     #   @iterate_count: Integer
     #   @total_duration: Float
     #   @exceed_cumulative_time_limit: bool
-    #   @state_items: Hash[[State, States::Item], StateItem]
+    #   @state_items: Hash[[State, State::Item], StateItem]
     #   @triples: Hash[Integer, Triple]
     #   @transitions: Hash[[StateItem, Grammar::Symbol], StateItem]
     #   @reverse_transitions: Hash[[StateItem, Grammar::Symbol], Set[StateItem]]
@@ -76,7 +76,7 @@ module Lrama
 
     private
 
-    # @rbs (State state, States::Item item) -> StateItem
+    # @rbs (State state, State::Item item) -> StateItem
     def get_state_item(state, item)
       @state_items[[state, item]]
     end
@@ -179,7 +179,7 @@ module Lrama
     # @rbs (State conflict_state, State::ShiftReduceConflict conflict) -> Example
     def shift_reduce_example(conflict_state, conflict)
       conflict_symbol = conflict.symbols.first
-      # @type var shift_conflict_item: ::Lrama::States::Item
+      # @type var shift_conflict_item: ::Lrama::State::Item
       shift_conflict_item = conflict_state.items.find { |item| item.next_sym == conflict_symbol }
       path2 = with_timeout("#shortest_path:") do
         shortest_path(conflict_state, conflict.reduce.item, conflict_symbol)
@@ -204,7 +204,7 @@ module Lrama
       Example.new(path1, path2, conflict, conflict_symbol, self)
     end
 
-    # @rbs (Array[StateItem]? reduce_state_items, State conflict_state, States::Item conflict_item) -> Array[StateItem]
+    # @rbs (Array[StateItem]? reduce_state_items, State conflict_state, State::Item conflict_item) -> Array[StateItem]
     def find_shift_conflict_shortest_path(reduce_state_items, conflict_state, conflict_item)
       time1 = Time.now.to_f
       @iterate_count = 0
@@ -323,7 +323,7 @@ module Lrama
       result
     end
 
-    # @rbs (State conflict_state, States::Item conflict_reduce_item, Grammar::Symbol conflict_term) -> ::Array[StateItem]?
+    # @rbs (State conflict_state, State::Item conflict_reduce_item, Grammar::Symbol conflict_term) -> ::Array[StateItem]?
     def shortest_path(conflict_state, conflict_reduce_item, conflict_term)
       time1 = Time.now.to_f
       @iterate_count = 0
@@ -388,7 +388,7 @@ module Lrama
       return nil
     end
 
-    # @rbs (States::Item item, Bitmap::bitmap current_l) -> Bitmap::bitmap
+    # @rbs (State::Item item, Bitmap::bitmap current_l) -> Bitmap::bitmap
     def follow_l(item, current_l)
       # 1. follow_L (A -> X1 ... Xn-1 • Xn) = L
       # 2. follow_L (A -> X1 ... Xk • Xk+1 Xk+2 ... Xn) = {Xk+2} if Xk+2 is a terminal

--- a/lib/lrama/counterexamples/derivation.rb
+++ b/lib/lrama/counterexamples/derivation.rb
@@ -5,14 +5,14 @@ module Lrama
   class Counterexamples
     class Derivation
       # @rbs!
-      #   @item: States::Item
+      #   @item: State::Item
       #   @left: Derivation?
 
-      attr_reader :item  #: States::Item
+      attr_reader :item  #: State::Item
       attr_reader :left  #: Derivation?
       attr_accessor :right #: Derivation?
 
-      # @rbs (States::Item item, Derivation? left) -> void
+      # @rbs (State::Item item, Derivation? left) -> void
       def initialize(item, left)
         @item = item
         @left = left

--- a/lib/lrama/counterexamples/example.rb
+++ b/lib/lrama/counterexamples/example.rb
@@ -39,12 +39,12 @@ module Lrama
         @conflict.type
       end
 
-      # @rbs () -> States::Item
+      # @rbs () -> State::Item
       def path1_item
         @path1.last.item
       end
 
-      # @rbs () -> States::Item
+      # @rbs () -> State::Item
       def path2_item
         @path2.last.item
       end

--- a/lib/lrama/counterexamples/state_item.rb
+++ b/lib/lrama/counterexamples/state_item.rb
@@ -6,9 +6,9 @@ module Lrama
     class StateItem
       attr_reader :id #: Integer
       attr_reader :state #: State
-      attr_reader :item #: States::Item
+      attr_reader :item #: State::Item
 
-      # @rbs (Integer id, State state, States::Item item) -> void
+      # @rbs (Integer id, State state, State::Item item) -> void
       def initialize(id, state, item)
         @id = id
         @state = state

--- a/lib/lrama/counterexamples/triple.rb
+++ b/lib/lrama/counterexamples/triple.rb
@@ -20,7 +20,7 @@ module Lrama
       end
       alias :s :state
 
-      # @rbs () -> States::Item
+      # @rbs () -> State::Item
       def item
         @state_item.item
       end

--- a/lib/lrama/state.rb
+++ b/lib/lrama/state.rb
@@ -2,10 +2,11 @@
 # frozen_string_literal: true
 
 require_relative "state/action"
+require_relative "state/inadequacy_annotation"
+require_relative "state/item"
 require_relative "state/reduce_reduce_conflict"
 require_relative "state/resolved_conflict"
 require_relative "state/shift_reduce_conflict"
-require_relative "state/inadequacy_annotation"
 
 module Lrama
   class State
@@ -16,17 +17,17 @@ module Lrama
     # @rbs!
     #   type conflict = State::ShiftReduceConflict | State::ReduceReduceConflict
     #   type transition = Action::Shift | Action::Goto
-    #   type lookahead_set = Hash[States::Item, Array[Grammar::Symbol]]
+    #   type lookahead_set = Hash[Item, Array[Grammar::Symbol]]
     #
     #   @id: Integer
     #   @accessing_symbol: Grammar::Symbol
-    #   @kernels: Array[States::Item]
-    #   @items: Array[States::Item]
-    #   @items_to_state: Hash[Array[States::Item], State]
+    #   @kernels: Array[Item]
+    #   @items: Array[Item]
+    #   @items_to_state: Hash[Array[Item], State]
     #   @conflicts: Array[conflict]
     #   @resolved_conflicts: Array[ResolvedConflict]
     #   @default_reduction_rule: Grammar::Rule?
-    #   @closure: Array[States::Item]
+    #   @closure: Array[Item]
     #   @nterm_transitions: Array[Action::Goto]
     #   @term_transitions: Array[Action::Shift]
     #   @transitions: Array[transition]
@@ -35,27 +36,27 @@ module Lrama
 
     attr_reader :id #: Integer
     attr_reader :accessing_symbol #: Grammar::Symbol
-    attr_reader :kernels #: Array[States::Item]
+    attr_reader :kernels #: Array[Item]
     attr_reader :conflicts #: Array[conflict]
     attr_reader :resolved_conflicts #: Array[ResolvedConflict]
     attr_reader :default_reduction_rule #: Grammar::Rule?
-    attr_reader :closure #: Array[States::Item]
-    attr_reader :items #: Array[States::Item]
+    attr_reader :closure #: Array[Item]
+    attr_reader :items #: Array[Item]
     attr_reader :annotation_list #: Array[InadequacyAnnotation]
     attr_reader :predecessors #: Array[State]
-    attr_reader :items_to_state #: Hash[Array[States::Item], State]
-    attr_reader :lane_items #: Hash[State, Array[[States::Item, States::Item]]]
+    attr_reader :items_to_state #: Hash[Array[Item], State]
+    attr_reader :lane_items #: Hash[State, Array[[Item, Item]]]
 
-    attr_accessor :_transitions #: Array[[Grammar::Symbol, Array[States::Item]]]
+    attr_accessor :_transitions #: Array[[Grammar::Symbol, Array[Item]]]
     attr_accessor :reduces #: Array[Action::Reduce]
     attr_accessor :ielr_isocores #: Array[State]
     attr_accessor :lalr_isocore #: State
     attr_accessor :lookaheads_recomputed #: bool
-    attr_accessor :follow_kernel_items #: Hash[Action::Goto, Hash[States::Item, bool]]
+    attr_accessor :follow_kernel_items #: Hash[Action::Goto, Hash[Item, bool]]
     attr_accessor :always_follows #: Hash[Action::Goto, Array[Grammar::Symbol]]
     attr_accessor :goto_follows #: Hash[Action::Goto, Array[Grammar::Symbol]]
 
-    # @rbs (Integer id, Grammar::Symbol accessing_symbol, Array[States::Item] kernels) -> void
+    # @rbs (Integer id, Grammar::Symbol accessing_symbol, Array[Item] kernels) -> void
     def initialize(id, accessing_symbol, kernels)
       @id = id
       @accessing_symbol = accessing_symbol
@@ -86,7 +87,7 @@ module Lrama
       self.id == other.id
     end
 
-    # @rbs (Array[States::Item] closure) -> void
+    # @rbs (Array[Item] closure) -> void
     def closure=(closure)
       @closure = closure
       @items = @kernels + @closure
@@ -132,7 +133,7 @@ module Lrama
       @lane_items[next_state] = @_lane_items[next_sym]
     end
 
-    # @rbs (Array[States::Item] items, State next_state) -> void
+    # @rbs (Array[Item] items, State next_state) -> void
     def set_items_to_state(items, next_state)
       @items_to_state[items] = next_state
     end
@@ -231,7 +232,7 @@ module Lrama
       result
     end
 
-    # @rbs (States::Item item) -> Action::Reduce
+    # @rbs (Item item) -> Action::Reduce
     def find_reduce_by_item!(item)
       reduces.find do |r|
         r.item == item
@@ -401,7 +402,7 @@ module Lrama
       predecessor.append_annotation_list(propagating_list)
     end
 
-    # @rbs () -> Array[States::Item]
+    # @rbs () -> Array[Item]
     def first_kernels
       @first_kernels ||= kernels.select {|kernel| kernel.position == 1 }
     end
@@ -419,7 +420,7 @@ module Lrama
 
     # Definition 3.31 (compute_lhs_contributions)
     #
-    # @rbs (Grammar::Symbol sym, Grammar::Symbol token) -> (nil | Hash[States::Item, bool])
+    # @rbs (Grammar::Symbol sym, Grammar::Symbol token) -> (nil | Hash[Item, bool])
     def lhs_contributions(sym, token)
       return @lhs_contributions[sym][token] unless @lhs_contributions.dig(sym, token).nil?
 
@@ -461,7 +462,7 @@ module Lrama
       @item_lookahead_set = k
     end
 
-    # @rbs (States::Item item) -> Array[[State, States::Item]]
+    # @rbs (Item item) -> Array[[State, Item]]
     def predecessors_with_item(item)
       result = []
       @predecessors.each do |pre|

--- a/lib/lrama/state/action/goto.rb
+++ b/lib/lrama/state/action/goto.rb
@@ -12,15 +12,15 @@ module Lrama
         # @rbs!
         #   @from_state: State
         #   @next_sym: Grammar::Symbol
-        #   @to_items: Array[States::Item]
+        #   @to_items: Array[Item]
         #   @to_state: State
 
         attr_reader :from_state #: State
         attr_reader :next_sym #: Grammar::Symbol
-        attr_reader :to_items #: Array[States::Item]
+        attr_reader :to_items #: Array[Item]
         attr_reader :to_state #: State
 
-        # @rbs (State from_state, Grammar::Symbol next_sym, Array[States::Item] to_items, State to_state) -> void
+        # @rbs (State from_state, Grammar::Symbol next_sym, Array[Item] to_items, State to_state) -> void
         def initialize(from_state, next_sym, to_items, to_state)
           @from_state = from_state
           @next_sym = next_sym

--- a/lib/lrama/state/action/reduce.rb
+++ b/lib/lrama/state/action/reduce.rb
@@ -10,12 +10,12 @@ module Lrama
         #       see: https://github.com/soutaro/rbs-inline/pull/149
         #
         # @rbs!
-        #   @item: States::Item
+        #   @item: Item
         #   @look_ahead: Array[Grammar::Symbol]?
         #   @look_ahead_sources: Hash[Grammar::Symbol, Array[Action::Goto]]?
         #   @not_selected_symbols: Array[Grammar::Symbol]
 
-        attr_reader :item #: States::Item
+        attr_reader :item #: Item
         attr_reader :look_ahead #: Array[Grammar::Symbol]?
         attr_reader :look_ahead_sources #: Hash[Grammar::Symbol, Array[Action::Goto]]?
         attr_reader :not_selected_symbols #: Array[Grammar::Symbol]
@@ -23,7 +23,7 @@ module Lrama
         # https://www.gnu.org/software/bison/manual/html_node/Default-Reductions.html
         attr_accessor :default_reduction #: bool
 
-        # @rbs (States::Item item) -> void
+        # @rbs (Item item) -> void
         def initialize(item)
           @item = item
           @look_ahead = nil

--- a/lib/lrama/state/action/shift.rb
+++ b/lib/lrama/state/action/shift.rb
@@ -12,16 +12,16 @@ module Lrama
         # @rbs!
         #   @from_state: State
         #   @next_sym: Grammar::Symbol
-        #   @to_items: Array[States::Item]
+        #   @to_items: Array[Item]
         #   @to_state: State
 
         attr_reader :from_state #: State
         attr_reader :next_sym #: Grammar::Symbol
-        attr_reader :to_items #: Array[States::Item]
+        attr_reader :to_items #: Array[Item]
         attr_reader :to_state #: State
         attr_accessor :not_selected #: bool
 
-        # @rbs (State from_state, Grammar::Symbol next_sym, Array[States::Item] to_items, State to_state) -> void
+        # @rbs (State from_state, Grammar::Symbol next_sym, Array[Item] to_items, State to_state) -> void
         def initialize(from_state, next_sym, to_items, to_state)
           @from_state = from_state
           @next_sym = next_sym

--- a/lib/lrama/state/inadequacy_annotation.rb
+++ b/lib/lrama/state/inadequacy_annotation.rb
@@ -10,9 +10,9 @@ module Lrama
       attr_accessor :state #: State
       attr_accessor :token #: Grammar::Symbol
       attr_accessor :actions #: Array[action]
-      attr_accessor :contribution_matrix #: Hash[action, Hash[States::Item, bool]]
+      attr_accessor :contribution_matrix #: Hash[action, Hash[Item, bool]]
 
-      # @rbs (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[States::Item, bool]] contribution_matrix) -> void
+      # @rbs (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[Item, bool]] contribution_matrix) -> void
       def initialize(state, token, actions, contribution_matrix)
         @state = state
         @token = token
@@ -20,12 +20,12 @@ module Lrama
         @contribution_matrix = contribution_matrix
       end
 
-      # @rbs (States::Item item) -> bool
+      # @rbs (Item item) -> bool
       def contributed?(item)
         @contribution_matrix.any? {|action, contributions| !contributions.nil? && contributions[item] }
       end
 
-      # @rbs (Array[Hash[action, Hash[States::Item, bool]]] another_matrixes) -> void
+      # @rbs (Array[Hash[action, Hash[Item, bool]]] another_matrixes) -> void
       def merge_matrix(another_matrixes)
         another_matrixes.each do |another_matrix|
           @contribution_matrix.merge!(another_matrix) {|action, contributions, another_contributions|

--- a/lib/lrama/state/item.rb
+++ b/lib/lrama/state/item.rb
@@ -6,7 +6,7 @@
 require "forwardable"
 
 module Lrama
-  class States
+  class State
     class Item < Struct.new(:rule, :position, keyword_init: true)
       # @rbs!
       #   include Grammar::Rule::_DelegatedMethods
@@ -72,7 +72,7 @@ module Lrama
         rule.initial_rule? && beginning_of_rule?
       end
 
-      # @rbs () -> States::Item
+      # @rbs () -> State::Item
       def new_by_next_position
         Item.new(rule: rule, position: position + 1)
       end
@@ -111,7 +111,7 @@ module Lrama
         ". #{r}  (rule #{rule_id})"
       end
 
-      # @rbs (States::Item other_item) -> bool
+      # @rbs (State::Item other_item) -> bool
       def predecessor_item_of?(other_item)
         rule == other_item.rule && position == other_item.position - 1
       end

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -3,7 +3,7 @@
 
 require "forwardable"
 require_relative "tracer/duration"
-require_relative "states/item"
+require_relative "state/item"
 
 module Lrama
   # States is passed to a template file
@@ -229,7 +229,7 @@ module Lrama
 
     private
 
-    # @rbs (Grammar::Symbol accessing_symbol, Array[Item] kernels, Hash[Array[Item], State] states_created) -> [State, bool]
+    # @rbs (Grammar::Symbol accessing_symbol, Array[State::Item] kernels, Hash[Array[State::Item], State] states_created) -> [State, bool]
     def create_state(accessing_symbol, kernels, states_created)
       # A item can appear in some states,
       # so need to use `kernels` (not `kernels.first`) as a key.
@@ -293,7 +293,7 @@ module Lrama
 
         if (sym = item.next_sym) && sym.nterm?
           @grammar.find_rules_by_symbol!(sym).each do |rule|
-            i = Item.new(rule: rule, position: 0)
+            i = State::Item.new(rule: rule, position: 0)
             next if queued[i]
             closure << i
             items << i
@@ -325,7 +325,7 @@ module Lrama
       states = []
       states_created = {}
 
-      state, _ = create_state(symbols.first, [Item.new(rule: @grammar.rules.first, position: 0)], states_created)
+      state, _ = create_state(symbols.first, [State::Item.new(rule: @grammar.rules.first, position: 0)], states_created)
       enqueue_state(states, state)
 
       while (state = states.shift) do

--- a/sig/generated/lrama/counterexamples.rbs
+++ b/sig/generated/lrama/counterexamples.rbs
@@ -16,7 +16,7 @@ module Lrama
 
     @exceed_cumulative_time_limit: bool
 
-    @state_items: Hash[[ State, States::Item ], StateItem]
+    @state_items: Hash[[ State, State::Item ], StateItem]
 
     @triples: Hash[Integer, Triple]
 
@@ -47,8 +47,8 @@ module Lrama
 
     private
 
-    # @rbs (State state, States::Item item) -> StateItem
-    def get_state_item: (State state, States::Item item) -> StateItem
+    # @rbs (State state, State::Item item) -> StateItem
+    def get_state_item: (State state, State::Item item) -> StateItem
 
     # For optimization, create all StateItem in advance
     # and use them by fetching an instance from `@state_items`.
@@ -77,17 +77,17 @@ module Lrama
     # @rbs (State conflict_state, State::ReduceReduceConflict conflict) -> Example
     def reduce_reduce_examples: (State conflict_state, State::ReduceReduceConflict conflict) -> Example
 
-    # @rbs (Array[StateItem]? reduce_state_items, State conflict_state, States::Item conflict_item) -> Array[StateItem]
-    def find_shift_conflict_shortest_path: (Array[StateItem]? reduce_state_items, State conflict_state, States::Item conflict_item) -> Array[StateItem]
+    # @rbs (Array[StateItem]? reduce_state_items, State conflict_state, State::Item conflict_item) -> Array[StateItem]
+    def find_shift_conflict_shortest_path: (Array[StateItem]? reduce_state_items, State conflict_state, State::Item conflict_item) -> Array[StateItem]
 
     # @rbs (StateItem target) -> Set[StateItem]
     def reachable_state_items: (StateItem target) -> Set[StateItem]
 
-    # @rbs (State conflict_state, States::Item conflict_reduce_item, Grammar::Symbol conflict_term) -> ::Array[StateItem]?
-    def shortest_path: (State conflict_state, States::Item conflict_reduce_item, Grammar::Symbol conflict_term) -> ::Array[StateItem]?
+    # @rbs (State conflict_state, State::Item conflict_reduce_item, Grammar::Symbol conflict_term) -> ::Array[StateItem]?
+    def shortest_path: (State conflict_state, State::Item conflict_reduce_item, Grammar::Symbol conflict_term) -> ::Array[StateItem]?
 
-    # @rbs (States::Item item, Bitmap::bitmap current_l) -> Bitmap::bitmap
-    def follow_l: (States::Item item, Bitmap::bitmap current_l) -> Bitmap::bitmap
+    # @rbs (State::Item item, Bitmap::bitmap current_l) -> Bitmap::bitmap
+    def follow_l: (State::Item item, Bitmap::bitmap current_l) -> Bitmap::bitmap
 
     # @rbs [T] (String message) { -> T } -> T
     def with_timeout: [T] (String message) { () -> T } -> T

--- a/sig/generated/lrama/counterexamples/derivation.rbs
+++ b/sig/generated/lrama/counterexamples/derivation.rbs
@@ -3,18 +3,18 @@
 module Lrama
   class Counterexamples
     class Derivation
-      @item: States::Item
+      @item: State::Item
 
       @left: Derivation?
 
-      attr_reader item: States::Item
+      attr_reader item: State::Item
 
       attr_reader left: Derivation?
 
       attr_accessor right: Derivation?
 
-      # @rbs (States::Item item, Derivation? left) -> void
-      def initialize: (States::Item item, Derivation? left) -> void
+      # @rbs (State::Item item, Derivation? left) -> void
+      def initialize: (State::Item item, Derivation? left) -> void
 
       # @rbs () -> ::String
       def to_s: () -> ::String

--- a/sig/generated/lrama/counterexamples/example.rbs
+++ b/sig/generated/lrama/counterexamples/example.rbs
@@ -34,11 +34,11 @@ module Lrama
       # @rbs () -> (:shift_reduce | :reduce_reduce)
       def type: () -> (:shift_reduce | :reduce_reduce)
 
-      # @rbs () -> States::Item
-      def path1_item: () -> States::Item
+      # @rbs () -> State::Item
+      def path1_item: () -> State::Item
 
-      # @rbs () -> States::Item
-      def path2_item: () -> States::Item
+      # @rbs () -> State::Item
+      def path2_item: () -> State::Item
 
       # @rbs () -> Derivation
       def derivations1: () -> Derivation

--- a/sig/generated/lrama/counterexamples/state_item.rbs
+++ b/sig/generated/lrama/counterexamples/state_item.rbs
@@ -7,10 +7,10 @@ module Lrama
 
       attr_reader state: State
 
-      attr_reader item: States::Item
+      attr_reader item: State::Item
 
-      # @rbs (Integer id, State state, States::Item item) -> void
-      def initialize: (Integer id, State state, States::Item item) -> void
+      # @rbs (Integer id, State state, State::Item item) -> void
+      def initialize: (Integer id, State state, State::Item item) -> void
 
       # @rbs () -> (:start | :transition | :production)
       def type: () -> (:start | :transition | :production)

--- a/sig/generated/lrama/counterexamples/triple.rbs
+++ b/sig/generated/lrama/counterexamples/triple.rbs
@@ -15,8 +15,8 @@ module Lrama
 
       alias s state
 
-      # @rbs () -> States::Item
-      def item: () -> States::Item
+      # @rbs () -> State::Item
+      def item: () -> State::Item
 
       alias itm item
 

--- a/sig/generated/lrama/state.rbs
+++ b/sig/generated/lrama/state.rbs
@@ -6,17 +6,17 @@ module Lrama
 
     type transition = Action::Shift | Action::Goto
 
-    type lookahead_set = Hash[States::Item, Array[Grammar::Symbol]]
+    type lookahead_set = Hash[Item, Array[Grammar::Symbol]]
 
     @id: Integer
 
     @accessing_symbol: Grammar::Symbol
 
-    @kernels: Array[States::Item]
+    @kernels: Array[Item]
 
-    @items: Array[States::Item]
+    @items: Array[Item]
 
-    @items_to_state: Hash[Array[States::Item], State]
+    @items_to_state: Hash[Array[Item], State]
 
     @conflicts: Array[conflict]
 
@@ -24,7 +24,7 @@ module Lrama
 
     @default_reduction_rule: Grammar::Rule?
 
-    @closure: Array[States::Item]
+    @closure: Array[Item]
 
     @nterm_transitions: Array[Action::Goto]
 
@@ -40,7 +40,7 @@ module Lrama
 
     attr_reader accessing_symbol: Grammar::Symbol
 
-    attr_reader kernels: Array[States::Item]
+    attr_reader kernels: Array[Item]
 
     attr_reader conflicts: Array[conflict]
 
@@ -48,19 +48,19 @@ module Lrama
 
     attr_reader default_reduction_rule: Grammar::Rule?
 
-    attr_reader closure: Array[States::Item]
+    attr_reader closure: Array[Item]
 
-    attr_reader items: Array[States::Item]
+    attr_reader items: Array[Item]
 
     attr_reader annotation_list: Array[InadequacyAnnotation]
 
     attr_reader predecessors: Array[State]
 
-    attr_reader items_to_state: Hash[Array[States::Item], State]
+    attr_reader items_to_state: Hash[Array[Item], State]
 
-    attr_reader lane_items: Hash[State, Array[[ States::Item, States::Item ]]]
+    attr_reader lane_items: Hash[State, Array[[ Item, Item ]]]
 
-    attr_accessor _transitions: Array[[ Grammar::Symbol, Array[States::Item] ]]
+    attr_accessor _transitions: Array[[ Grammar::Symbol, Array[Item] ]]
 
     attr_accessor reduces: Array[Action::Reduce]
 
@@ -70,20 +70,20 @@ module Lrama
 
     attr_accessor lookaheads_recomputed: bool
 
-    attr_accessor follow_kernel_items: Hash[Action::Goto, Hash[States::Item, bool]]
+    attr_accessor follow_kernel_items: Hash[Action::Goto, Hash[Item, bool]]
 
     attr_accessor always_follows: Hash[Action::Goto, Array[Grammar::Symbol]]
 
     attr_accessor goto_follows: Hash[Action::Goto, Array[Grammar::Symbol]]
 
-    # @rbs (Integer id, Grammar::Symbol accessing_symbol, Array[States::Item] kernels) -> void
-    def initialize: (Integer id, Grammar::Symbol accessing_symbol, Array[States::Item] kernels) -> void
+    # @rbs (Integer id, Grammar::Symbol accessing_symbol, Array[Item] kernels) -> void
+    def initialize: (Integer id, Grammar::Symbol accessing_symbol, Array[Item] kernels) -> void
 
     # @rbs (State other) -> bool
     def ==: (State other) -> bool
 
-    # @rbs (Array[States::Item] closure) -> void
-    def closure=: (Array[States::Item] closure) -> void
+    # @rbs (Array[Item] closure) -> void
+    def closure=: (Array[Item] closure) -> void
 
     # @rbs () -> Array[Action::Reduce]
     def non_default_reduces: () -> Array[Action::Reduce]
@@ -94,8 +94,8 @@ module Lrama
     # @rbs (Grammar::Symbol next_sym, State next_state) -> void
     def set_lane_items: (Grammar::Symbol next_sym, State next_state) -> void
 
-    # @rbs (Array[States::Item] items, State next_state) -> void
-    def set_items_to_state: (Array[States::Item] items, State next_state) -> void
+    # @rbs (Array[Item] items, State next_state) -> void
+    def set_items_to_state: (Array[Item] items, State next_state) -> void
 
     # @rbs (Grammar::Rule rule, Array[Grammar::Symbol] look_ahead) -> void
     def set_look_ahead: (Grammar::Rule rule, Array[Grammar::Symbol] look_ahead) -> void
@@ -126,8 +126,8 @@ module Lrama
     # @rbs (Grammar::Symbol sym) -> State
     def transition: (Grammar::Symbol sym) -> State
 
-    # @rbs (States::Item item) -> Action::Reduce
-    def find_reduce_by_item!: (States::Item item) -> Action::Reduce
+    # @rbs (Item item) -> Action::Reduce
+    def find_reduce_by_item!: (Item item) -> Action::Reduce
 
     # @rbs (Grammar::Rule default_reduction_rule) -> void
     def default_reduction_rule=: (Grammar::Rule default_reduction_rule) -> void
@@ -183,16 +183,16 @@ module Lrama
     # @rbs (State predecessor) -> void
     def annotate_predecessor: (State predecessor) -> void
 
-    # @rbs () -> Array[States::Item]
-    def first_kernels: () -> Array[States::Item]
+    # @rbs () -> Array[Item]
+    def first_kernels: () -> Array[Item]
 
     # @rbs (Array[InadequacyAnnotation] propagating_list) -> void
     def append_annotation_list: (Array[InadequacyAnnotation] propagating_list) -> void
 
     # Definition 3.31 (compute_lhs_contributions)
     #
-    # @rbs (Grammar::Symbol sym, Grammar::Symbol token) -> (nil | Hash[States::Item, bool])
-    def lhs_contributions: (Grammar::Symbol sym, Grammar::Symbol token) -> (nil | Hash[States::Item, bool])
+    # @rbs (Grammar::Symbol sym, Grammar::Symbol token) -> (nil | Hash[Item, bool])
+    def lhs_contributions: (Grammar::Symbol sym, Grammar::Symbol token) -> (nil | Hash[Item, bool])
 
     # Definition 3.26 (item_lookahead_sets)
     #
@@ -202,8 +202,8 @@ module Lrama
     # @rbs (lookahead_set k) -> void
     def item_lookahead_set=: (lookahead_set k) -> void
 
-    # @rbs (States::Item item) -> Array[[State, States::Item]]
-    def predecessors_with_item: (States::Item item) -> Array[[ State, States::Item ]]
+    # @rbs (Item item) -> Array[[State, Item]]
+    def predecessors_with_item: (Item item) -> Array[[ State, Item ]]
 
     # @rbs (State prev_state) -> void
     def append_predecessor: (State prev_state) -> void

--- a/sig/generated/lrama/state/action/goto.rbs
+++ b/sig/generated/lrama/state/action/goto.rbs
@@ -8,7 +8,7 @@ module Lrama
 
         @next_sym: Grammar::Symbol
 
-        @to_items: Array[States::Item]
+        @to_items: Array[Item]
 
         @to_state: State
 
@@ -16,12 +16,12 @@ module Lrama
 
         attr_reader next_sym: Grammar::Symbol
 
-        attr_reader to_items: Array[States::Item]
+        attr_reader to_items: Array[Item]
 
         attr_reader to_state: State
 
-        # @rbs (State from_state, Grammar::Symbol next_sym, Array[States::Item] to_items, State to_state) -> void
-        def initialize: (State from_state, Grammar::Symbol next_sym, Array[States::Item] to_items, State to_state) -> void
+        # @rbs (State from_state, Grammar::Symbol next_sym, Array[Item] to_items, State to_state) -> void
+        def initialize: (State from_state, Grammar::Symbol next_sym, Array[Item] to_items, State to_state) -> void
       end
     end
   end

--- a/sig/generated/lrama/state/action/reduce.rbs
+++ b/sig/generated/lrama/state/action/reduce.rbs
@@ -4,7 +4,7 @@ module Lrama
   class State
     class Action
       class Reduce
-        @item: States::Item
+        @item: Item
 
         @look_ahead: Array[Grammar::Symbol]?
 
@@ -12,7 +12,7 @@ module Lrama
 
         @not_selected_symbols: Array[Grammar::Symbol]
 
-        attr_reader item: States::Item
+        attr_reader item: Item
 
         attr_reader look_ahead: Array[Grammar::Symbol]?
 
@@ -23,8 +23,8 @@ module Lrama
         # https://www.gnu.org/software/bison/manual/html_node/Default-Reductions.html
         attr_accessor default_reduction: bool
 
-        # @rbs (States::Item item) -> void
-        def initialize: (States::Item item) -> void
+        # @rbs (Item item) -> void
+        def initialize: (Item item) -> void
 
         # @rbs () -> Grammar::Rule
         def rule: () -> Grammar::Rule

--- a/sig/generated/lrama/state/action/shift.rbs
+++ b/sig/generated/lrama/state/action/shift.rbs
@@ -8,7 +8,7 @@ module Lrama
 
         @next_sym: Grammar::Symbol
 
-        @to_items: Array[States::Item]
+        @to_items: Array[Item]
 
         @to_state: State
 
@@ -16,14 +16,14 @@ module Lrama
 
         attr_reader next_sym: Grammar::Symbol
 
-        attr_reader to_items: Array[States::Item]
+        attr_reader to_items: Array[Item]
 
         attr_reader to_state: State
 
         attr_accessor not_selected: bool
 
-        # @rbs (State from_state, Grammar::Symbol next_sym, Array[States::Item] to_items, State to_state) -> void
-        def initialize: (State from_state, Grammar::Symbol next_sym, Array[States::Item] to_items, State to_state) -> void
+        # @rbs (State from_state, Grammar::Symbol next_sym, Array[Item] to_items, State to_state) -> void
+        def initialize: (State from_state, Grammar::Symbol next_sym, Array[Item] to_items, State to_state) -> void
 
         # @rbs () -> void
         def clear_conflicts: () -> void

--- a/sig/generated/lrama/state/inadequacy_annotation.rbs
+++ b/sig/generated/lrama/state/inadequacy_annotation.rbs
@@ -11,16 +11,16 @@ module Lrama
 
       attr_accessor actions: Array[action]
 
-      attr_accessor contribution_matrix: Hash[action, Hash[States::Item, bool]]
+      attr_accessor contribution_matrix: Hash[action, Hash[Item, bool]]
 
-      # @rbs (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[States::Item, bool]] contribution_matrix) -> void
-      def initialize: (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[States::Item, bool]] contribution_matrix) -> void
+      # @rbs (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[Item, bool]] contribution_matrix) -> void
+      def initialize: (State state, Grammar::Symbol token, Array[action] actions, Hash[action, Hash[Item, bool]] contribution_matrix) -> void
 
-      # @rbs (States::Item item) -> bool
-      def contributed?: (States::Item item) -> bool
+      # @rbs (Item item) -> bool
+      def contributed?: (Item item) -> bool
 
-      # @rbs (Array[Hash[action, Hash[States::Item, bool]]] another_matrixes) -> void
-      def merge_matrix: (Array[Hash[action, Hash[States::Item, bool]]] another_matrixes) -> void
+      # @rbs (Array[Hash[action, Hash[Item, bool]]] another_matrixes) -> void
+      def merge_matrix: (Array[Hash[action, Hash[Item, bool]]] another_matrixes) -> void
 
       # Definition 3.42 (dominant_contribution)
       #

--- a/sig/generated/lrama/state/item.rbs
+++ b/sig/generated/lrama/state/item.rbs
@@ -1,7 +1,7 @@
-# Generated from lib/lrama/states/item.rb with RBS::Inline
+# Generated from lib/lrama/state/item.rb with RBS::Inline
 
 module Lrama
-  class States
+  class State
     class Item
       include Grammar::Rule::_DelegatedMethods
 
@@ -45,8 +45,8 @@ module Lrama
       # @rbs () -> bool
       def start_item?: () -> bool
 
-      # @rbs () -> States::Item
-      def new_by_next_position: () -> States::Item
+      # @rbs () -> State::Item
+      def new_by_next_position: () -> State::Item
 
       # @rbs () -> Array[Grammar::Symbol]
       def symbols_before_dot: () -> Array[Grammar::Symbol]
@@ -68,8 +68,8 @@ module Lrama
       # @rbs () -> ::String
       def display_rest: () -> ::String
 
-      # @rbs (States::Item other_item) -> bool
-      def predecessor_item_of?: (States::Item other_item) -> bool
+      # @rbs (State::Item other_item) -> bool
+      def predecessor_item_of?: (State::Item other_item) -> bool
     end
   end
 end

--- a/sig/generated/lrama/states.rbs
+++ b/sig/generated/lrama/states.rbs
@@ -83,8 +83,8 @@ module Lrama
 
     private
 
-    # @rbs (Grammar::Symbol accessing_symbol, Array[Item] kernels, Hash[Array[Item], State] states_created) -> [State, bool]
-    def create_state: (Grammar::Symbol accessing_symbol, Array[Item] kernels, Hash[Array[Item], State] states_created) -> [ State, bool ]
+    # @rbs (Grammar::Symbol accessing_symbol, Array[State::Item] kernels, Hash[Array[State::Item], State] states_created) -> [State, bool]
+    def create_state: (Grammar::Symbol accessing_symbol, Array[State::Item] kernels, Hash[Array[State::Item], State] states_created) -> [ State, bool ]
 
     # @rbs (State state) -> void
     def setup_state: (State state) -> void


### PR DESCRIPTION
`Item` is held by `State` thne it's better to place `Item` under `State` rather than `States`.