### PR TITLE
Add LAC (Lookahead Correction) support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,27 @@
 
 ## Lrama 0.8.0 (2026-xx-xx)
 
+### LAC (Lookahead Correction) Support
+
+Added support for LAC (Lookahead Correction), which improves syntax error reporting by providing more accurate error messages. LAC can be enabled using the `%define parse.lac full` directive in grammar files.
+
+Key features:
+- More precise "expected token" lists in syntax error messages
+- Early error detection (before default reductions)
+- Better handling of `%nonassoc` operators
+- Compatible with existing LALR parser generation
+
+Example usage:
+```yacc
+%define parse.lac full
+%define parse.error verbose
+
+%%
+expr: expr '+' expr
+    | NUMBER
+    ;
+```
+
 ## Lrama 0.7.1 (2025-12-24)
 
 ### Optimize IELR

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Lrama (pronounced in the same way as the noun “llama” in English) is LALR (1
   * b4_locations_if is always true
   * b4_pure_if is always true
   * b4_pull_if is always false
-  * b4_lac_if is always false
+* LAC (Lookahead Correction)
+  * Improves syntax error reporting with more accurate "expected token" messages
+  * Enable with `%define parse.lac full`
+  * Compatible with LALR parser generation
 * Error Tolerance parser
   * Subset of [Repairing Syntax Errors in LR Parsers (Corchuelo et al.)](https://idus.us.es/bitstream/handle/11441/65631/Repairing%20syntax%20errors.pdf) algorithm is supported
 * Parameterizing rules

--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -277,6 +277,7 @@ module Lrama
       validate_no_precedence_for_nterm!
       validate_rule_lhs_is_nterm!
       validate_duplicated_precedence!
+      validate_parse_lac!
     end
 
     # @rbs (Grammar::Symbol sym) -> Array[Rule]
@@ -302,6 +303,16 @@ module Lrama
     # @rbs () -> bool
     def ielr_defined?
       @define.key?('lr.type') && @define['lr.type'] == 'ielr'
+    end
+
+    # @rbs () -> String
+    def parse_lac
+      @define['parse.lac'] || 'none'
+    end
+
+    # @rbs () -> bool
+    def lac_enabled?
+      parse_lac == 'full'
     end
 
     private
@@ -598,6 +609,18 @@ module Lrama
     # @rbs () -> void
     def set_locations
       @locations = @locations || @rules.any? {|rule| rule.contains_at_reference? }
+    end
+
+    # @rbs () -> void
+    def validate_parse_lac!
+      return unless @define.key?('parse.lac')
+
+      value = @define['parse.lac']
+      valid_values = ['none', 'full']
+
+      unless valid_values.include?(value)
+        raise "Invalid value for parse.lac: '#{value}'. Expected 'none' or 'full'."
+      end
     end
   end
 end

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -372,6 +372,10 @@ module Lrama
       @grammar.aux
     end
 
+    def lac_enabled?
+      @grammar.lac_enabled?
+    end
+
     def int_array_to_string(ary)
       last = ary.count - 1
 

--- a/sig/generated/lrama/grammar.rbs
+++ b/sig/generated/lrama/grammar.rbs
@@ -227,6 +227,12 @@ module Lrama
     # @rbs () -> bool
     def ielr_defined?: () -> bool
 
+    # @rbs () -> String
+    def parse_lac: () -> String
+
+    # @rbs () -> bool
+    def lac_enabled?: () -> bool
+
     private
 
     # @rbs () -> void
@@ -285,5 +291,8 @@ module Lrama
 
     # @rbs () -> void
     def set_locations: () -> void
+
+    # @rbs () -> void
+    def validate_parse_lac!: () -> void
   end
 end

--- a/spec/fixtures/integration/lac.y
+++ b/spec/fixtures/integration/lac.y
@@ -1,0 +1,46 @@
+%{
+#include <stdio.h>
+#include <stdlib.h>
+
+int yylex(YYSTYPE *yylval, YYLTYPE *yylloc);
+void yyerror(YYLTYPE *yylloc, const char *s);
+%}
+
+%define parse.lac full
+%define parse.error verbose
+%locations
+
+%token NUMBER
+
+%left '+' '-'
+%left '*' '/'
+
+%%
+
+program: expr
+       ;
+
+expr: expr '+' expr
+    | expr '-' expr
+    | expr '*' expr
+    | expr '/' expr
+    | '(' expr ')'
+    | NUMBER
+    ;
+
+%%
+
+void yyerror(YYLTYPE *yylloc, const char *s) {
+  (void)yylloc;
+  fprintf(stderr, "Error: %s\n", s);
+}
+
+int yylex(YYSTYPE *yylval, YYLTYPE *yylloc) {
+  (void)yylval;
+  (void)yylloc;
+  return 0;
+}
+
+int main() {
+  return yyparse();
+}

--- a/spec/fixtures/integration/lac_accurate_tokens.l
+++ b/spec/fixtures/integration/lac_accurate_tokens.l
@@ -1,0 +1,48 @@
+%option noinput nounput noyywrap never-interactive bison-bridge bison-locations
+
+%{
+#include <stdio.h>
+#include <stdlib.h>
+#include "lac_accurate_tokens.h"
+%}
+
+%%
+
+"if"    { return IF; }
+"then"  { return THEN; }
+"else"  { return ELSE; }
+"while" { return WHILE; }
+"do"    { return DO; }
+
+[a-zA-Z_][a-zA-Z0-9_]* {
+  (void)yylval;
+  (void)yylloc;
+  return ID;
+}
+
+[0-9]+ {
+  (void)yylval;
+  (void)yylloc;
+  return NUM;
+}
+
+[+\-*/] {
+  return yytext[0];
+}
+
+[\n|\r\n] {
+  return(YYEOF);
+}
+
+[[:space:]] {}
+
+<<EOF>> {
+  return(YYEOF);
+}
+
+. {
+  fprintf(stderr, "Illegal character '%s'\n", yytext);
+  return(YYEOF);
+}
+
+%%

--- a/spec/fixtures/integration/lac_accurate_tokens.y
+++ b/spec/fixtures/integration/lac_accurate_tokens.y
@@ -1,0 +1,65 @@
+%{
+#include <stdio.h>
+#include "lac_accurate_tokens.h"
+#include "lac_accurate_tokens-lexer.h"
+
+static int yyerror(YYLTYPE *loc, const char *str);
+%}
+
+%define parse.lac full
+%define parse.error verbose
+
+%token IF THEN ELSE WHILE DO ID NUM
+
+%left '+' '-'
+%left '*' '/'
+
+%locations
+
+%%
+
+program: stmt_list
+       ;
+
+stmt_list: stmt
+         | stmt_list stmt
+         ;
+
+stmt: if_stmt
+    | while_stmt
+    | expr
+    ;
+
+if_stmt: IF expr THEN stmt
+       | IF expr THEN stmt ELSE stmt
+       ;
+
+while_stmt: WHILE expr DO stmt
+          ;
+
+expr: expr '+' expr
+    | expr '-' expr
+    | expr '*' expr
+    | expr '/' expr
+    | NUM
+    | ID
+    ;
+
+%%
+
+static int yyerror(YYLTYPE *loc, const char *str) {
+  (void)loc;
+  printf("Error: %s\n", str);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc == 2) {
+    yy_scan_string(argv[1]);
+  }
+
+  if (yyparse()) {
+    return 1;
+  }
+  return 0;
+}

--- a/spec/fixtures/integration/lac_default_reduction.l
+++ b/spec/fixtures/integration/lac_default_reduction.l
@@ -1,0 +1,42 @@
+%option noinput nounput noyywrap never-interactive bison-bridge bison-locations
+
+%{
+#include <stdio.h>
+#include <stdlib.h>
+#include "lac_default_reduction.h"
+%}
+
+%%
+
+[a-zA-Z_][a-zA-Z0-9_]* {
+  (void)yylval;
+  (void)yylloc;
+  return ID;
+}
+
+[0-9]+ {
+  (void)yylval;
+  (void)yylloc;
+  return NUM;
+}
+
+[=+*;] {
+  return yytext[0];
+}
+
+[\n|\r\n] {
+  return(YYEOF);
+}
+
+[[:space:]] {}
+
+<<EOF>> {
+  return(YYEOF);
+}
+
+. {
+  fprintf(stderr, "Illegal character '%s'\n", yytext);
+  return(YYEOF);
+}
+
+%%

--- a/spec/fixtures/integration/lac_default_reduction.y
+++ b/spec/fixtures/integration/lac_default_reduction.y
@@ -1,0 +1,48 @@
+%{
+#include <stdio.h>
+#include "lac_default_reduction.h"
+#include "lac_default_reduction-lexer.h"
+
+static int yyerror(YYLTYPE *loc, const char *str);
+%}
+
+%define parse.lac full
+%define parse.error verbose
+
+%token ID NUM
+
+%locations
+
+%%
+
+program: stmt
+       ;
+
+stmt: ID '=' expr ';'
+    | expr ';'
+    ;
+
+expr: expr '+' expr
+    | expr '*' expr
+    | NUM
+    | ID
+    ;
+
+%%
+
+static int yyerror(YYLTYPE *loc, const char *str) {
+  (void)loc;
+  printf("Error: %s\n", str);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc == 2) {
+    yy_scan_string(argv[1]);
+  }
+
+  if (yyparse()) {
+    return 1;
+  }
+  return 0;
+}

--- a/spec/fixtures/integration/lac_nonassoc.l
+++ b/spec/fixtures/integration/lac_nonassoc.l
@@ -1,0 +1,36 @@
+%option noinput nounput noyywrap never-interactive bison-bridge bison-locations
+
+%{
+#include <stdio.h>
+#include <stdlib.h>
+#include "lac_nonassoc.h"
+%}
+
+%%
+
+[0-9]+ {
+  (void)yylval;
+  (void)yylloc;
+  return NUMBER;
+}
+
+"<" {
+  return '<';
+}
+
+[\n|\r\n] {
+  return(YYEOF);
+}
+
+[[:space:]] {}
+
+<<EOF>> {
+  return(YYEOF);
+}
+
+. {
+  fprintf(stderr, "Illegal character '%s'\n", yytext);
+  return(YYEOF);
+}
+
+%%

--- a/spec/fixtures/integration/lac_nonassoc.y
+++ b/spec/fixtures/integration/lac_nonassoc.y
@@ -1,0 +1,44 @@
+%{
+#include <stdio.h>
+#include "lac_nonassoc.h"
+#include "lac_nonassoc-lexer.h"
+
+static int yyerror(YYLTYPE *loc, const char *str);
+%}
+
+%define parse.lac full
+%define parse.error verbose
+
+%token NUMBER
+
+%nonassoc '<'
+
+%locations
+
+%%
+
+program: expr
+       ;
+
+expr: expr '<' expr
+    | NUMBER
+    ;
+
+%%
+
+static int yyerror(YYLTYPE *loc, const char *str) {
+  (void)loc;
+  printf("Error: %s\n", str);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc == 2) {
+    yy_scan_string(argv[1]);
+  }
+
+  if (yyparse()) {
+    return 1;
+  }
+  return 0;
+}

--- a/spec/lrama/grammar_spec.rb
+++ b/spec/lrama/grammar_spec.rb
@@ -242,5 +242,57 @@ RSpec.describe Lrama::Grammar do
           end
       end
     end
+
+    context 'when parse.lac has an invalid value' do
+      it 'raises an error' do
+        grammar.define['parse.lac'] = 'invalid'
+        expect { grammar.validate! }
+          .to raise_error(RuntimeError, "Invalid value for parse.lac: 'invalid'. Expected 'none' or 'full'.")
+      end
+    end
+  end
+
+  describe '#parse_lac' do
+    context 'when parse.lac is not set' do
+      it 'returns "none" as default' do
+        expect(grammar.parse_lac).to eq('none')
+      end
+    end
+
+    context 'when parse.lac is set to "none"' do
+      it 'returns "none"' do
+        grammar.define['parse.lac'] = 'none'
+        expect(grammar.parse_lac).to eq('none')
+      end
+    end
+
+    context 'when parse.lac is set to "full"' do
+      it 'returns "full"' do
+        grammar.define['parse.lac'] = 'full'
+        expect(grammar.parse_lac).to eq('full')
+      end
+    end
+  end
+
+  describe '#lac_enabled?' do
+    context 'when parse.lac is not set (default)' do
+      it 'returns false' do
+        expect(grammar.lac_enabled?).to be false
+      end
+    end
+
+    context 'when parse.lac is "none"' do
+      it 'returns false' do
+        grammar.define['parse.lac'] = 'none'
+        expect(grammar.lac_enabled?).to be false
+      end
+    end
+
+    context 'when parse.lac is "full"' do
+      it 'returns true' do
+        grammar.define['parse.lac'] = 'full'
+        expect(grammar.lac_enabled?).to be true
+      end
+    end
   end
 end

--- a/spec/lrama/integration_spec.rb
+++ b/spec/lrama/integration_spec.rb
@@ -269,6 +269,54 @@ RSpec.describe "integration" do
     end
   end
 
+  describe "LAC (Lookahead Correction)" do
+    describe "%nonassoc operators" do
+      it "provides accurate error messages for chained comparisons" do
+        test_parser("lac_nonassoc", "1 < 2 < 3", "Error: syntax error, unexpected '<', expecting end of file\n", expect_success: false)
+      end
+
+      it "accepts valid single comparison" do
+        test_parser("lac_nonassoc", "1 < 2", "", expect_success: true)
+      end
+    end
+
+    describe "default reductions" do
+      it "detects errors early before default reductions" do
+        test_parser("lac_default_reduction", "x = 1 + *", "Error: syntax error, unexpected '*', expecting ID or NUM\n", expect_success: false)
+      end
+
+      it "accepts valid assignment" do
+        test_parser("lac_default_reduction", "x = 1 + 2;", "", expect_success: true)
+      end
+
+      it "accepts valid expression statement" do
+        test_parser("lac_default_reduction", "1 + 2 * 3;", "", expect_success: true)
+      end
+    end
+
+    describe "accurate expected token lists" do
+      it "detects invalid tokens in control flow statements" do
+        test_parser("lac_accurate_tokens", "if x do y", "Error: syntax error, unexpected DO\n", expect_success: false)
+      end
+
+      it "accepts valid if-then statement" do
+        test_parser("lac_accurate_tokens", "if x then y", "", expect_success: true)
+      end
+
+      it "accepts valid if-then-else statement" do
+        test_parser("lac_accurate_tokens", "if x then y else z", "", expect_success: true)
+      end
+
+      it "accepts valid while-do statement" do
+        test_parser("lac_accurate_tokens", "while x do y", "", expect_success: true)
+      end
+
+      it "accepts nested control flow" do
+        test_parser("lac_accurate_tokens", "if x then while y do z", "", expect_success: true)
+      end
+    end
+  end
+
   describe "sample files" do
     let(:c_path)   { Dir.tmpdir + "/test#{file_extension}" }
     let(:obj_path) { Dir.tmpdir + "/test" }


### PR DESCRIPTION
LALR parsers with default reductions can report inaccurate syntax error messages. When a default reduction is performed, the parser may consume tokens before detecting an error, leading to confusing "expected token" lists that include tokens not actually acceptable at the error point.

Additionally, `%nonassoc` operators can cause similar issues where the parser reports unexpected tokens in error messages.

LAC (Lookahead Correction) solves these problems by performing exploratory parsing to verify token acceptability before committing to reductions.

refs: https://www.gnu.org/software/bison/manual/html_node/LAC.html