### PR TITLE
Improve error messages in Lexer for unexpected tokens and code

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -145,7 +145,7 @@ module Lrama
           end
         return [type, token]
       else
-        raise ParseError, "Unexpected token: #{@scanner.peek(10).chomp}." # steep:ignore UnknownConstant
+        raise ParseError, location.generate_error_message("Unexpected token") # steep:ignore UnknownConstant
       end
     end
 
@@ -186,7 +186,7 @@ module Lrama
           code << @scanner.getch
         end
       end
-      raise ParseError, "Unexpected code: #{code}." # steep:ignore UnknownConstant
+      raise ParseError, location.generate_error_message("Unexpected code: #{code}") # steep:ignore UnknownConstant
     end
 
     private

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -396,10 +396,14 @@ RSpec.describe Lrama::Lexer do
     it do
       path = fixture_path("common/unexpected_token.y")
       text = File.read(path)
-      grammar_file = Lrama::Lexer::GrammarFile.new(path, text)
+      grammar_file = Lrama::Lexer::GrammarFile.new("unexpected_token.y", text)
       lexer = Lrama::Lexer.new(grammar_file)
 
-      expect { lexer.next_token }.to raise_error(ParseError, "Unexpected token: @invalid.")
+      expect { lexer.next_token }.to raise_error(ParseError, <<~MSG)
+        unexpected_token.y:5:0: Unexpected token
+           5 | @invalid
+             | ^
+      MSG
     end
   end
 
@@ -410,7 +414,11 @@ RSpec.describe Lrama::Lexer do
       lexer.status = :c_declaration
       lexer.end_symbol = "%}"
 
-      expect { lexer.next_token }.to raise_error(ParseError, "Unexpected code: @invalid.")
+      expect { lexer.next_token }.to raise_error(ParseError, <<~MSG)
+        invalid.y:1:0: Unexpected code: @invalid
+           1 | @invalid
+             | ^~~~~~~~
+        MSG
     end
   end
 


### PR DESCRIPTION
Before:
```
Unexpected token: @invalid
```

After:
```
unexpected_token.y:5:0: Unexpected token
  5 | @invalid
    | ^
```