### PR TITLE
Fix IELR follow-kernel item filtering

### DIFF
--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -661,9 +661,8 @@ module Lrama
       base_function = compute_goto_bitmaps
       Digraph.new(set, relation, base_function).compute.each do |goto, follow_kernel_items|
         state = goto.from_state
-        state.follow_kernel_items[goto] = state.kernels.map {|kernel|
-          [kernel, Bitmap.to_bool_array(follow_kernel_items, state.kernels.count)]
-        }.to_h
+        bools = Bitmap.to_bool_array(follow_kernel_items, state.kernels.count)
+        state.follow_kernel_items[goto] = state.kernels.zip(bools).to_h
       end
     end
 

--- a/spec/lrama/states_spec.rb
+++ b/spec/lrama/states_spec.rb
@@ -1876,6 +1876,24 @@ RSpec.describe Lrama::States do
   end
 
   describe '#compute_ielr' do
+    it 'stores a boolean for each follow kernel item' do
+      path = "integration/ielr.y"
+      y = File.read(fixture_path(path))
+      grammar = Lrama::Parser.new(y, path).parse
+      grammar.prepare
+      grammar.validate!
+      states = Lrama::States.new(grammar, Lrama::Tracer.new(Lrama::Logger.new))
+      states.compute
+      states.compute_ielr
+
+      values = states.states.flat_map do |state|
+        state.follow_kernel_items.values.compact.flat_map(&:values)
+      end
+
+      expect(values).to include(false)
+      expect(values).to all(satisfy("be a boolean") { |value| value == true || value == false })
+    end
+
     it 'recompute states' do
       path = "integration/ielr.y"
       y = File.read(fixture_path(path))


### PR DESCRIPTION
`States#compute_follow_kernel_items` assigned the complete boolean array to every kernel instead of assigning each bitmap bit to its corresponding kernel.

As both `[false]` and `[true]` are truthy in Ruby, the checks in `lhs_contributions` and `goto_follow_set` admitted every kernel. This made the follow-kernel filter ineffective and could overestimate IELR contributions.

Convert the bitmap to booleans once and zip each boolean with its corresponding kernel.