### PR TITLE
Improve format for generate_error_message

### DIFF
--- a/lib/lrama/lexer/location.rb
+++ b/lib/lrama/lexer/location.rb
@@ -69,15 +69,15 @@ module Lrama
       def generate_error_message(error_message)
         <<~ERROR.chomp
           #{path}:#{first_line}:#{first_column}: #{error_message}
-          #{line_with_carets}
+          #{error_with_carets}
         ERROR
       end
 
       # @rbs () -> String
-      def line_with_carets
+      def error_with_carets
         <<~TEXT
-          #{text}
-          #{carets}
+          #{formatted_first_lineno} | #{text}
+          #{line_number_padding} | #{carets_line}
         TEXT
       end
 
@@ -89,13 +89,30 @@ module Lrama
       end
 
       # @rbs () -> String
-      def blanks
-        (text[0...first_column] or raise "#{first_column} is invalid").gsub(/[^\t]/, ' ')
+      def carets_line
+        leading_whitespace + highlight_marker
       end
 
       # @rbs () -> String
-      def carets
-        blanks + '^' * (last_column - first_column)
+      def leading_whitespace
+        (text[0...first_column] or raise "Invalid first_column: #{first_column}")
+          .gsub(/[^\t]/, ' ')
+      end
+
+      # @rbs () -> String
+      def highlight_marker
+        length = last_column - first_column
+        '^' + '~' * [0, length - 1].max
+      end
+
+      # @rbs () -> String
+      def formatted_first_lineno
+        first_line.to_s.rjust(4)
+      end
+
+      # @rbs () -> String
+      def line_number_padding
+        ' ' * formatted_first_lineno.length
       end
 
       # @rbs () -> String

--- a/sig/generated/lrama/lexer/location.rbs
+++ b/sig/generated/lrama/lexer/location.rbs
@@ -29,7 +29,7 @@ module Lrama
       def generate_error_message: (String error_message) -> String
 
       # @rbs () -> String
-      def line_with_carets: () -> String
+      def error_with_carets: () -> String
 
       private
 
@@ -37,10 +37,19 @@ module Lrama
       def path: () -> String
 
       # @rbs () -> String
-      def blanks: () -> String
+      def carets_line: () -> String
 
       # @rbs () -> String
-      def carets: () -> String
+      def leading_whitespace: () -> String
+
+      # @rbs () -> String
+      def highlight_marker: () -> String
+
+      # @rbs () -> String
+      def formatted_first_lineno: () -> String
+
+      # @rbs () -> String
+      def line_number_padding: () -> String
 
       # @rbs () -> String
       def text: () -> String

--- a/spec/lrama/grammar/rule_builder_spec.rb
+++ b/spec/lrama/grammar/rule_builder_spec.rb
@@ -240,8 +240,8 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
 
         expected = <<~TEXT
           parse.y:1:53: Can not refer following component. 10 >= 4.
-          class : keyword_class tSTRING keyword_end { $class = $10; }
-                                                               ^^^
+             1 | class : keyword_class tSTRING keyword_end { $class = $10; }
+               |                                                      ^~~
         TEXT
 
         expect { rule_builder.send(:preprocess_references) }.to raise_error(expected)
@@ -275,8 +275,8 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
 
         expected = <<~TEXT
           parse.y:1:24: Can not refer following component. 3 >= 2.
-          class : keyword_class { $3; } tSTRING keyword_end { $class = $1; }
-                                  ^^
+             1 | class : keyword_class { $3; } tSTRING keyword_end { $class = $1; }
+               |                         ^~
         TEXT
 
         expect { rule_builder.send(:preprocess_references) }.to raise_error(expected)
@@ -307,8 +307,8 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
 
         expected = <<~TEXT
           parse.y:1:44: Referring symbol `classes` is not found.
-          class : keyword_class tSTRING keyword_end { $classes = $1; }
-                                                      ^^^^^^^^
+             1 | class : keyword_class tSTRING keyword_end { $classes = $1; }
+               |                                             ^~~~~~~~
         TEXT
 
         expect { rule_builder.send(:preprocess_references) }.to raise_error(expected)
@@ -337,8 +337,8 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
         it "raises error" do
           expected = <<~TEXT
             parse.y:10:60: Referring symbol `tSTRING` is duplicated.
-            class: keyword_class tSTRING tSTRING keyword_end { $class = $tSTRING; }
-                                                                        ^^^^^^^^
+              10 | class: keyword_class tSTRING tSTRING keyword_end { $class = $tSTRING; }
+                 |                                                             ^~~~~~~~
           TEXT
           expect {
             grammar = Lrama::Parser.new(y, "parse.y").parse
@@ -369,8 +369,8 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
         it "raises error" do
           expected = <<~TEXT
             parse.y:10:35: Referring symbol `class` is duplicated.
-            class: class tSTRING keyword_end { $class = $tSTRING; }
-                                               ^^^^^^
+              10 | class: class tSTRING keyword_end { $class = $tSTRING; }
+                 |                                    ^~~~~~
           TEXT
           expect {
             grammar = Lrama::Parser.new(y, "parse.y").parse
@@ -401,8 +401,8 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
         it "raises error" do
           expected = <<~TEXT
             parse.y:10:42: Referring symbol `class` is duplicated.
-            klass[class]: class tSTRING keyword_end { $class = $tSTRING; }
-                                                      ^^^^^^
+              10 | klass[class]: class tSTRING keyword_end { $class = $tSTRING; }
+                 |                                           ^~~~~~
           TEXT
           expect {
             grammar = Lrama::Parser.new(y, "parse.y").parse
@@ -433,8 +433,8 @@ RSpec.describe Lrama::Grammar::RuleBuilder do
         it "raises error" do
           expected = <<~TEXT
             parse.y:10:49: Referring symbol `class` is duplicated.
-            klass[class]: Klass[class] tSTRING keyword_end { $class = $tSTRING; }
-                                                             ^^^^^^
+              10 | klass[class]: Klass[class] tSTRING keyword_end { $class = $tSTRING; }
+                 |                                                  ^~~~~~
           TEXT
           expect {
             grammar = Lrama::Parser.new(y, "parse.y").parse

--- a/spec/lrama/lexer/location_spec.rb
+++ b/spec/lrama/lexer/location_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Lrama::Lexer::Location do
       location = Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 33, first_column: 12, last_line: 33, last_column: 15)
       expected = <<~TEXT
         #{path}:33:12: ERROR
-             | expr '+' expr { $$ = $1 + $3; }
-                    ^^^
+          33 |      | expr '+' expr { $$ = $1 + $3; }
+             |             ^~~
       TEXT
 
       expect(location.generate_error_message("ERROR")).to eq expected
@@ -40,11 +40,11 @@ RSpec.describe Lrama::Lexer::Location do
       grammar_file = Lrama::Lexer::GrammarFile.new(path, File.read(path))
       location = Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 33, first_column: 12, last_line: 33, last_column: 15)
       expected = <<-TEXT
-     | expr '+' expr { $$ = $1 + $3; }
-            ^^^
+  33 |      | expr '+' expr { $$ = $1 + $3; }
+     |             ^~~
       TEXT
 
-      expect(location.line_with_carets).to eq expected
+      expect(location.error_with_carets).to eq expected
     end
   end
 end

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -3523,8 +3523,8 @@ RSpec.describe Lrama::Parser do
 
         expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
           parse.y:31:78: multiple User_code after %prec
-          class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { code 6 }
-                                                                                        ^
+            31 | class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { code 6 }
+               |                                                                               ^
         ERROR
       end
 
@@ -3544,8 +3544,8 @@ RSpec.describe Lrama::Parser do
 
         expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
           parse.y:31:34: intermediate %prec in a rule
-          class : keyword_class %prec tPLUS keyword_end { code 1 }
-                                            ^^^^^^^^^^^
+            31 | class : keyword_class %prec tPLUS keyword_end { code 1 }
+               |                                   ^~~~~~~~~~~
         ERROR
       end
 
@@ -3565,8 +3565,8 @@ RSpec.describe Lrama::Parser do
 
         expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
           parse.y:31:32: intermediate %prec in a rule
-          class : keyword_class %prec "=" keyword_end { code 1 }
-                                          ^^^^^^^^^^^
+            31 | class : keyword_class %prec "=" keyword_end { code 1 }
+               |                                 ^~~~~~~~~~~
         ERROR
       end
 
@@ -3586,8 +3586,8 @@ RSpec.describe Lrama::Parser do
 
         expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
           parse.y:31:40: multiple %prec in a rule
-          class : keyword_class %prec tPLUS %prec tMINUS keyword_end { code 1 }
-                                                  ^^^^^^
+            31 | class : keyword_class %prec tPLUS %prec tMINUS keyword_end { code 1 }
+               |                                         ^~~~~~
         ERROR
       end
     end
@@ -4131,8 +4131,8 @@ RSpec.describe Lrama::Parser do
 
             expected = <<~ERROR
               parse.y:27:18: Referring symbol `results` is not found.
-                                $results = $left + $right;
-                                ^^^^^^^^
+                27 |                   $results = $left + $right;
+                   |                   ^~~~~~~~
             ERROR
 
             expect do
@@ -4165,8 +4165,8 @@ RSpec.describe Lrama::Parser do
 
           expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
             error_messages/parse.y:5:8: parse error on value 'invalid' (IDENTIFIER)
-            %expect invalid
-                    ^^^^^^^
+               5 | %expect invalid
+                 |         ^~~~~~~
           ERROR
         end
       end
@@ -4190,8 +4190,8 @@ RSpec.describe Lrama::Parser do
 
           expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
             error_messages/parse.y:5:10: parse error on value 10 (INTEGER)
-            %expect 0 10
-                      ^^
+               5 | %expect 0 10
+                 |           ^~
           ERROR
         end
       end
@@ -4215,8 +4215,8 @@ RSpec.describe Lrama::Parser do
 
           expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
             error_messages/parse.y:5:9: parse error on value 'invalid' (IDENTIFIER)
-            %expect\t\tinvalid
-                   \t\t^^^^^^^
+               5 | %expect\t\tinvalid
+                 |        \t\t^~~~~~~
           ERROR
         end
       end
@@ -4241,8 +4241,8 @@ RSpec.describe Lrama::Parser do
 
           expect { parser.parse }.to raise_error(ParseError, <<~ERROR)
             error_messages/parse.y:6:7: symbol EOI redeclared as a nonterminal
-            %nterm EOI
-                   ^^^
+               6 | %nterm EOI
+                 |        ^~~
           ERROR
         end
       end
@@ -4264,8 +4264,8 @@ RSpec.describe Lrama::Parser do
 
           expect { parser.parse }.to raise_error(ParseError, <<~'ERROR')
             error_messages/parse.y:7:9: %empty on non-empty rule
-            program: %empty %empty
-                     ^^^^^^
+               7 | program: %empty %empty
+                 |          ^~~~~~
           ERROR
         end
       end
@@ -4289,8 +4289,8 @@ RSpec.describe Lrama::Parser do
 
           expect { parser.parse }.to raise_error(ParseError, <<~'ERROR')
             error_messages/parse.y:9:16: %empty on non-empty rule
-            program: NUMBER %empty
-                            ^^^^^^
+               9 | program: NUMBER %empty
+                 |                 ^~~~~~
           ERROR
         end
       end


### PR DESCRIPTION
Before:
```
parse.y:31:78: multiple User_code after %prec
class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { code 6 }
                                                                              ^

error_messages/parse.y:7:9: %empty on non-empty rule
program: %empty %empty
         ^^^^^^
```

After:
```
parse.y:31:78: multiple User_code after %prec
  31 | class : keyword_class { code 4 } tSTRING '?' keyword_end %prec tEQ { code 5 } { code 6 }
     |                                                                               ^

error_messages/parse.y:7:9: %empty on non-empty rule
  7 | program: %empty %empty
    |          ^~~~~~
```