### PR TITLE
Reject unterminated block comments

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -198,15 +198,11 @@ module Lrama
 
     # @rbs () -> void
     def lex_comment
-      until @scanner.eos? do
-        case
-        when @scanner.scan_until(/[\s\S]*?\*\//)
-          @scanner.matched.count("\n").times { newline }
-          return
-        when @scanner.scan_until(/\n/)
-          newline
-        end
+      unless @scanner.scan_until(/[\s\S]*?\*\//)
+        raise ParseError, location.generate_error_message("Unterminated comment") # steep:ignore UnknownConstant
       end
+
+      @scanner.matched.count("\n").times { newline }
     end
 
     # @rbs () -> void

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 RSpec.describe Lrama::Lexer do
   let(:token_class) { Lrama::Lexer::Token }
 
@@ -427,6 +429,15 @@ RSpec.describe Lrama::Lexer do
     lexer = Lrama::Lexer.new(grammar_file)
 
     expect(lexer.next_token).to be_nil
+  end
+
+  it 'raises an error for an unterminated block comment' do
+    ["/* unterminated\n%%\nprogram: ;", "/* unterminated\n%%\nprogram: ;\n"].each do |text|
+      grammar_file = Lrama::Lexer::GrammarFile.new("comment.y", text)
+      lexer = Lrama::Lexer.new(grammar_file)
+
+      expect { Timeout.timeout(1) { lexer.next_token } }.to raise_error(ParseError, /Unterminated comment/)
+    end
   end
 
   it 'lex a trailing space with newline' do


### PR DESCRIPTION
`Lexer#lex_comment` could loop indefinitely when a block comment reached EOF without a closing `*/` or trailing newline. With a trailing newline, the same invalid comment was silently accepted as EOF.

Replace the retry loop with a single terminator scan and raise an `Unterminated comment` parse error when it fails.