### PR TITLE
Reject recursive inline rules

### DIFF
--- a/lib/lrama/grammar.rb
+++ b/lib/lrama/grammar.rb
@@ -440,6 +440,8 @@ module Lrama
 
     # @rbs () -> void
     def resolve_inline_rules
+      validate_inline_rules!
+
       while @rule_builders.any?(&:has_inline_rules?) do
         @rule_builders = @rule_builders.flat_map do |builder|
           if builder.has_inline_rules?
@@ -449,6 +451,34 @@ module Lrama
           end
         end
       end
+    end
+
+    # @rbs () -> void
+    def validate_inline_rules!
+      visiting = {} #: Hash[Parameterized::Rule, bool]
+      visited = {} #: Hash[Parameterized::Rule, bool]
+
+      parameterized_rules.select(&:inline?).each do |rule|
+        validate_inline_rule!(rule, visiting, visited)
+      end
+    end
+
+    # @rbs (Parameterized::Rule rule, Hash[Parameterized::Rule, bool] visiting, Hash[Parameterized::Rule, bool] visited) -> void
+    def validate_inline_rule!(rule, visiting, visited)
+      return if visited[rule]
+      raise "Recursive inline rule: #{rule.name}" if visiting[rule]
+
+      visiting[rule] = true
+      rule.rhs.each do |rhs|
+        rhs.symbols.each do |symbol|
+          next if rule.parameters.any? { |parameter| parameter.s_value == symbol.s_value }
+
+          inline_rule = @parameterized_resolver.find_inline(symbol)
+          validate_inline_rule!(inline_rule, visiting, visited) if inline_rule
+        end
+      end
+      visiting.delete(rule)
+      visited[rule] = true
     end
 
     # @rbs () -> void

--- a/sig/generated/lrama/grammar.rbs
+++ b/sig/generated/lrama/grammar.rbs
@@ -248,6 +248,12 @@ module Lrama
     def resolve_inline_rules: () -> void
 
     # @rbs () -> void
+    def validate_inline_rules!: () -> void
+
+    # @rbs (Parameterized::Rule rule, Hash[Parameterized::Rule, bool] visiting, Hash[Parameterized::Rule, bool] visited) -> void
+    def validate_inline_rule!: (Parameterized::Rule rule, Hash[Parameterized::Rule, bool] visiting, Hash[Parameterized::Rule, bool] visited) -> void
+
+    # @rbs () -> void
     def normalize_rules: () -> void
 
     # Add $accept rule to the top of rules

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "tempfile"
+require "timeout"
 
 RSpec.describe Lrama::Parser do
   T ||= Lrama::Lexer::Token
@@ -3037,6 +3038,21 @@ RSpec.describe Lrama::Parser do
               lineno: 28,
             ),
           ])
+        end
+      end
+
+      context 'when inline is recursive' do
+        let(:path) { "recursive_inline.y" }
+        let(:y) do
+          <<~GRAMMAR
+            %rule %inline a : 'x' a | 'y' ;
+            %%
+            program : a ;
+          GRAMMAR
+        end
+
+        it "raises an error" do
+          expect { Timeout.timeout(1) { grammar } }.to raise_error(RuntimeError, "Recursive inline rule: a")
         end
       end
 


### PR DESCRIPTION
Recursive `%rule %inline` definitions caused `Grammar#resolve_inline_rules` to expand indefinitely because no cycle detection was performed before expansion.

Validate the inline-rule dependency graph and raise `Recursive inline rule: <name>` when a direct or mutual cycle is found. Formal parameters are excluded from dependencies so parameters whose names match inline rules are not rejected.