### PR TITLE
Report undefined start symbols

### DIFF
--- a/lib/lrama/grammar/symbols/resolver.rb
+++ b/lib/lrama/grammar/symbols/resolver.rb
@@ -112,7 +112,11 @@ module Lrama
 
         # @rbs (Lexer::Token::Base id) -> Grammar::Symbol
         def find_symbol_by_id!(id)
-          find_symbol_by_id(id) || (raise id.location.generate_error_message("symbol #{id.s_value} is used, but is not defined as a token and has no rules"))
+          symbol = find_symbol_by_id(id)
+          return symbol if symbol
+
+          message = "symbol #{id.s_value} is used, but is not defined as a token and has no rules"
+          raise(id.location&.generate_error_message(message) || message)
         end
 
         # @rbs (Integer token_id) -> Grammar::Symbol?

--- a/lib/lrama/grammar/symbols/resolver.rb
+++ b/lib/lrama/grammar/symbols/resolver.rb
@@ -112,7 +112,7 @@ module Lrama
 
         # @rbs (Lexer::Token::Base id) -> Grammar::Symbol
         def find_symbol_by_id!(id)
-          find_symbol_by_id(id) || (raise "Symbol not found. #{id}")
+          find_symbol_by_id(id) || (raise id.location.generate_error_message("symbol #{id.s_value} is used, but is not defined as a token and has no rules"))
         end
 
         # @rbs (Integer token_id) -> Grammar::Symbol?

--- a/lib/lrama/parser.rb
+++ b/lib/lrama/parser.rb
@@ -2272,7 +2272,7 @@ module_eval(<<'.,.,', 'parser.y', 488)
 
 module_eval(<<'.,.,', 'parser.y', 500)
   def _reduce_136(val, _values, result)
-     result = Lrama::Lexer::Token::Ident.new(s_value: val[0].s_value)
+     result = Lrama::Lexer::Token::Ident.new(s_value: val[0].s_value, location: val[0].location)
     result
   end
 .,.,

--- a/parser.y
+++ b/parser.y
@@ -498,7 +498,7 @@ rule
        | STRING
        | "{...}"
 
-  string_as_id: STRING { result = Lrama::Lexer::Token::Ident.new(s_value: val[0].s_value) }
+  string_as_id: STRING { result = Lrama::Lexer::Token::Ident.new(s_value: val[0].s_value, location: val[0].location) }
 end
 
 ---- inner

--- a/spec/lrama/grammar/symbols/resolver_spec.rb
+++ b/spec/lrama/grammar/symbols/resolver_spec.rb
@@ -141,6 +141,13 @@ RSpec.describe Lrama::Grammar::Symbols::Resolver do
              |   ^~~~~
       ERROR
     end
+
+    it "raises error if symbol has no location" do
+      id = Lrama::Lexer::Token::Ident.new(s_value: "alias")
+
+      expect { resolver.find_symbol_by_id!(id) }
+        .to raise_error("symbol alias is used, but is not defined as a token and has no rules")
+    end
   end
 
   describe "#find_symbol_by_token_id" do

--- a/spec/lrama/grammar/symbols/resolver_spec.rb
+++ b/spec/lrama/grammar/symbols/resolver_spec.rb
@@ -132,10 +132,14 @@ RSpec.describe Lrama::Grammar::Symbols::Resolver do
     end
 
     it "raises error if symbol not found" do
-      grammar_file = Lrama::Lexer::GrammarFile.new("foo/basic.y", "")
-      location = Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 1, first_column: 2, last_line: 3, last_column: 4)
+      grammar_file = Lrama::Lexer::GrammarFile.new("foo/basic.y", "  alias")
+      location = Lrama::Lexer::Location.new(grammar_file: grammar_file, first_line: 1, first_column: 2, last_line: 1, last_column: 7)
       symbol = Lrama::Grammar::Symbol.new(id: Lrama::Lexer::Token::Ident.new(s_value: "alias", location: location), alias_name: "alias", term: true)
-      expect { resolver.find_symbol_by_id!(symbol.id) }.to raise_error("Symbol not found. value: `alias`, location: foo/basic.y (1,2)-(3,4)")
+      expect { resolver.find_symbol_by_id!(symbol.id) }.to raise_error(<<~ERROR)
+        foo/basic.y:1:2: symbol alias is used, but is not defined as a token and has no rules
+           1 |   alias
+             |   ^~~~~
+      ERROR
     end
   end
 

--- a/spec/lrama/parser_spec.rb
+++ b/spec/lrama/parser_spec.rb
@@ -4434,6 +4434,25 @@ RSpec.describe Lrama::Parser do
     end
 
     describe "error messages" do
+      context "when the start symbol is not defined" do
+        it "reports the symbol and its location" do
+          y = <<~INPUT
+            %start nosuch
+            %%
+            program: "a" ;
+          INPUT
+
+          expect do
+            grammar = Lrama::Parser.new(y, "parse.y").parse
+            grammar.prepare
+          end.to raise_error(<<~ERROR)
+            parse.y:1:7: symbol nosuch is used, but is not defined as a token and has no rules
+               1 | %start nosuch
+                 |        ^~~~~~
+          ERROR
+        end
+      end
+
       context "error_value has line number and column" do
         it "contains line number and column" do
           y = <<~INPUT


### PR DESCRIPTION
An undefined `%start` symbol could leak an internal `NoMethodError` when a string alias appeared as the first symbol on a rule's right-hand side. The `string_as_id` parser action discarded the original token location, and unresolved symbols otherwise produced a generic internal resolver error.

Preserve the string token's location when converting it to an identifier, and report unresolved symbols with their source location and the standard grammar diagnostic.