### PR TITLE
Reject unknown percent directives with known prefixes

### DIFF
--- a/lib/lrama/lexer.rb
+++ b/lib/lrama/lexer.rb
@@ -121,7 +121,7 @@ module Lrama
         return
       when @scanner.scan(/#{SYMBOLS.join('|')}/)
         return [@scanner.matched, Lrama::Lexer::Token::Token.new(s_value: @scanner.matched, location: location)]
-      when @scanner.scan(/#{PERCENT_TOKENS.join('|')}/)
+      when @scanner.scan(/(?:#{PERCENT_TOKENS.join('|')})(?![-.\w])/)
         return [@scanner.matched, Lrama::Lexer::Token::Token.new(s_value: @scanner.matched, location: location)]
       when @scanner.scan(/[\?\+\*]/)
         return [@scanner.matched, Lrama::Lexer::Token::Token.new(s_value: @scanner.matched, location: location)]

--- a/spec/lrama/lexer_spec.rb
+++ b/spec/lrama/lexer_spec.rb
@@ -407,6 +407,15 @@ RSpec.describe Lrama::Lexer do
     end
   end
 
+  it 'does not match known percent directives as prefixes' do
+    ["%tokens FOO", "%typeof", "%expect-rr 2"].each do |text|
+      grammar_file = Lrama::Lexer::GrammarFile.new("directive.y", text)
+      lexer = Lrama::Lexer.new(grammar_file)
+
+      expect { lexer.next_token }.to raise_error(ParseError, /Unexpected token/)
+    end
+  end
+
   context 'unexpected_c_code.y' do
     it do
       grammar_file = Lrama::Lexer::GrammarFile.new("invalid.y", "@invalid")


### PR DESCRIPTION
Known percent directives were matched without checking their trailing boundary. Unknown directives such as `%tokens` and `%typeof` could therefore be split into valid directives and identifiers, while `%expect-rr` was only rejected after `%expect` had already been consumed.

Reject a percent directive match when it is followed by another directive-name character, including letters, digits, underscores, dots, or hyphens.