### PR TITLE
Ignore references in C literals and comments

### DIFF
--- a/lib/lrama/lexer/token/user_code.rb
+++ b/lib/lrama/lexer/token/user_code.rb
@@ -26,13 +26,33 @@ module Lrama
             when reference = scan_reference(scanner)
               references << reference
             when scanner.scan(/\/\*/)
-              scanner.scan_until(/\*\//)
+              scanner.scan_until(/\*\//) || scanner.terminate
+            when scanner.scan(%r{//})
+              scanner.scan_until(/\n/) || scanner.terminate
+            when quote = scanner.scan(/["']/)
+              skip_quoted_literal(scanner, quote)
             else
               scanner.getch
             end
           end
 
           references
+        end
+
+        # @rbs (StringScanner scanner, String quote) -> void
+        def skip_quoted_literal(scanner, quote)
+          escaped = false
+
+          until scanner.eos?
+            char = scanner.getch
+            if escaped
+              escaped = false
+            elsif char == "\\"
+              escaped = true
+            elsif char == quote
+              break
+            end
+          end
         end
 
         # @rbs (StringScanner scanner) -> Lrama::Grammar::Reference?

--- a/sig/generated/lrama/lexer/token/user_code.rbs
+++ b/sig/generated/lrama/lexer/token/user_code.rbs
@@ -14,6 +14,9 @@ module Lrama
         # @rbs () -> Array[Lrama::Grammar::Reference]
         def _references: () -> Array[Lrama::Grammar::Reference]
 
+        # @rbs (StringScanner scanner, String quote) -> void
+        def skip_quoted_literal: (StringScanner scanner, String quote) -> void
+
         # @rbs (StringScanner scanner) -> Lrama::Grammar::Reference?
         def scan_reference: (StringScanner scanner) -> Lrama::Grammar::Reference?
       end

--- a/spec/lrama/lexer/token/user_code_spec.rb
+++ b/spec/lrama/lexer/token/user_code_spec.rb
@@ -58,5 +58,20 @@ RSpec.describe Lrama::Lexer::Token::UserCode do
       expect(references.count).to eq 1
       expect(references[0]).to eq Lrama::Grammar::Reference.new(type: :at, name: "expr.right", ex_tag: nil, first_column: 1, last_column: 14)
     end
+
+    it "ignores references in C literals and comments" do
+      code = <<~'C'
+        $1;
+        printf("total $2 and @2 \"done\"");
+        int character = '$3';
+        // note $3 and @3
+        $4; @4;
+        /* note $5 and @5 */
+      C
+
+      references = Lrama::Lexer::Token::UserCode.new(s_value: code, location: location).references
+
+      expect(references.map { |ref| [ref.type, ref.index] }).to eq([[:dollar, 1], [:dollar, 4], [:at, 4]])
+    end
   end
 end


### PR DESCRIPTION
 `UserCode#references` treated `$n` and `@n` inside C string literals and `//` comments as grammar references. As a result, generated C silently rewrote text that Bison preserves. Only `/* */` comments were previously skipped.

Skip string and character literals while honoring escaped quotes, and skip both line and block comments. References outside those regions continue to be detected normally.