### PR TITLE
Exclude vendored gems from C source check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,9 +135,10 @@ jobs:
       - run: bundle install
 
       # Copy from https://github.com/ruby/ruby/blob/cb9a47f2acd6e373ef868b890a9d07da6f565dd4/.github/workflows/check_misc.yml#L31
+      # Exclude vendored gems: they are not part of this repository's sources.
       - name: Check if C-sources are US-ASCII
         run: |
-          grep -r -n --include='*.[chyS]' --include='*.asm' $'[^\t-~]' -- . && exit 1 || :
+          grep -r -n --exclude-dir=vendor --include='*.[chyS]' --include='*.asm' $'[^\t-~]' -- . && exit 1 || :
 
       # Copy from https://github.com/ruby/ruby/blob/089227e94823542acfdafa68541d330eee42ffea/.github/workflows/check_misc.yml#L27
       - name: Check for trailing spaces


### PR DESCRIPTION
The US-ASCII C source check recursively scanned `vendor/bundle` after Bundler restored cached gems. RBS 4.2.0 contains a non-ASCII comment in `src/lexstate.c`, causing `check-misc` to fail on dependency source code.

Exclude `vendor` from the recursive grep while continuing to check repository-owned C sources.