### PR TITLE
Fix line number counting when there are trailing spaces

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -104,7 +104,7 @@ module Lrama
         when @scanner.scan(/\n/)
           newline
         when @scanner.scan(/\s+/)
-          # noop
+          @scanner.matched.count("\n").times { newline }
         when @scanner.scan(/\/\*/)
           lex_comment
         when @scanner.scan(/\/\/.*(?<newline>\n)?/)

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -420,4 +420,11 @@ RSpec.describe Lrama::Lexer do
 
     expect(lexer.next_token).to be_nil
   end
+
+  it 'lex a trailing space with newline' do
+    grammar_file = Lrama::Lexer::GrammarFile.new("trailing_space.y", " \n%require")
+    lexer = Lrama::Lexer.new(grammar_file)
+
+    expect(lexer.next_token[1].location).to eq Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 2, first_column: 0, last_line: 2, last_column: 8)
+  end
 end


### PR DESCRIPTION
Previously, when there are trailing whitespace characters at the end of line, lrama miscounted the line number.

```
  // <=== Place whitespace here (and do not place this comment)
%{puts("Hello");
%}
%%
a: ‘-’;
```

```
$ ./exe/lrama t.y && less y.tab.c
*snip*

/* First part of user prologue.  */
#line 1 "t.y"  // <=== This should be #line 2
puts("Hello");

*snip*
```